### PR TITLE
fix: resolve index out of range panic in fetchContainerInfo for Ascend devices

### DIFF
--- a/server/internal/data/pod.go
+++ b/server/internal/data/pod.go
@@ -112,11 +112,23 @@ func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
 	if err != nil {
 		return containers
 	}
-	bizContainerDevices := []biz.ContainerDevices{}
-	for _, pds := range pdevices {
-		copier.Copy(&bizContainerDevices, pds)
+	// Merge devices from all device types per container index.
+	// pdevices: map[deviceType]PodSingleDevice([]ContainerDevices)
+	totalContainers := len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
+	bizContainerDevices := make([]biz.ContainerDevices, totalContainers)
+	for devType, pds := range pdevices {
+		var bizPds biz.PodSingleDevice
+		if err := copier.Copy(&bizPds, pds); err != nil {
+			r.log.Warnf("failed to copy %s device info for pod %s/%s: %v", devType, pod.Namespace, pod.Name, err)
+			continue
+		}
+		for i, cd := range bizPds {
+			if i < totalContainers {
+				bizContainerDevices[i] = append(bizContainerDevices[i], cd...)
+			}
+		}
 	}
-	if len(bizContainerDevices) < 1 {
+	if len(pdevices) == 0 {
 		return containers
 	}
 

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -326,7 +326,14 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 		pd[devType] = make(PodSingleDevice, 0)
 		switch devType {
 		case AscendGPUDevice, Ascend310PGPUDevice:
-			for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+				if i >= podContainerCount(pod) {
+					break
+				}
+				if s == "" {
+					pd[devType] = append(pd[devType], ContainerDevices{})
+					continue
+				}
 				cd, err := DecodeNpuContainerDevices(s)
 				if err != nil {
 					return PodDevices{}, nil

--- a/server/internal/provider/util/util_test.go
+++ b/server/internal/provider/util/util_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -350,8 +351,21 @@ func Test_DecodePodDevices(t *testing.T) {
 	}
 }
 
+func setSupportDeviceForTest(t *testing.T, deviceType, annotation string) {
+	t.Helper()
+	previous, existed := SupportDevices[deviceType]
+	SupportDevices[deviceType] = annotation
+	t.Cleanup(func() {
+		if existed {
+			SupportDevices[deviceType] = previous
+			return
+		}
+		delete(SupportDevices, deviceType)
+	})
+}
+
 func TestDecodePodDevicesWithInitContainers(t *testing.T) {
-	SupportDevices["NVIDIA"] = "hami.io/vgpu-devices-allocated"
+	setSupportDeviceForTest(t, "NVIDIA", "hami.io/vgpu-devices-allocated")
 	logger := log.NewHelper(log.DefaultLogger)
 
 	pod := &corev1.Pod{
@@ -399,5 +413,184 @@ func TestDecodePodDevicesWithInitContainers(t *testing.T) {
 	}
 	if nvidiaDevices[1][0].Priority != "1" {
 		t.Fatalf("unexpected priority: %s", nvidiaDevices[1][0].Priority)
+	}
+}
+
+func Test_DecodePodDevices_Ascend(t *testing.T) {
+	// Ensure Ascend device keys are registered in SupportDevices.
+	setSupportDeviceForTest(t, "Ascend", "hami.io/Ascend910B-devices-allocated")
+	setSupportDeviceForTest(t, "Ascend310P", "hami.io/Ascend310P-devices-allocated")
+
+	logger := log.NewHelper(log.DefaultLogger)
+
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		want    PodDevices
+		wantErr bool
+	}{
+		{
+			name: "Ascend310P single container single device",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"hami.io/Ascend310P-devices-allocated": "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019,Ascend310P,6144,100:",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main"}},
+				},
+			},
+			want: PodDevices{
+				"Ascend310P": {
+					{
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ascend310P two containers",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"hami.io/Ascend310P-devices-allocated": "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019,Ascend310P,6144,100:;D7E96E64-214123F1-E8E618E4-AED8030A-E3003039,Ascend310P,6144,100:",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "ctr1"},
+						{Name: "ctr2"},
+					},
+				},
+			},
+			want: PodDevices{
+				"Ascend310P": {
+					{
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+					{
+						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ascend310P annotation segments exceed container count - should truncate",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						// Two device segments but only one container in spec.
+						"hami.io/Ascend310P-devices-allocated": "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019,Ascend310P,6144,100:;D7E96E64-214123F1-E8E618E4-AED8030A-E3003039,Ascend310P,6144,100:",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main"}},
+				},
+			},
+			want: PodDevices{
+				"Ascend310P": {
+					{
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ascend310P empty segment in middle should produce empty ContainerDevices placeholder",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"hami.io/Ascend310P-devices-allocated": "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019,Ascend310P,6144,100:;;D7E96E64-214123F1-E8E618E4-AED8030A-E3003039,Ascend310P,6144,100:",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "ctr1"},
+						{Name: "ctr2"},
+						{Name: "ctr3"},
+					},
+				},
+			},
+			want: PodDevices{
+				"Ascend310P": {
+					{
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+					{}, // empty segment placeholder
+					{
+						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ascend310P init container placeholder keeps main container aligned",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"hami.io/Ascend310P-devices-allocated": ";E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019,Ascend310P,6144,100:",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init"}},
+					Containers:     []corev1.Container{{Name: "main"}},
+				},
+			},
+			want: PodDevices{
+				"Ascend310P": {
+					{},
+					{
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ascend310P malformed device should produce empty device set",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"hami.io/Ascend310P-devices-allocated": "bad-format-string",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main"}},
+				},
+			},
+			want:    PodDevices{"Ascend310P": {}},
+			wantErr: false,
+		},
+		{
+			name: "empty annotations should return empty PodDevices",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main"}},
+				},
+			},
+			want:    PodDevices{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodePodDevices(tt.pod, logger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecodePodDevices() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecodePodDevices() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes the `runtime error: index out of range [1] with length 1` panic that occurs in `fetchContainerInfo` when scanning Pods using **Ascend310P / AscendGPU** devices.

Previous PR #35 fixed the same symptom for NVIDIA/Hygon/Metax paths, but the **Ascend branch in `DecodePodDevices`** was missed and still lacks the container-index boundary check.

### Root Cause

1. **`DecodePodDevices` (Ascend path)**: `strings.Split(str, OnePodMultiContainerSplitSymbol)` may yield more segments than actual containers in the pod spec, causing `PodSingleDevice` (i.e. `[]ContainerDevices`) to be longer than `len(pod.Spec.Containers)`.
2. **`fetchContainerInfo`**: The old code blindly copied decoded devices into a slice and then indexed it with the container loop variable, triggering the panic when lengths mismatch.

### Changes

- **`server/internal/data/pod.go`**: Pre-allocate `bizContainerDevices` based on `len(pod.Spec.Containers)` and merge per-container devices with index guard (`i < numContainers`). Also fixes device data loss for multi-device-type pods by appending instead of overwriting.
- **`server/internal/provider/util/util.go`**: Add `i >= len(pod.Spec.Containers) { break }` guard and empty-segment handling (`s == ""`) to the `AscendGPUDevice / Ascend310PGPUDevice` branch, aligning it with NVIDIA/Hygon/Metax behavior.

### Related

- Fixes #94
- Related to #45, #52, #31 (same panic, different root branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod device decoding to keep per-container device assignments correctly aligned, especially when allocation data includes multiple containers.
  * Preserves empty allocation segments as placeholders to prevent container order mismatches during parsing.
  * More robust handling for truncated, malformed, or empty device allocation annotations, avoiding incorrect device placement.

* **Tests**
  * Added coverage for Ascend device decoding, including multi-container, truncation, placeholder behavior, and malformed/empty annotation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->