### PR TITLE
fix incompatible with hami 2.8.0

### DIFF
--- a/server/internal/provider/util/types.go
+++ b/server/internal/provider/util/types.go
@@ -102,6 +102,20 @@ type DeviceInfo struct {
 	Driver  string
 }
 
+type NewDeviceInfo struct {
+	ID              string          `json:"id,omitempty"`
+	Index           uint            `json:"index,omitempty"`
+	Count           int32           `json:"count,omitempty"`
+	Devmem          int32           `json:"devmem,omitempty"`
+	Devcore         int32           `json:"devcore,omitempty"`
+	Type            string          `json:"type,omitempty"`
+	Numa            int             `json:"numa,omitempty"`
+	Mode            string          `json:"mode,omitempty"`
+	Health          bool            `json:"health,omitempty"`
+	DeviceVendor    string          `json:"devicevendor,omitempty"`
+	CustomInfo      map[string]any  `json:"custominfo,omitempty"`
+}
+
 type NodeInfo struct {
 	ID      string
 	Devices []DeviceInfo

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -402,3 +402,18 @@ func UnMarshalNodeDevices(str string) ([]*DeviceInfo, error) {
 	err := json.Unmarshal([]byte(str), &dlist)
 	return dlist, err
 }
+
+func MapNewDeviceInfoToDeviceInfo(newDeviceInfo *NewDeviceInfo) *DeviceInfo {
+	return &DeviceInfo{
+		ID:      newDeviceInfo.ID,
+		AliasId: newDeviceInfo.ID,
+		Index:   newDeviceInfo.Index,
+		Count:   newDeviceInfo.Count,
+		Devmem:  newDeviceInfo.Devmem,
+		Devcore: newDeviceInfo.Devcore,
+		Type:    newDeviceInfo.Type,
+		Numa:    newDeviceInfo.Numa,
+		Mode:    newDeviceInfo.Mode,
+		Health:  newDeviceInfo.Health,
+	}
+}


### PR DESCRIPTION
Fix #76 

For hami v2.8.0 change the node annotation from string to json, the webui need to change the decoding function.

As we don not have release plan recently, this fix dose not change the old struct to achieve the best backward compatibility.