### PR TITLE
Add support for configuring NodeSelectors for different node types

### DIFF
--- a/charts/hami-webui/templates/configmap.yaml
+++ b/charts/hami-webui/templates/configmap.yaml
@@ -15,3 +15,7 @@ data:
     prometheus:
       address: {{ ternary .Values.externalPrometheus.address (printf "http://%s-kube-prometh-prometheus.%s.svc.cluster.local:9090" (include "hami-webui.fullname" .) (include "hami-webui.namespace" .)) .Values.externalPrometheus.enabled }}
       timeout: 1m
+    node_selectors:
+    {{- range $key, $value := .Values.vendorNodeSelectors }}
+      {{ $key }}: {{ $value }}
+    {{- end }}

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -4,16 +4,22 @@
 
 replicaCount: 1
 
+vendorNodeSelectors:
+  NVIDIA: gpu=on
+  Ascend: ascend=on
+  DCU: dcu=on
+  MLU: mlu=on
+
 image:
   frontend:
     repository: projecthami/hami-webui-fe-oss
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v1.0.4"
+    tag: "main"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
-    tag: "v1.0.4"
+    tag: "main"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kratos/kratos/v2/transport/grpc"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	"os"
+	"vgpu/internal/conf"
 
 	_ "go.uber.org/automaxprocs"
 )
@@ -56,4 +57,8 @@ func newApp(ctx context.Context, logger log.Logger, gs *grpc.Server, hs *http.Se
 			hs,
 		),
 	)
+}
+
+func getNodeSelectors(c *conf.Bootstrap) map[string]string {
+	return c.NodeSelectors
 }

--- a/server/cmd/server/wire.go
+++ b/server/cmd/server/wire.go
@@ -26,5 +26,6 @@ func initApp(configPath string, ctx context.Context) (*kratos.App, func(), error
 		service.ProviderSet,
 		exporter.ProviderSet,
 		newApp,
+		getNodeSelectors,
 	))
 }

--- a/server/config/config.yaml
+++ b/server/config/config.yaml
@@ -8,3 +8,8 @@ server:
 prometheus:
   address: http://localhost:9090
   timeout: 1m
+node_selectors:
+  NVIDIA: gpu=on
+  Ascend: ascend=on
+  DCU: dcu=on
+  MLU: mlu=on

--- a/server/internal/conf/conf.proto
+++ b/server/internal/conf/conf.proto
@@ -8,6 +8,7 @@ import "google/protobuf/duration.proto";
 message Bootstrap {
   Server server = 1;
   Prometheus prometheus = 2;
+  map<string, string> node_selectors = 3;
 }
 
 message Server {

--- a/server/internal/data/node.go
+++ b/server/internal/data/node.go
@@ -32,17 +32,17 @@ type nodeRepo struct {
 }
 
 // NewNodeRepo .
-func NewNodeRepo(data *Data, logger log.Logger) biz.NodeRepo {
+func NewNodeRepo(data *Data, nodeSelectors map[string]string, logger log.Logger) biz.NodeRepo {
 	nodeRepo := &nodeRepo{
 		data:       data,
 		nodeNotify: make(chan struct{}, 1),
 		nodes:      map[k8stypes.UID]*biz.Node{},
 		log:        log.NewHelper(logger),
 		providers: []provider.Provider{
-			nvidia.NewNvidia(data.promCl, log.NewHelper(logger)),
-			mlu.NewCambricon(data.promCl, log.NewHelper(logger)),
-			ascend.NewAscend(data.promCl, log.NewHelper(logger)),
-			hygon.NewHygon(data.promCl, log.NewHelper(logger)),
+			nvidia.NewNvidia(data.promCl, log.NewHelper(logger), nodeSelectors[biz.NvidiaGPUDevice]),
+			mlu.NewCambricon(data.promCl, log.NewHelper(logger), nodeSelectors[biz.CambriconGPUDevice]),
+			ascend.NewAscend(data.promCl, log.NewHelper(logger), nodeSelectors[biz.AscendGPUDevice]),
+			hygon.NewHygon(data.promCl, log.NewHelper(logger), nodeSelectors[biz.HygonGPUDevice]),
 		},
 	}
 	nodeRepo.init()

--- a/server/internal/provider/mlu/provider.go
+++ b/server/internal/provider/mlu/provider.go
@@ -15,17 +15,20 @@ import (
 type Cambricon struct {
 	prom *prom.Client
 	log  *log.Helper
+
+	labelsSelector string
 }
 
-func NewCambricon(prom *prom.Client, log *log.Helper) *Cambricon {
+func NewCambricon(prom *prom.Client, log *log.Helper, labelSelector string) *Cambricon {
 	return &Cambricon{
-		prom: prom,
-		log:  log,
+		prom:           prom,
+		log:            log,
+		labelsSelector: labelSelector,
 	}
 }
 
 func (c *Cambricon) GetNodeDevicePluginLabels() (labels.Selector, error) {
-	return labels.Parse("mlu=on")
+	return labels.Parse(c.labelsSelector)
 }
 
 func (c *Cambricon) GetProvider() string {

--- a/server/internal/provider/nvidia/provider.go
+++ b/server/internal/provider/nvidia/provider.go
@@ -12,17 +12,20 @@ import (
 type Nvidia struct {
 	prom *prom.Client
 	log  *log.Helper
+
+	labelSelector string
 }
 
-func NewNvidia(prom *prom.Client, log *log.Helper) *Nvidia {
+func NewNvidia(prom *prom.Client, log *log.Helper, labelSelector string) *Nvidia {
 	return &Nvidia{
-		prom: prom,
-		log:  log,
+		prom:          prom,
+		log:           log,
+		labelSelector: labelSelector,
 	}
 }
 
 func (n *Nvidia) GetNodeDevicePluginLabels() (labels.Selector, error) {
-	return labels.Parse("gpu=on")
+	return labels.Parse(n.labelSelector)
 }
 
 func (n *Nvidia) GetProvider() string {


### PR DESCRIPTION
This PR introduces support for configuring vendorNodeSelectors within the Helm charts for HAMi-WebUI. 

Related Issue:
#5