### PR TITLE
ci: add frontend PR checks

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -1,0 +1,107 @@
+name: PR Frontend Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Only run the frontend jobs when frontend sources (the NestJS BFF in src/,
+  # the Vue app in packages/, the workspace manifests) or this workflow change.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ github.event_name != 'pull_request' || steps.filter.outputs.frontend == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'Makefile'
+              - '.github/workflows/pr-frontend.yaml'
+
+  build-test:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build BFF
+        run: pnpm run build
+      - name: Build web
+        run: pnpm --filter hami-webui-web run build
+      - name: Test BFF
+        run: pnpm test
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # The package `lint` script auto-fixes (`--fix`) and `--require`s a
+      # structured-clone polyfill that is not committed to the repo; run ESLint
+      # directly in check mode (node 22 has structuredClone natively).
+      - name: Lint BFF
+        run: pnpm exec eslint "{src,apps,libs,test}/**/*.ts"
+      - name: Lint web
+        run: pnpm --filter hami-webui-web run lint
+
+  # Single required status check: green only if every frontend job passed (or
+  # there were no frontend-relevant changes).
+  pr-frontend-required:
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build-test
+      - lint
+    if: always()
+    steps:
+      - name: Aggregate frontend check results
+        run: |
+          if [[ "${{ needs.changes.outputs.frontend }}" != "true" ]]; then
+            echo "No frontend-relevant changes; skipping."
+            exit 0
+          fi
+          for result in \
+            "${{ needs.build-test.result }}" \
+            "${{ needs.lint.result }}"; do
+            if [[ "${result}" != "success" ]]; then
+              echo "Frontend checks did not complete successfully: ${result}"
+              exit 1
+            fi
+          done
+          echo "All frontend checks passed."

--- a/packages/web/.eslintrc.js
+++ b/packages/web/.eslintrc.js
@@ -33,5 +33,10 @@ module.exports = {
   },
   globals: {
     globals: 'readonly',
+    // Vue 3.3+ compiler macros, not covered by the installed
+    // eslint-plugin-vue's `vue/setup-compiler-macros` env.
+    defineOptions: 'readonly',
+    defineModel: 'readonly',
+    defineSlots: 'readonly',
   },
 };

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   })
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.healthCheck()).toBe('Ok')
+    it('should return "OK"', () => {
+      expect(appController.healthCheck()).toBe('OK')
     })
   })
 })

--- a/src/proxy/proxy.service.spec.ts
+++ b/src/proxy/proxy.service.spec.ts
@@ -1,11 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { HttpModule } from '@nestjs/axios'
 import { ProxyService } from './proxy.service'
 
-describe('ProyService', () => {
+describe('ProxyService', () => {
   let service: ProxyService
 
   beforeEach(async() => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       providers: [ProxyService]
     }).compile()
 


### PR DESCRIPTION
## What this does

Adds a frontend CI workflow, plus the small fixes needed for it to pass green.

### `ci: add frontend PR checks`

`.github/workflows/pr-frontend.yaml` — the repository had no CI that linted, built, or tested the frontend (the NestJS BFF in `src/` and the Vue app in `packages/web`); only the image build exercised it. Following the pnpm-based pipeline common to Vue projects:

- a paths filter so the jobs only run when frontend sources or this workflow change;
- **build-test**: `pnpm install --frozen-lockfile`, then build the BFF (`nest build`) and the web app (`vite build`), then run the BFF unit tests (jest);
- **lint**: ESLint over the BFF and the web app, in check mode;
- **pr-frontend-required**: a single aggregated required status check.

Validated end-to-end locally with [`act`](https://github.com/nektos/act) — both jobs pass green.

### Fixes the new gate surfaced

- **`fix(bff)`**: the two BFF jest specs failed against the current code — `app.controller.spec` asserted `healthCheck()` returns `"Ok"` but it returns `"OK"`; `proxy.service.spec`'s `TestingModule` did not import `HttpModule`, so Nest could not resolve `ProxyService`'s `HttpService` dependency.
- **`fix(web)`**: ESLint flagged `defineOptions` (a Vue 3.3+ compiler macro) as `no-undef`; the installed eslint-plugin-vue's `vue/setup-compiler-macros` env predates it, so the 3.3+ macros are declared as globals.

> Note: the frontend `lint` script's `--require ./scripts/structured-clone-polyfill.js` points at a file that is not committed (so `pnpm lint` is currently broken); CI runs ESLint directly instead, since node 22 provides `structuredClone` natively.

> Note: the web `test:unit` script (vue-cli) cannot run (missing deps) and is not wired into this CI; adding web unit tests is tracked separately.
