### PR TITLE
ci: add Go PR checks for the server backend

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -1,0 +1,128 @@
+name: PR Go Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  GO_VERSION: "1.25.1"
+  GOLANGCI_VERSION: "v2.12"
+  PROTOC_VERSION: "28.3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Only run the Go jobs when the backend (server/) or this workflow changed.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ github.event_name != 'pull_request' || steps.filter.outputs.go == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            go:
+              - 'server/**'
+              - '.github/workflows/pr-go.yaml'
+
+  # `make generate` (proto + wire) is mandatory before build/vet/test because
+  # the generated code is NOT committed (server/.gitignore ignores *.pb.go and
+  # *_gen.go).
+  build-test:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: server/go.sum
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install codegen tools (wire / kratos / protoc-gen-*)
+        run: make install-deps
+      - name: Generate proto + wire
+        run: make generate
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Unit tests
+        run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: server/go.sum
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install codegen tools (wire / kratos / protoc-gen-*)
+        run: make install-deps
+      - name: Generate proto + wire
+        run: make generate
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ env.GOLANGCI_VERSION }}
+          working-directory: server
+          # Only flag issues introduced by the PR so the legacy codebase does
+          # not block every PR. Generated files (DO NOT EDIT header) are skipped
+          # by golangci-lint automatically.
+          only-new-issues: true
+
+  # Single required status check: green only if every Go job passed (or there
+  # were no Go-relevant changes).
+  pr-go-required:
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build-test
+      - lint
+    if: always()
+    steps:
+      - name: Aggregate Go check results
+        run: |
+          if [[ "${{ needs.changes.outputs.go }}" != "true" ]]; then
+            echo "No Go-relevant changes; skipping."
+            exit 0
+          fi
+          for result in \
+            "${{ needs.build-test.result }}" \
+            "${{ needs.lint.result }}"; do
+            if [[ "${result}" != "success" ]]; then
+              echo "Go checks did not complete successfully: ${result}"
+              exit 1
+            fi
+          done
+          echo "All Go checks passed."

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -329,7 +329,7 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 			}
 		case CambriconGPUDevice:
 			instance := annos[DsmluProfileAndInstance]
-			cd, err := DecodeMLUContainerDevices(fmt.Sprintf("%s_%s", str, instance, nodeName), nodeName)
+			cd, err := DecodeMLUContainerDevices(fmt.Sprintf("%s_%s", str, instance), nodeName)
 			if err != nil {
 				return PodDevices{}, nil
 			}


### PR DESCRIPTION
## What this does

Adds a Go CI workflow for the `server/` backend, and fixes a latent bug that the new `go vet` gate immediately surfaces.

### `ci: add Go checks workflow for the server backend`

`.github/workflows/pr-go.yaml` — the repository previously had no CI that compiled, vetted, tested, or linted the Go backend (the only workflow builds container images), so backend defects could merge unnoticed.

- **`changes`** — a paths filter so the Go jobs only run when `server/` (or the workflow) changes.
- **`build-test`** — installs `protoc` + the codegen tools, runs `make generate` (the proto/wire output is not committed), then `go build ./...`, `go vet ./...`, `go test ./...`.
- **`lint`** — `golangci-lint` with `only-new-issues: true`, so the existing backlog does not block PRs (generated files are skipped automatically).
- **`pr-go-required`** — a single aggregated required status check.

### `fix(provider): correct MLU container device decode format string`

The new `go vet` gate flags a real bug in `DecodePodDevices`: the MLU (Cambricon) container-device string was built with `fmt.Sprintf("%s_%s", str, instance, nodeName)` — a 2-verb format with 3 arguments. The extra `nodeName` is rendered as a `%!(EXTRA string=...)` suffix, so the string never splits into the ≥3 underscore-separated fields that `DecodeMLUContainerDevices` requires; MLU decoding therefore always returned the "information missing" error (silently swallowed by the caller). This has been the case since the initial commit.

The fix drops the stray `nodeName` argument from the format string — it is already passed separately as the function's second parameter, and the function explicitly rejects strings that embed it.

## Validation

With the fix applied: `make generate` → `go build ./...` → `go vet ./...` are clean, and `go test ./...` passes (the `internal/provider/util` test, which previously failed to build on the vet error, now runs and passes).

> Note: GitHub does not run a newly-added workflow on the PR that introduces it, so this PR's own Go checks may not appear here; the workflow gates subsequent PRs once merged.
