### PR TITLE
fix: accumulate devices in node map instead of overwriting each iteration

### DIFF
--- a/server/internal/data/node.go
+++ b/server/internal/data/node.go
@@ -79,7 +79,7 @@ func (r *nodeRepo) updateLocalNodes() {
 					continue
 				}
 				for _, device := range devices {
-					n[node.UID].Devices = append(bizNode.Devices, &biz.DeviceInfo{
+					n[node.UID].Devices = append(n[node.UID].Devices, &biz.DeviceInfo{
 						Index:    int(device.Index),
 						Id:       device.ID,
 						AliasId:  device.AliasId,


### PR DESCRIPTION
### Problem

In `updateLocalNodes()`, when iterating over a node's devices, the code uses `bizNode.Devices` as the base slice for `append`:

```
n[node.UID].Devices = append(bizNode.Devices, &biz.DeviceInfo{...})
```

`bizNode` is created once per node by `fetchNodeInfo()` and its `Devices` field is always `nil` (it only sets metadata like IP, Name, etc.). This means every iteration overwrites the previous device instead of accumulating:

- A node with multiple devices (e.g. Ascend910B with 4 cards) loses all but the last device
- When multiple providers match the same node, devices from all but the last provider are lost

### Fix

Use the accumulated slice `n[node.UID].Devices` instead of `bizNode.Devices`:

```
n[node.UID].Devices = append(n[node.UID].Devices, &biz.DeviceInfo{...})
```

So each device is appended to the growing list in the map entry.

### Changes

`server/internal/data/node.go` — 1 line changed, 1 insertion, 1 deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where device information could be attached to the wrong node record during node updates.
  * Improved consistency of node/device data shown in the system when refreshed from provider results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->