### PR TITLE
fix: update CI configuration to conditionally push Docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: projecthami/hami-webui-fe-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
+          tags: projecthami/hami-webui-fe-oss:${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}
 
   build-and-push-backend:
     name: Build and Push Backend Image
@@ -70,4 +70,4 @@ jobs:
           context: ./server
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: projecthami/hami-webui-be-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
+          tags: projecthami/hami-webui-be-oss:${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -38,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: projecthami/hami-webui-fe-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}
 
   build-and-push-backend:
@@ -57,6 +58,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -67,5 +69,5 @@ jobs:
         with:
           context: ./server
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: projecthami/hami-webui-be-oss:${{ steps.branch-names.outputs.current_branch || steps.branch-names.outputs.tag }}


### PR DESCRIPTION
- Modify the CI configuration to push the Docker image only when it is not a pull request event.
- Added conditional judgment for the DockerHub login step to ensure that no push operation is executed during pull request events.
- Adjusted the CI configuration to improve Docker image tagging logic, ensuring that the correct tag is used based on the current branch or pull request number.