### PR TITLE
feat: support ascend and nvidia use mode(hami-core mig mps)

### DIFF
--- a/packages/web/projects/vgpu/components/previewBar.vue
+++ b/packages/web/projects/vgpu/components/previewBar.vue
@@ -173,16 +173,32 @@ ul {
 
   .nodeCard {
     height: 100%;
+
     .pie {
       width: 200px;
       height: 200px;
       margin: 0 auto;
     }
+
     .nodeCard-legend {
       width: 100%;
       display: flex;
       flex-direction: column;
       gap: 15px;
+      max-height: calc(3 * (12px + 15px));
+      overflow-y: auto;
+      padding-right: 10px;
+
+      /* 自定义滚动条样式（可选） */
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.2);
+        border-radius: 3px;
+      }
+
       li {
         display: flex;
         justify-content: space-between;
@@ -194,8 +210,8 @@ ul {
           gap: 5px;
         }
         .color-box {
-          width: 4px;
-          height: 4px;
+          width: 10px;
+          height: 10px;
           display: inline-block;
         }
       }

--- a/packages/web/projects/vgpu/views/card/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/card/admin/Detail.vue
@@ -196,6 +196,15 @@ const columns = [
     label: '驱动版本',
     value: 'driver_version',
   },
+  {
+    label: '使用模式',
+    value: 'mode',
+    render: ({ mode, type }) => (
+        <el-tag disable-transitions>
+          {type?.split('-')[0] === "NVIDIA" ? mode : 'default'}
+        </el-tag>
+    )
+  }
 ];
 
 const cp = useInstantVector(

--- a/packages/web/projects/vgpu/views/card/admin/index.vue
+++ b/packages/web/projects/vgpu/views/card/admin/index.vue
@@ -64,6 +64,15 @@ const columns = [
     )
   },
   {
+    title: '使用模式',
+    dataIndex: 'mode',
+    render: ({ mode, type }) => (
+        <el-tag disable-transitions>
+          {type?.split('-')[0] === "NVIDIA" ? mode : 'default'}
+        </el-tag>
+    )
+  },
+  {
     title: '所属节点',
     dataIndex: 'nodeName',
   },

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -42,11 +42,16 @@
   </block-box>
 
   <block-box v-for="{ title, data } in lineConfig" :key="title" :title="title">
-    <template #extra>
+    <template #extra v-if="detail.type && detail.type.startsWith('NVIDIA')">
       <time-picker v-model="times" type="datetimerange" size="small" />
     </template>
     <div style="height: 200px">
-      <echarts-plus :options="getLineOptions({ data })" />
+      <template v-if="detail.type && !detail.type.startsWith('NVIDIA')">
+        <el-empty description="该设备厂商暂不支持任务维度监控" :image-size="60" />
+      </template>
+      <template v-else>
+        <echarts-plus :options="getLineOptions({ data })" />
+      </template>
     </div>
   </block-box>
 </template>

