### PR TITLE
fix(ascend): proportionally split card-level metrics for vnpu container metrics

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -363,6 +363,33 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 
 	s.generateMetricsForMetaxGPU(containers)
 	for _, device := range deviceInfos {
+		// === Ascend pre-calculation: card-level metrics + total allocation ===
+		// ponytail: proportional split — npu-exporter doesn't support vnpu for 910B/A3 yet.
+		// Card-level metrics are divided across containers by Usedmem ratio.
+		var ascendCardUtil float32
+		var ascendCardMemUsedMB float32
+		var ascendTotalMemoryOnCard int32
+		var ascendCardQueriesOK bool
+		if strings.HasPrefix(device.Provider, biz.AscendGPUDevice) {
+			var cdMemBytes float32
+			var ascendCardUtilErr, ascendCardMemErr error
+			ascendCardUtil, ascendCardUtilErr = s.deviceCoreUtil(ctx, device.Provider, device.Id)
+			cdMemBytes, ascendCardMemErr = s.deviceMemUsed(ctx, device.Provider, device.Id)
+			ascendCardQueriesOK = ascendCardUtilErr == nil && ascendCardMemErr == nil
+			if ascendCardQueriesOK && cdMemBytes > 0 {
+				ascendCardMemUsedMB = cdMemBytes / 1024 / 1024
+			}
+			for _, c := range containers {
+				for _, cd := range c.ContainerDevices {
+					if device.AliasId != "" && !device.MatchAlias(cd.UUID) {
+						continue
+					}
+					if strings.HasPrefix(cd.Type, biz.AscendGPUDevice) {
+						ascendTotalMemoryOnCard += cd.Usedmem
+					}
+				}
+			}
+		}
 		for _, c := range containers {
 			var vGPU int32 = 0
 			var core int32 = 0
@@ -385,8 +412,15 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			s.set(HamiContainerVmemoryAllocated, float64(memory), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			// 查询任务在当前设备下的算力利用率
-			taskCoreUsed, err := s.taskCoreUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
-			if err == nil {
+			var taskCoreUsed float32
+			var taskCoreUsedErr error
+			if provider == biz.AscendGPUDevice && ascendCardQueriesOK && ascendTotalMemoryOnCard > 0 {
+				ratio := float32(memory) / float32(ascendTotalMemoryOnCard)
+				taskCoreUsed = ascendCardUtil * ratio
+			} else {
+				taskCoreUsed, taskCoreUsedErr = s.taskCoreUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
+			}
+			if taskCoreUsedErr == nil {
 				used := float64(0)
 				util := float64(0)
 				switch provider {
@@ -396,6 +430,9 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				case biz.CambriconGPUDevice:
 					used = float64(taskCoreUsed) / 100 * float64(core)
 					util = float64(taskCoreUsed)
+				case biz.AscendGPUDevice:
+					used = float64(taskCoreUsed)
+					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
 				case biz.HygonGPUDevice:
 					used = float64(taskCoreUsed)
 					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
@@ -412,8 +449,15 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				s.set(HamiContainerCoreUsed, used, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
 				s.set(HamiContainerCoreUtil, util, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
 			}
-			taskMemoryUsed, err := s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
-			if err == nil {
+			var taskMemoryUsed float32
+			var taskMemoryUsedErr error
+			if provider == biz.AscendGPUDevice && ascendCardQueriesOK && ascendTotalMemoryOnCard > 0 {
+				ratio := float32(memory) / float32(ascendTotalMemoryOnCard)
+				taskMemoryUsed = ascendCardMemUsedMB * ratio
+			} else {
+				taskMemoryUsed, taskMemoryUsedErr = s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
+			}
+			if taskMemoryUsedErr == nil {
 				switch provider {
 				case biz.CambriconGPUDevice:
 					taskMemoryUsed = float32((taskMemoryUsed/100)*float32(memory)) * 1024 * 1024

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -367,7 +367,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 		// ponytail: proportional split — npu-exporter doesn't support vnpu for 910B/A3 yet.
 		// Card-level metrics are divided across containers by Usedmem ratio.
 		var ascendCardUtil float32
-		var ascendCardMemUsedMB float32
+		var ascendCardMemUsedBytes float32
 		var ascendTotalMemoryOnCard int32
 		var ascendCardQueriesOK bool
 		if strings.HasPrefix(device.Provider, biz.AscendGPUDevice) {
@@ -375,13 +375,19 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			var ascendCardUtilErr, ascendCardMemErr error
 			ascendCardUtil, ascendCardUtilErr = s.deviceCoreUtil(ctx, device.Provider, device.Id)
 			cdMemBytes, ascendCardMemErr = s.deviceMemUsed(ctx, device.Provider, device.Id)
+			if ascendCardUtilErr != nil {
+				s.log.Warnf("failed to query Ascend card util for device %s: %v", device.Id, ascendCardUtilErr)
+			}
+			if ascendCardMemErr != nil {
+				s.log.Warnf("failed to query Ascend card mem for device %s: %v", device.Id, ascendCardMemErr)
+			}
 			ascendCardQueriesOK = ascendCardUtilErr == nil && ascendCardMemErr == nil
 			if ascendCardQueriesOK && cdMemBytes > 0 {
-				ascendCardMemUsedMB = cdMemBytes / 1024 / 1024
+				ascendCardMemUsedBytes = cdMemBytes
 			}
 			for _, c := range containers {
 				for _, cd := range c.ContainerDevices {
-					if device.AliasId != "" && !device.MatchAlias(cd.UUID) {
+					if device.AliasId != "" && !strings.HasPrefix(cd.UUID, device.AliasId) {
 						continue
 					}
 					if strings.HasPrefix(cd.Type, biz.AscendGPUDevice) {
@@ -453,7 +459,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			var taskMemoryUsedErr error
 			if provider == biz.AscendGPUDevice && ascendCardQueriesOK && ascendTotalMemoryOnCard > 0 {
 				ratio := float32(memory) / float32(ascendTotalMemoryOnCard)
-				taskMemoryUsed = ascendCardMemUsedMB * ratio
+				taskMemoryUsed = ascendCardMemUsedBytes * ratio
 			} else {
 				taskMemoryUsed, taskMemoryUsedErr = s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
 			}

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -364,7 +364,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 	s.generateMetricsForMetaxGPU(containers)
 	for _, device := range deviceInfos {
 		// === Ascend pre-calculation: card-level metrics + total allocation ===
-		// ponytail: proportional split — npu-exporter doesn't support vnpu for 910B/A3 yet.
+		// npu-exporter doesn't support vnpu for 910B/A3 yet.
 		// Card-level metrics are divided across containers by Usedmem ratio.
 		var ascendCardUtil float32
 		var ascendCardMemUsedBytes float32

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -405,6 +405,9 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				core = core + cd.Usedcores
 				memory = memory + cd.Usedmem
 				provider = cd.Type
+				if strings.HasPrefix(provider, biz.AscendGPUDevice) {
+					provider = biz.AscendGPUDevice
+				}
 			}
 			if provider == "" || provider == metax.MetaxGPUDevice {
 				continue

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -428,28 +428,35 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			if taskCoreUsedErr == nil {
 				used := float64(0)
 				util := float64(0)
-				switch provider {
-				case biz.NvidiaGPUDevice:
+				isProportionalSplit := provider == biz.AscendGPUDevice && ascendCardQueriesOK && ascendTotalMemoryOnCard > 0
+				if isProportionalSplit {
+					// 比例拆分：used/util 都是 ratio×cardUtil，不除以 core
 					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case biz.CambriconGPUDevice:
-					used = float64(taskCoreUsed) / 100 * float64(core)
-					util = float64(taskCoreUsed)
-				case biz.AscendGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case biz.HygonGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case metax.MetaxSGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				default:
-				}
-				cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
-				if err == nil && used != 0 && cardCoreUtil > 95 {
-					used = float64(cardCoreUtil) / 100 * float64(core)
-					util = float64(cardCoreUtil)
+					util = roundToOneDecimal(float64(taskCoreUsed))
+				} else {
+					switch provider {
+					case biz.NvidiaGPUDevice:
+						used = float64(taskCoreUsed)
+						util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+					case biz.CambriconGPUDevice:
+						used = float64(taskCoreUsed) / 100 * float64(core)
+						util = float64(taskCoreUsed)
+					case biz.AscendGPUDevice:
+						used = float64(taskCoreUsed)
+						util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+					case biz.HygonGPUDevice:
+						used = float64(taskCoreUsed)
+						util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+					case metax.MetaxSGPUDevice:
+						used = float64(taskCoreUsed)
+						util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+					default:
+					}
+					cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
+					if err == nil && used != 0 && cardCoreUtil > 95 {
+						used = float64(cardCoreUtil) / 100 * float64(core)
+						util = float64(cardCoreUtil)
+					}
 				}
 				s.set(HamiContainerCoreUsed, used, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
 				s.set(HamiContainerCoreUtil, util, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -370,7 +370,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 		var ascendCardMemUsedMB float32
 		var ascendTotalMemoryOnCard int32
 		var ascendCardQueriesOK bool
-		if strings.HasPrefix(device.Provider, biz.AscendGPUDevice) {
+		if device.Provider == biz.AscendGPUDevice {
 			var ascendCardUtilErr, ascendCardMemErr error
 			ascendCardUtil, ascendCardUtilErr = s.deviceCoreUtil(ctx, device.Provider, device.Id)
 			ascendCardMemUsedMB, ascendCardMemErr = s.deviceMemUsed(ctx, device.Provider, device.Id)

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -367,14 +367,13 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 		// npu-exporter doesn't support vnpu for 910B/A3 yet.
 		// Card-level metrics are divided across containers by Usedmem ratio.
 		var ascendCardUtil float32
-		var ascendCardMemUsedBytes float32
+		var ascendCardMemUsedMB float32
 		var ascendTotalMemoryOnCard int32
 		var ascendCardQueriesOK bool
 		if strings.HasPrefix(device.Provider, biz.AscendGPUDevice) {
-			var cdMemBytes float32
 			var ascendCardUtilErr, ascendCardMemErr error
 			ascendCardUtil, ascendCardUtilErr = s.deviceCoreUtil(ctx, device.Provider, device.Id)
-			cdMemBytes, ascendCardMemErr = s.deviceMemUsed(ctx, device.Provider, device.Id)
+			ascendCardMemUsedMB, ascendCardMemErr = s.deviceMemUsed(ctx, device.Provider, device.Id)
 			if ascendCardUtilErr != nil {
 				s.log.Warnf("failed to query Ascend card util for device %s: %v", device.Id, ascendCardUtilErr)
 			}
@@ -382,9 +381,6 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				s.log.Warnf("failed to query Ascend card mem for device %s: %v", device.Id, ascendCardMemErr)
 			}
 			ascendCardQueriesOK = ascendCardUtilErr == nil && ascendCardMemErr == nil
-			if ascendCardQueriesOK && cdMemBytes > 0 {
-				ascendCardMemUsedBytes = cdMemBytes
-			}
 			for _, c := range containers {
 				for _, cd := range c.ContainerDevices {
 					if device.AliasId != "" && !strings.HasPrefix(cd.UUID, device.AliasId) {
@@ -459,7 +455,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			var taskMemoryUsedErr error
 			if provider == biz.AscendGPUDevice && ascendCardQueriesOK && ascendTotalMemoryOnCard > 0 {
 				ratio := float32(memory) / float32(ascendTotalMemoryOnCard)
-				taskMemoryUsed = ascendCardMemUsedBytes * ratio
+				taskMemoryUsed = ascendCardMemUsedMB * ratio
 			} else {
 				taskMemoryUsed, taskMemoryUsedErr = s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
 			}
@@ -467,6 +463,8 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				switch provider {
 				case biz.CambriconGPUDevice:
 					taskMemoryUsed = float32((taskMemoryUsed/100)*float32(memory)) * 1024 * 1024
+				case biz.AscendGPUDevice:
+					taskMemoryUsed = taskMemoryUsed * 1024 * 1024
 				case metax.MetaxSGPUDevice:
 					taskMemoryUsed = float32(taskMemoryUsed) * 1024 // KB->Byte
 				default:

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -1,0 +1,384 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+	"vgpu/internal/biz"
+	"vgpu/internal/conf"
+	"vgpu/internal/data/prom"
+	"vgpu/internal/service"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+)
+
+// ---- Fake repos ----
+
+type fakePodRepo struct {
+	containers []*biz.Container
+}
+
+func (f *fakePodRepo) ListAll(_ context.Context) ([]*biz.Container, error) {
+	return f.containers, nil
+}
+
+func (f *fakePodRepo) FindOne(_ context.Context, _, _ string) (*biz.Container, error) {
+	if len(f.containers) > 0 {
+		return f.containers[0], nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+type fakeNodeRepo struct {
+	devices []*biz.DeviceInfo
+}
+
+func (f *fakeNodeRepo) ListAll(_ context.Context) ([]*biz.Node, error) {
+	return nil, nil
+}
+
+func (f *fakeNodeRepo) GetNode(_ context.Context, _ string) (*biz.Node, error) {
+	return nil, nil
+}
+
+func (f *fakeNodeRepo) ListAllDevices(_ context.Context) ([]*biz.DeviceInfo, error) {
+	return f.devices, nil
+}
+
+func (f *fakeNodeRepo) FindDeviceByAliasId(_ string) (*biz.DeviceInfo, error) {
+	return nil, nil
+}
+
+// ---- Mock Prometheus server ----
+
+type mockPromHandler struct {
+	responses map[string]string
+}
+
+func (h *mockPromHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/v1/query" {
+		http.NotFound(w, r)
+		return
+	}
+	query := r.URL.Query().Get("query")
+	if r.Method == "POST" {
+		query = r.PostFormValue("query")
+	}
+	if body, ok := h.responses[query]; ok {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}
+}
+
+func buildPromVectorResponse(samples []model.Sample) string {
+	var result []map[string]interface{}
+	for _, s := range samples {
+		metric := make(map[string]string)
+		for k, v := range s.Metric {
+			metric[string(k)] = string(v)
+		}
+		result = append(result, map[string]interface{}{
+			"metric": metric,
+			"value":  []interface{}{float64(s.Timestamp.Unix()), s.Value.String()},
+		})
+	}
+	wrapper := map[string]interface{}{
+		"status": "success",
+		"data": map[string]interface{}{
+			"resultType": "vector",
+			"result":     result,
+		},
+	}
+	body, _ := json.Marshal(wrapper)
+	return string(body)
+}
+
+// ---- Test helpers ----
+
+func newTestMetricsGenerator(t *testing.T, promURL string, containers []*biz.Container, devices []*biz.DeviceInfo) *MetricsGenerator {
+	t.Helper()
+	promClient, err := prom.NewClient(promURL, time.Second*5, "")
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	podUC := biz.NewPodUseCase(&fakePodRepo{containers: containers}, log.DefaultLogger)
+	nodeUC := biz.NewNodeUsecase(&fakeNodeRepo{devices: devices}, log.DefaultLogger)
+	monitorSvc := service.NewMonitorService(promClient, nodeUC, podUC)
+	gen := NewMetricsGenerator(
+		&conf.Bootstrap{},
+		promClient,
+		nodeUC,
+		podUC,
+		monitorSvc,
+		log.DefaultLogger,
+	)
+	return gen
+}
+
+func readMetricAnyLabels(metricName string, partialLabels map[string]string) float64 {
+	registry := prometheus.DefaultRegisterer.(*prometheus.Registry)
+	families, err := registry.Gather()
+	if err != nil {
+		return -1
+	}
+	for _, f := range families {
+		if f.GetName() != metricName {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			ml := m.GetLabel()
+			match := true
+			for _, l := range ml {
+				if v, ok := partialLabels[l.GetName()]; ok && v != l.GetValue() {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func resetTestMetrics() {
+	// Reset all gauge vectors between tests
+	for _, m := range []*prometheus.GaugeVec{
+		HamiContainerVgpuAllocated, HamiContainerVmemoryAllocated, HamiContainerVcoreAllocated,
+		HamiContainerMemoryUsed, HamiContainerMemoryUtil,
+		HamiContainerCoreUsed, HamiContainerCoreUtil,
+	} {
+		m.Reset()
+	}
+}
+
+func approxEqual(a, b, epsilon float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < epsilon
+}
+
+// ---- Ascend proportional split tests ----
+
+func TestAscend910B_Proportional_SingleContainer_Success(t *testing.T) {
+	devices := []*biz.DeviceInfo{
+		{
+			Id: "npu-uuid-1", AliasId: "npu-uuid-1",
+			Count: 1, Devmem: 65536, Devcore: 100,
+			Type: "Ascend910B", NodeName: "node-1", Provider: "Ascend", Health: true,
+		},
+	}
+	containers := []*biz.Container{
+		{
+			Name: "ctr", PodName: "pod-1", Namespace: "ns-1", PodUID: "pod-uid-1", NodeName: "node-1",
+			ContainerDevices: biz.ContainerDevices{
+				{UUID: "npu-uuid-1", Type: "Ascend910B", Usedmem: 11264, Usedcores: 25},
+			},
+		},
+	}
+
+	now := model.Now()
+	totalQ := fmt.Sprintf("avg(npu_chip_info_hbm_total_memory{vdie_id=\"%s\"})", "npu-uuid-1")
+	coreUtilQ := fmt.Sprintf("avg(npu_chip_info_utilization{vdie_id=\"%s\"})", "npu-uuid-1")
+	memUsedQ := fmt.Sprintf("avg(npu_chip_info_hbm_used_memory{vdie_id=\"%s\"})", "npu-uuid-1")
+
+	mockResponses := map[string]string{
+		totalQ: buildPromVectorResponse([]model.Sample{
+			{Value: 65536, Timestamp: now},
+		}),
+		coreUtilQ: buildPromVectorResponse([]model.Sample{
+			{Value: 30, Timestamp: now},
+		}),
+		memUsedQ: buildPromVectorResponse([]model.Sample{
+			{Value: 14305.1, Timestamp: now},
+		}),
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/query", &mockPromHandler{responses: mockResponses})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	gen := newTestMetricsGenerator(t, server.URL, containers, devices)
+	resetTestMetrics()
+	err := gen.GenerateContainerMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("GenerateContainerMetrics failed: %v", err)
+	}
+
+	// ratio=11264/11264=1.0, cardUtil=30
+	// core_used = 30 × 1.0 = 30, core_util = core_used = 30
+	wantUsed := float64(30)
+	wantUtil := float64(30)
+	if got := readMetricAnyLabels("hami_container_core_used", map[string]string{
+		"pod_name": "pod-1", "container_name": "ctr", "namespace_name": "ns-1",
+	}); !approxEqual(wantUsed, got, 0.1) {
+		t.Errorf("hami_container_core_used: want %v, got %v", wantUsed, got)
+	}
+	if got := readMetricAnyLabels("hami_container_core_util", map[string]string{
+		"pod_name": "pod-1", "container_name": "ctr", "namespace_name": "ns-1",
+	}); !approxEqual(wantUtil, got, 0.1) {
+		t.Errorf("hami_container_core_util: want ~%v (=core_used), got %v", wantUtil, got)
+	}
+}
+
+func TestAscend910B_Proportional_MultiContainer_CoreMemory(t *testing.T) {
+	deviceUUID := "npu-multi-1"
+	devices := []*biz.DeviceInfo{
+		{
+			Id: deviceUUID, AliasId: deviceUUID,
+			Count: 1, Devmem: 65536, Devcore: 100,
+			Type: "Ascend910B", NodeName: "node-1", Provider: "Ascend", Health: true,
+		},
+	}
+	containers := []*biz.Container{
+		{
+			Name: "ctr-a", PodName: "pod-a", Namespace: "ns-1", PodUID: "pod-uid-a", NodeName: "node-1",
+			ContainerDevices: biz.ContainerDevices{
+				{UUID: deviceUUID, Type: "Ascend910B", Usedmem: 16384, Usedcores: 25},
+			},
+		},
+		{
+			Name: "ctr-b", PodName: "pod-b", Namespace: "ns-1", PodUID: "pod-uid-b", NodeName: "node-1",
+			ContainerDevices: biz.ContainerDevices{
+				{UUID: deviceUUID, Type: "Ascend910B", Usedmem: 32768, Usedcores: 50},
+			},
+		},
+	}
+
+	now := model.Now()
+	coreUtilQ := fmt.Sprintf("avg(npu_chip_info_utilization{vdie_id=\"%s\"})", deviceUUID)
+	memUsedQ := fmt.Sprintf("avg(npu_chip_info_hbm_used_memory{vdie_id=\"%s\"})", deviceUUID)
+	memTotalQ := fmt.Sprintf("avg(npu_chip_info_hbm_total_memory{vdie_id=\"%s\"})", deviceUUID)
+
+	mockResponses := map[string]string{
+		coreUtilQ: buildPromVectorResponse([]model.Sample{{Value: 90, Timestamp: now}}),
+		memUsedQ:  buildPromVectorResponse([]model.Sample{{Value: 28610.2, Timestamp: now}}),
+		memTotalQ: buildPromVectorResponse([]model.Sample{{Value: 65536, Timestamp: now}}),
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/query", &mockPromHandler{responses: mockResponses})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	gen := newTestMetricsGenerator(t, server.URL, containers, devices)
+	resetTestMetrics()
+
+	err := gen.GenerateContainerMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("GenerateContainerMetrics failed: %v", err)
+	}
+
+	labelsA := map[string]string{"pod_name": "pod-a", "container_name": "ctr-a", "namespace_name": "ns-1"}
+	labelsB := map[string]string{"pod_name": "pod-b", "container_name": "ctr-b", "namespace_name": "ns-1"}
+
+	// ctr-a: ratio=16384/49152=0.333, core_used=90*0.333=30, core_util=30
+	// ctr-b: ratio=32768/49152=0.667, core_used=90*0.667=60, core_util=60
+	if got := readMetricAnyLabels("hami_container_core_used", labelsA); !approxEqual(30, got, 1.0) {
+		t.Errorf("ctr-a core_used: want ~30, got %v", got)
+	}
+	if got := readMetricAnyLabels("hami_container_core_util", labelsA); !approxEqual(30, got, 1.0) {
+		t.Errorf("ctr-a core_util: want ~30 (=core_used), got %v", got)
+	}
+	if got := readMetricAnyLabels("hami_container_core_used", labelsB); !approxEqual(60, got, 1.0) {
+		t.Errorf("ctr-b core_used: want ~60, got %v", got)
+	}
+	if got := readMetricAnyLabels("hami_container_core_util", labelsB); !approxEqual(60, got, 1.0) {
+		t.Errorf("ctr-b core_util: want ~60 (=core_used), got %v", got)
+	}
+
+	// ctr-a: memory_used = 28610.2 * (16384/49152) ≈ 9536.7 MB
+	wantMemA := roundToOneDecimal(28610.2 * float64(16384) / float64(49152))
+	if got := readMetricAnyLabels("hami_container_memory_used", labelsA); !approxEqual(wantMemA, got, 1.0) {
+		t.Errorf("ctr-a memory_used: want ~%v, got %v", wantMemA, got)
+	}
+	// ctr-b: memory_used = 28610.2 * (32768/49152) ≈ 19073.5 MB
+	wantMemB := roundToOneDecimal(28610.2 * float64(32768) / float64(49152))
+	if got := readMetricAnyLabels("hami_container_memory_used", labelsB); !approxEqual(wantMemB, got, 1.0) {
+		t.Errorf("ctr-b memory_used: want ~%v, got %v", wantMemB, got)
+	}
+
+	// Sum of memory should equal full card memory used
+	if got := readMetricAnyLabels("hami_container_memory_used", labelsA) + readMetricAnyLabels("hami_container_memory_used", labelsB); !approxEqual(28610.2, got, 2.0) {
+		t.Errorf("memory_used sum: want ~28610.2, got %v", got)
+	}
+}
+
+func TestAscend910B_CardQueryFails_FallbackToContainerMetric(t *testing.T) {
+	// Card-level query failure → ascendCardQueriesOK = false → fallback to taskCoreUsed/taskMemoryUsed
+	// container_npu_* queries return empty (not mocked) → queryInstantVal returns (0, nil)
+	// → metrics set to 0 (this PR branch does not have ascendSkipMetrics)
+	deviceUUID := "npu-uuid-skip"
+	devices := []*biz.DeviceInfo{
+		{
+			Id: deviceUUID, AliasId: deviceUUID,
+			Count: 1, Devmem: 65536, Devcore: 100,
+			Type: "Ascend910B", NodeName: "node-1", Provider: "Ascend", Health: true,
+		},
+	}
+	containers := []*biz.Container{
+		{
+			Name: "ctr", PodName: "pod-1", Namespace: "ns-1", PodUID: "pod-uid-1", NodeName: "node-1",
+			ContainerDevices: biz.ContainerDevices{
+				{UUID: deviceUUID, Type: "Ascend910B", Usedmem: 16384, Usedcores: 25},
+			},
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/query", func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		if r.Method == "POST" {
+			query = r.PostFormValue("query")
+		}
+		if strings.Contains(query, "npu_chip_info_utilization") || strings.Contains(query, "npu_chip_info_hbm_used_memory") {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	gen := newTestMetricsGenerator(t, server.URL, containers, devices)
+	resetTestMetrics()
+
+	err := gen.GenerateContainerMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("GenerateContainerMetrics failed: %v", err)
+	}
+
+	labels := map[string]string{"pod_name": "pod-1", "container_name": "ctr", "namespace_name": "ns-1"}
+
+	// Allocation metrics should be set
+	if got := readMetricAnyLabels("hami_container_vgpu_allocated", labels); got != 1 {
+		t.Errorf("hami_container_vgpu_allocated: want 1, got %v", got)
+	}
+	if got := readMetricAnyLabels("hami_container_vmemory_allocated", labels); got != 16384 {
+		t.Errorf("hami_container_vmemory_allocated: want 16384, got %v", got)
+	}
+
+	// Fallback path: container_npu_* returns empty → queryInstantVal returns (0, nil)
+	// → taskCoreUsed=0, taskMemoryUsed=0 → metrics set to 0
+	if got := readMetricAnyLabels("hami_container_core_used", labels); got != 0 {
+		t.Errorf("hami_container_core_used: want 0 (fallback empty), got %v", got)
+	}
+	if got := readMetricAnyLabels("hami_container_memory_used", labels); got != 0 {
+		t.Errorf("hami_container_memory_used: want 0 (fallback empty), got %v", got)
+	}
+}


### PR DESCRIPTION
### Problem

`taskCoreUsed()` and `taskMemoryUsed()` both return `(0, nil)` for `AscendGPUDevice`. This means Ascend containers always report `hami_container_core_used = 0` and `hami_container_memory_used = 0` — the metrics are silently zeroed out.

### Root Cause

The npu-exporter does not expose per-container (vnpu) Prometheus metrics for Ascend910B/A3. The previous `return 0, nil` stub was a placeholder that left container-level core/memory utilization broken.

### Fix

Before iterating containers, pre-query card-level metrics (`npu_chip_info_utilization`, `npu_chip_info_hbm_used_memory`) for each Ascend device and compute the total allocated memory (`Usedmem`) across all containers on that card. Then, for each container, split the card-level metrics proportionally by its share of `Usedmem`.

- If card queries fail (guard: `ascendCardQueriesOK`), fall back to the existing `taskCoreUsed`/`taskMemoryUsed` path (which returns 0 for Ascend — matching prior behavior).
- The proportional split only activates when `ascendTotalMemoryOnCard > 0` to avoid division by zero.

### core_util > 100% fix (latest commit)

The original proportional split computed `core_util = 100 × core_used / core`, where `core_used = cardUtil × ratio` (ratio denominator = sum of container allocations) but `core = 100 × memory / deviceMemSize` (physical total). When containers don't fill the card, this denominator mismatch inflates `core_util` beyond 100% (e.g. 2 pods each allocated 25% of a 32GB card, cardUtil=90% → core_util=175%).

**Root cause**: `util = 100 × used / core` was designed for vendors with independent container-level metrics (e.g. NVIDIA's `Device_utilization_desc_of_container`). It doesn't apply when `used` is an estimated proportional split of card-level metrics.

**Fix**: In the proportional split path, `core_util = roundToOneDecimal(core_used)` — since `ratio × cardUtil` is already a utilization value (0–100%), it should not be divided by `core`. `memory_util` is unchanged (its formula already simplifies to `100 × cardMemUsed / sumAlloc`).

### Changes

`server/internal/exporter/exporter.go`
- Pre-calculation block for Ascend card-level metrics + total allocated memory
- Ascend case in the core/memory switch for proper util calculation
- Conditional split logic replacing the direct `taskCoreUsed`/`taskMemoryUsed` calls for Ascend
- `core_util = core_used` in proportional split path (not `100 × core_used / core`)

`server/internal/exporter/exporter_test.go` (new file)
- Single-container proportional split test
- Multi-container unequal split test (verifies core_used sum = cardUtil, memory_used sum = cardMemUsed)
- Card-query-failure fallback test

### Note for reviewers

Use AI to analyze issue, writing code, writting commit message and also this pr description and I review all the code written by ai