### PR TITLE
fix: resolve Go module import path issue causing Docker build failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
     branches: [ "main" ]
 
 env:
-  GO_VERSION: "1.22.5"
+  GO_VERSION: "1.25.1"
 
 jobs:
   build-and-push-frontend:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 
 WORKDIR /src
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -14,6 +14,7 @@ install-deps:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2@latest
+	go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
 
 # 2. Generate proto and wire files
 .PHONY: generate


### PR DESCRIPTION
- Change module name from 'vgpu' to 'github.com/Project-HAMi/HAMi-WebUI/server'
- Update all import paths from 'vgpu/internal/*' to proper module path
- Fix wire dependency injection configuration

This resolves the build error:
wire: could not import vgpu/internal/conf (invalid package name: "")

Fixes the multi-arch Docker builds in GitHub Actions.