### PR TITLE
fix: correct Ascend GPU vcore allocation based on memory ratio

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -383,6 +383,14 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			podUIDLabel := fmt.Sprintf("%s:%s", c.Name, c.PodUID)
 			s.set(HamiContainerVgpuAllocated, float64(vGPU), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			s.set(HamiContainerVmemoryAllocated, float64(memory), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
+			// For Ascend GPU, Usedcores is a 1-100 value that doesn't reflect actual core allocation.
+			// Recalculate core as the percentage of device memory allocated to this container.
+			if provider == biz.AscendGPUDevice {
+				if deviceMemSize, err := s.deviceMemTotal(ctx, provider, device.Id); err == nil && deviceMemSize > 0 {
+					perc := float32(memory) / deviceMemSize
+					core = int32(float32(100) * perc)
+				}
+			}
 			s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			// 查询任务在当前设备下的算力利用率
 			taskCoreUsed, err := s.taskCoreUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)


### PR DESCRIPTION
### Problem

For Ascend GPU, `Usedcores` is a static value (25, 50, etc.) that reflects a fixed mapping to memory size rather than the actual core allocation ratio on the device. Setting `HamiContainerVcoreAllocated` to this raw value produces misleading metrics.

### Fix

Before setting `HamiContainerVcoreAllocated` for Ascend devices, recalculate `core` as the percentage of device memory allocated to this container relative to total device memory:

```
perc = memory / deviceMemSize
core = int32(100 * perc)
```

This matches the intended semantics of `VcoreAllocated` — the share of the device allocated to the container.

### Changes

`server/internal/exporter/exporter.go` — 8 insertions
- Ascend-specific core recalculation before `HamiContainerVcoreAllocated` set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource reporting for Ascend GPU containers so allocation values now better reflect memory-based usage when available.
  * Made container metric calculations more accurate and consistent for GPU-backed workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->