### PR TITLE
fix(web): add historyApiFallback to fix SPA routing 404 issue

### DIFF
--- a/packages/web/vue.config.js
+++ b/packages/web/vue.config.js
@@ -58,6 +58,7 @@ module.exports = defineConfig({
   },
   devServer: {
     port: port,
+    historyApiFallback: true,
     client: {
       overlay: false,
       logging: 'info',


### PR DESCRIPTION
Add historyApiFallback configuration to Vue dev server to ensure all non-API route requests fallback to index.html and handled by Vue Router.

Fixed scenarios:
- Direct access to deep routes (e.g. /admin/vgpu/monitor/overview)
- Page refresh on any route

Scope: Vue development environment only, production build unaffected