--- a/server/api/v1/card.proto
+++ b/server/api/v1/card.proto
@@ -64,6 +64,7 @@ message GPUReply {
   int32 memory_total = 9;
   string node_uid = 10;
   bool health = 11;
+  string mode = 12;
 }
 
 message GPUsReply {

--- a/server/internal/biz/node.go
+++ b/server/internal/biz/node.go
@@ -32,6 +32,7 @@ type DeviceInfo struct {
 	Devcore  int32
 	Type     string
 	Numa     int
+	Mode     string
 	Health   bool
 	NodeName string
 	NodeUid  string

--- a/server/internal/data/node.go
+++ b/server/internal/data/node.go
@@ -86,6 +86,7 @@ func (r *nodeRepo) updateLocalNodes() {
 						Devcore:  device.Devcore,
 						Type:     device.Type,
 						Numa:     device.Numa,
+						Mode:     device.Mode,
 						Health:   device.Health,
 						NodeName: node.Name,
 						NodeUid:  string(node.UID),

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -438,6 +438,8 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 	switch provider {
 	case biz.NvidiaGPUDevice:
 		query = fmt.Sprintf("DCGM_FI_DEV_POWER_USAGE{UUID=\"%s\"}", deviceUUID)
+	case biz.AscendGPUDevice:
+		query = fmt.Sprintf("npu_chip_info_power{vdie_id=\"%s\"}", deviceUUID)
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("mlu_power_usage{uuid=\"%s\"}", deviceUUID)
 	case biz.HygonGPUDevice:
@@ -462,6 +464,9 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 		case biz.CambriconGPUDevice:
 			info.DriverVersion = metric["driver"]
 			info.DeviceNo = metric["sn"]
+		case biz.AscendGPUDevice:
+			info.DriverVersion = "暂无"
+			info.DeviceNo = "ascend-" + metric["id"]
 		case biz.HygonGPUDevice:
 			info.DriverVersion = "暂无"
 			info.DeviceNo = "dcu-" + metric["minor_number"]

--- a/server/internal/provider/ascend/device.go
+++ b/server/internal/provider/ascend/device.go
@@ -8,17 +8,22 @@ const (
 	// IluvatarUseUUID is user can use specify Iluvatar device for set Iluvatar UUID.
 	AscendDeviceUseUUID = "huawei.com/use-ascenduuid"
 	// IluvatarNoUseUUID is user can not use specify Iluvatar device for set Iluvatar UUID.
-	AscendNoUseUUID         = "huawei.com/nouse-ascenduuid"
-	AscendResourceCoreCount = "huawei.com/Ascend910"
+	AscendNoUseUUID            = "huawei.com/nouse-ascenduuid"
+	Ascend910BNodeRegisterAnno = "hami.io/node-register-Ascend910B"
+	Ascend310PNodeRegisterAnno = "hami.io/node-register-Ascend310P"
 )
 
 var (
-	AscendResourceCount  string
-	AscendResourceMemory string
-	AscendResourceCores  string
+	AscendResourceCount     string
+	AscendResourceMemory    string
+	AscendResourceCores     string
+	AscendNodeRegisterAnnos []string
 )
 
 func init() {
-	util.InRequestDevices[AscendDevice] = "hami.io/ascend-devices-to-allocate"
-	util.SupportDevices[AscendDevice] = "hami.io/ascend-devices-allocated"
+	AscendNodeRegisterAnnos = []string{Ascend910BNodeRegisterAnno, Ascend310PNodeRegisterAnno}
+	util.InRequestDevices[AscendDevice] = "hami.io/Ascend910B-devices-to-allocate"
+	util.SupportDevices[AscendDevice] = "hami.io/Ascend910B-devices-allocated"
+	util.InRequestDevices["Ascend310P"] = "hami.io/Ascend310P-devices-to-allocate"
+	util.SupportDevices["Ascend310P"] = "hami.io/Ascend310P-devices-allocated"
 }

--- a/server/internal/provider/util/types.go
+++ b/server/internal/provider/util/types.go
@@ -97,6 +97,7 @@ type DeviceInfo struct {
 	Devcore int32
 	Type    string
 	Numa    int
+	Mode    string
 	Health  bool
 	Driver  string
 }

--- a/server/internal/service/card.go
+++ b/server/internal/service/card.go
@@ -50,6 +50,7 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		gpu.MemoryTotal = device.Devmem
 		gpu.NodeUid = device.NodeUid
 		gpu.Health = device.Health
+		gpu.Mode = device.Mode
 
 		vGPU, core, memory, err := s.pod.StatisticsByDeviceId(ctx, device.AliasId)
 		if err == nil {
@@ -120,6 +121,7 @@ func (s *CardService) GetGPU(ctx context.Context, req *pb.GetGpuReq) (*pb.GPURep
 		gpu.MemoryTotal = device.Devmem
 		gpu.NodeUid = device.NodeUid
 		gpu.Health = device.Health
+		gpu.Mode = device.Mode
 
 		vGPU, core, memory, err := s.pod.StatisticsByDeviceId(ctx, device.AliasId)
 		if err == nil {

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -69,7 +69,7 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 				deviceID = device.Id
 			}
 
-			if filters.DeviceId != "" && filters.DeviceId != deviceID {
+			if filters.DeviceId != "" && !strings.HasPrefix(deviceID, filters.DeviceId) {
 				continue
 			}
 


### PR DESCRIPTION
### Summary

This PR introduces several updates to enhance compatibility and support for the latest features in HAMi. The key changes include:

### Changes

1. **Annotation Adaptation**:
    - Updated to support the extended annotation fields introduced in the latest HAMi version.
    - Ensured backward compatibility with older versions of HAMi.
2. **MIG Mode Adaptation**:
    - Updated the UI to display GPU usage modes:
        - `default` (used for domestic cards), `hami-core`, `mig`, and `mps`.
    - For tasks using MIG mode, task card IDs are now associated with the physical GPU UUID.
3. **Ascend Adaptation**:
    - Enhanced support for Ascend devices to align with current monitoring and usage requirements.
4. **Task-Level Monitoring for Domestic GPUs**:
    - Added UI feedback when task-level monitoring is not fully supported for domestic GPUs.
    - Displays the message: **"Task-level monitoring is not supported for this manufacturer."**

### Notes

These updates improve HAMi's usability across diverse hardware configurations and ensure compatibility with both legacy and new deployments.