### PR TITLE
ci: publish images to GHCR alongside Docker Hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,13 +29,22 @@ jobs:
         id: branch-names
         uses: tj-actions/branch-names@v8
 
-      # ghcr.io requires a lowercase repository path (the org login may
-      # contain uppercase, e.g. "Project-HAMi"); compute the shared image tag
-      # once so the Docker Hub and GHCR references stay in sync.
-      - name: Prepare image refs
+      # Build the image tag list. ghcr.io requires a lowercase repository path
+      # (the org login may contain uppercase, e.g. "Project-HAMi"). On a push to
+      # the default branch we additionally publish a :latest tag to GHCR only.
+      - name: Prepare image tags
         run: |
-          echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-          echo "IMAGE_TAG=${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}" >> "$GITHUB_ENV"
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          tag="${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}"
+          {
+            echo "IMAGE_TAGS<<EOF"
+            echo "projecthami/hami-webui-fe-oss:${tag}"
+            echo "ghcr.io/${owner}/hami-webui-fe-oss:${tag}"
+            if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "ghcr.io/${owner}/hami-webui-fe-oss:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -60,9 +69,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            projecthami/hami-webui-fe-oss:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ env.GHCR_OWNER }}/hami-webui-fe-oss:${{ env.IMAGE_TAG }}
+          tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -77,13 +84,22 @@ jobs:
         id: branch-names
         uses: tj-actions/branch-names@v8
 
-      # ghcr.io requires a lowercase repository path (the org login may
-      # contain uppercase, e.g. "Project-HAMi"); compute the shared image tag
-      # once so the Docker Hub and GHCR references stay in sync.
-      - name: Prepare image refs
+      # Build the image tag list. ghcr.io requires a lowercase repository path
+      # (the org login may contain uppercase, e.g. "Project-HAMi"). On a push to
+      # the default branch we additionally publish a :latest tag to GHCR only.
+      - name: Prepare image tags
         run: |
-          echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-          echo "IMAGE_TAG=${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}" >> "$GITHUB_ENV"
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          tag="${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}"
+          {
+            echo "IMAGE_TAGS<<EOF"
+            echo "projecthami/hami-webui-be-oss:${tag}"
+            echo "ghcr.io/${owner}/hami-webui-be-oss:${tag}"
+            if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "ghcr.io/${owner}/hami-webui-be-oss:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -109,8 +125,6 @@ jobs:
           context: ./server
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            projecthami/hami-webui-be-oss:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ env.GHCR_OWNER }}/hami-webui-be-oss:${{ env.IMAGE_TAG }}
+          tags: ${{ env.IMAGE_TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   GO_VERSION: "1.25.1"
 
@@ -25,8 +29,16 @@ jobs:
         id: branch-names
         uses: tj-actions/branch-names@v8
 
+      # ghcr.io requires a lowercase repository path (the org login may
+      # contain uppercase, e.g. "Project-HAMi"); compute the shared image tag
+      # once so the Docker Hub and GHCR references stay in sync.
+      - name: Prepare image refs
+        run: |
+          echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
@@ -35,12 +47,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_TOKEN }}
           password: ${{ secrets.DOCKERHUB_PASSWD }}
 
+      - name: Log in to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push frontend image
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: projecthami/hami-webui-fe-oss:${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}
+          tags: |
+            projecthami/hami-webui-fe-oss:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ env.GHCR_OWNER }}/hami-webui-fe-oss:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -49,15 +71,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
 
       - name: Get branch names.
         id: branch-names
         uses: tj-actions/branch-names@v8
 
+      # ghcr.io requires a lowercase repository path (the org login may
+      # contain uppercase, e.g. "Project-HAMi"); compute the shared image tag
+      # once so the Docker Hub and GHCR references stay in sync.
+      - name: Prepare image refs
+        run: |
+          echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
@@ -66,12 +95,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_TOKEN }}
           password: ${{ secrets.DOCKERHUB_PASSWD }}
 
+      - name: Log in to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push backend image
         uses: docker/build-push-action@v6
         with:
           context: ./server
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: projecthami/hami-webui-be-oss:${{ steps.branch-names.outputs.tag || steps.branch-names.outputs.current_branch == 'main' && 'main' || format('pr-{0}', github.run_number) }}
+          tags: |
+            projecthami/hami-webui-be-oss:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ env.GHCR_OWNER }}/hami-webui-be-oss:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## What this does

Publishes the frontend and backend container images to the GitHub Container Registry **in addition to** Docker Hub — both registries receive the same image from a single build.

Each job now:
- logs in to `ghcr.io` with the built-in `GITHUB_TOKEN`, alongside the existing Docker Hub login;
- pushes to both `projecthami/hami-webui-{fe,be}-oss` (Docker Hub, unchanged) and `ghcr.io/<owner>/hami-webui-{fe,be}-oss` (GHCR), with the owner normalized to lower case (ghcr.io requires a lowercase path and the org login contains uppercase);
- is granted `packages: write`.

The image tag and the build steps themselves are unchanged. Two stale build actions are bumped in passing: `docker/setup-buildx-action` v1 → v3, and the backend job's `actions/checkout` v2 → v4.

> Note: the first push creates the GHCR packages as **private** by default; set their visibility (or link them to this repository) so they can be pulled.
