### PR TITLE
fix: associate resource allocation between MIG-enabled cards and tasks

### DIFF
--- a/server/internal/biz/pod.go
+++ b/server/internal/biz/pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/go-kratos/kratos/v2/log"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"strings"
 	"time"
 )
 
@@ -76,7 +77,7 @@ func ContainersStatisticsInfo(containers []*Container, deviceId string) (int32, 
 	var memory int32 = 0
 	for _, t := range containers {
 		for _, cd := range t.ContainerDevices {
-			if deviceId != "" && cd.UUID != deviceId {
+			if deviceId != "" && !strings.HasPrefix(cd.UUID, deviceId) {
 				continue
 			}
 			vGPU = vGPU + 1

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 	pb "vgpu/api/v1"
 	"vgpu/internal/biz"
@@ -163,7 +164,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			var memory int32 = 0
 			var provider string = ""
 			for _, cd := range c.ContainerDevices {
-				if device.AliasId != "" && device.AliasId != cd.UUID {
+				if device.AliasId != "" && !strings.HasPrefix(cd.UUID, device.AliasId) {
 					continue
 				}
 				vGPU = vGPU + 1


### PR DESCRIPTION
### Fix Details  
This PR resolves the issue where resource allocation between MIG-enabled cards and tasks was not properly associated, leading to:  
1. Allocated resources in the node and card dimensions showing as 0.  
2. Empty data in the resource allocation trend chart.