### PR TITLE
fix: enable Ascend NPU container-level metrics in exporter and chart display

### DIFF
--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -157,11 +157,16 @@
   <div class="task-trend-row">
     <block-box v-for="{ title, data } in lineConfigView" :key="title" :title="title">
       <div class="trend-chart">
-        <VChart
-          :option="getLineOptions({ data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
-          :autoresize="true"
-          class="trend-vchart"
-        />
+        <template v-if="data && data.length > 0">
+          <VChart
+            :option="getLineOptions({ data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
+            :autoresize="true"
+            class="trend-vchart"
+          />
+        </template>
+        <template v-else>
+          <el-empty :description="$t('task.noMonitorSupport')" :image-size="60" />
+        </template>
       </div>
     </block-box>
   </div>
@@ -384,6 +389,9 @@ const fetchLineData = async () => {
       })
       .then((res) => {
         lineConfig.value[index].data = res.data[0]?.values || [];
+      })
+      .catch(() => {
+        lineConfig.value[index].data = [];
       }),
   );
 };

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -150,23 +150,18 @@
   </block-box>
 
   <trend-time-filter
-    v-if="detail.type && (detail.type.startsWith('NVIDIA') || detail.type.startsWith('MXC'))"
+    v-if="detail.type"
     v-model="times"
   />
 
   <div class="task-trend-row">
     <block-box v-for="{ title, data } in lineConfigView" :key="title" :title="title">
       <div class="trend-chart">
-        <template v-if="detail.type && !detail.type.startsWith('NVIDIA') && !detail.type.startsWith('MXC')">
-          <el-empty :description="$t('task.noMonitorSupport')" :image-size="60" />
-        </template>
-        <template v-else>
-          <VChart
-            :option="getLineOptions({ data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
-            :autoresize="true"
-            class="trend-vchart"
-          />
-        </template>
+        <VChart
+          :option="getLineOptions({ data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
+          :autoresize="true"
+          class="trend-vchart"
+        />
       </div>
     </block-box>
   </div>

--- a/server/internal/data/pod.go
+++ b/server/internal/data/pod.go
@@ -132,7 +132,13 @@ func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
 		}
 	}
 
+	initContainerOffset := len(pod.Spec.InitContainers)
 	for i, ctr := range pod.Spec.Containers {
+		deviceIdx := initContainerOffset + i
+		var containerDevices biz.ContainerDevices
+		if deviceIdx < len(bizContainerDevices) {
+			containerDevices = bizContainerDevices[deviceIdx]
+		}
 		c := &biz.Container{
 			Name:             ctr.Name,
 			UUID:             ctrIdMaps[ctr.Name],
@@ -145,10 +151,10 @@ func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
 			NodeUID:          r.GetNodeUUID(pod),
 			Namespace:        pod.Namespace,
 			CreateTime:       r.GetCreateTime(pod),
-			ContainerDevices: bizContainerDevices[i],
+			ContainerDevices: containerDevices,
 		}
-		if len(bizContainerDevices[i]) > 0 {
-			c.Priority = bizContainerDevices[i][0].Priority
+		if len(containerDevices) > 0 {
+			c.Priority = containerDevices[0].Priority
 		}
 		containers = append(containers, c)
 	}

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -399,10 +399,13 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				case biz.HygonGPUDevice:
 					used = float64(taskCoreUsed)
 					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case metax.MetaxSGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				default:
+			case biz.AscendGPUDevice:
+				used = float64(taskCoreUsed) / 100 * float64(core)
+				util = float64(taskCoreUsed)
+			case metax.MetaxSGPUDevice:
+				used = float64(taskCoreUsed)
+				util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+			default:
 				}
 				cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
 				if err == nil && used != 0 && cardCoreUtil > 95 {
@@ -540,7 +543,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vcore\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
-		return 0, nil
+		query = fmt.Sprintf("avg(npu_chip_info_utilization{vdie_id=\"%s\"})", deviceUUID)
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_percent{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)
 	case biz.MetaxGPUDevice, metax.MetaxGPUDevice:
@@ -563,7 +566,7 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_memory_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vmemory\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
-		return 0, nil
+		query = fmt.Sprintf("avg(npu_chip_info_hbm_used_memory{vdie_id=\"%s\"})", deviceUUID)
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_usage_memory_size{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)
 	case metax.MetaxGPUDevice:

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -418,6 +418,9 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			taskMemoryUsed, err := s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
 			if err == nil {
 				switch provider {
+				case biz.AscendGPUDevice:
+					// npu_chip_info_hbm_used_memory returns MB (10^6 bytes), convert to bytes for downstream /1024/1024 → MiB
+					taskMemoryUsed = float32(float64(taskMemoryUsed) * 1000 * 1000)
 				case biz.CambriconGPUDevice:
 					taskMemoryUsed = float32((taskMemoryUsed/100)*float32(memory)) * 1024 * 1024
 				case metax.MetaxSGPUDevice:

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -399,13 +399,13 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				case biz.HygonGPUDevice:
 					used = float64(taskCoreUsed)
 					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-			case biz.AscendGPUDevice:
-				used = float64(taskCoreUsed) / 100 * float64(core)
-				util = float64(taskCoreUsed)
-			case metax.MetaxSGPUDevice:
-				used = float64(taskCoreUsed)
-				util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-			default:
+				case biz.AscendGPUDevice:
+					used = float64(taskCoreUsed) / 100 * float64(core)
+					util = float64(taskCoreUsed)
+				case metax.MetaxSGPUDevice:
+					used = float64(taskCoreUsed)
+					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
+				default:
 				}
 				cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
 				if err == nil && used != 0 && cardCoreUtil > 95 {
@@ -419,8 +419,8 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			if err == nil {
 				switch provider {
 				case biz.AscendGPUDevice:
-					// npu_chip_info_hbm_used_memory returns MB (10^6 bytes), convert to bytes for downstream /1024/1024 → MiB
-					taskMemoryUsed = float32(float64(taskMemoryUsed) * 1000 * 1000)
+					// npu_chip_info_hbm_used_memory returns bytes; downstream /1024/1024 converts to MiB.
+					// No divisor needed — keep as bytes to match device-level semantics.
 				case biz.CambriconGPUDevice:
 					taskMemoryUsed = float32((taskMemoryUsed/100)*float32(memory)) * 1024 * 1024
 				case metax.MetaxSGPUDevice:
@@ -546,6 +546,8 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vcore\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
+		// LIMITATION: npu_chip_info_utilization is device-scoped, not container-scoped.
+		// When multiple tasks share one NPU, each task is attributed the full device utilization.
 		query = fmt.Sprintf("avg(npu_chip_info_utilization{vdie_id=\"%s\"})", deviceUUID)
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_percent{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)
@@ -569,6 +571,8 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_memory_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vmemory\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
+		// LIMITATION: npu_chip_info_hbm_used_memory is device-scoped, not container-scoped.
+		// When multiple tasks share one NPU, each task is attributed the full device HBM usage.
 		query = fmt.Sprintf("avg(npu_chip_info_hbm_used_memory{vdie_id=\"%s\"})", deviceUUID)
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_usage_memory_size{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -1,0 +1,100 @@
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"vgpu/internal/biz"
+	"vgpu/internal/data/prom"
+	"vgpu/internal/service"
+
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+// testPromHandler returns a handler that acts as a fake Prometheus /api/v1/query
+// endpoint. When value is non-empty, it returns a single-sample vector with that
+// value. When value is empty, it returns an empty result vector.
+func testPromHandler(t *testing.T, value string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost && r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/v1/query") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if value == "" {
+			fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+			return
+		}
+		fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1719500000,%q]}]}}`, value)
+	}
+}
+
+// newTestGenerator starts an httptest server with the given handler, creates a
+// prom.Client pointed at it, wraps it in a MonitorService, and returns a bare
+// MetricsGenerator (other fields left nil). The returned close func shuts down
+// the test server.
+func newTestGenerator(t *testing.T, handler http.HandlerFunc) (*MetricsGenerator, func()) {
+	srv := httptest.NewServer(handler)
+
+	promClient, err := prom.NewClient(srv.URL, time.Second, "")
+	if err != nil {
+		srv.Close()
+		t.Fatalf("prom.NewClient: %v", err)
+	}
+
+	monitorSvc := service.NewMonitorService(promClient, nil, nil)
+
+	gen := &MetricsGenerator{
+		monitorService: monitorSvc,
+		log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+	}
+
+	return gen, srv.Close
+}
+
+func TestMetricsGenerator_taskCoreUsed_Ascend(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "42.5"))
+	defer cleanup()
+
+	result, err := gen.taskCoreUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
+	if err != nil {
+		t.Fatalf("taskCoreUsed failed: %v", err)
+	}
+	if result != 42.5 {
+		t.Errorf("expected 42.5, got %v", result)
+	}
+}
+
+func TestMetricsGenerator_taskMemoryUsed_Ascend(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8589934592"))
+	defer cleanup()
+
+	result, err := gen.taskMemoryUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
+	if err != nil {
+		t.Fatalf("taskMemoryUsed failed: %v", err)
+	}
+	if result != 8589934592 {
+		t.Errorf("expected 8589934592, got %v", result)
+	}
+}
+
+func TestMetricsGenerator_taskCoreUsed_Ascend_EmptyResult(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, ""))
+	defer cleanup()
+
+	result, err := gen.taskCoreUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
+	if err != nil {
+		t.Fatalf("taskCoreUsed failed: %v", err)
+	}
+	if result != 0 {
+		t.Errorf("expected 0, got %v", result)
+	}
+}

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -74,16 +74,16 @@ func TestMetricsGenerator_taskCoreUsed_Ascend(t *testing.T) {
 }
 
 func TestMetricsGenerator_taskMemoryUsed_Ascend(t *testing.T) {
-	// npu_chip_info_hbm_used_memory returns MB, e.g., 8192 for 8 GB HBM
-	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8192"))
+	// npu_chip_info_hbm_used_memory returns bytes, e.g., 8589934592 for 8 GiB HBM
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8589934592"))
 	defer cleanup()
 
 	result, err := gen.taskMemoryUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
 	if err != nil {
 		t.Fatalf("taskMemoryUsed failed: %v", err)
 	}
-	if result != 8192 {
-		t.Errorf("expected 8192 (MB), got %v", result)
+	if result != 8589934592 {
+		t.Errorf("expected 8589934592 (bytes), got %v", result)
 	}
 }
 
@@ -97,5 +97,71 @@ func TestMetricsGenerator_taskCoreUsed_Ascend_EmptyResult(t *testing.T) {
 	}
 	if result != 0 {
 		t.Errorf("expected 0, got %v", result)
+	}
+}
+
+// TestMetricsGenerator_deviceMemUsed_Ascend verifies the device-level memory query
+// returns raw bytes from npu_chip_info_hbm_used_memory.
+func TestMetricsGenerator_deviceMemUsed_Ascend(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8589934592"))
+	defer cleanup()
+
+	result, err := gen.deviceMemUsed(context.Background(), biz.AscendGPUDevice, "dev-uuid")
+	if err != nil {
+		t.Fatalf("deviceMemUsed failed: %v", err)
+	}
+	// deviceMemUsed returns the raw Prometheus value (bytes) without any divisor for Ascend.
+	if result != 8589934592 {
+		t.Errorf("expected 8589934592 (bytes), got %v", result)
+	}
+}
+
+// TestMetricsGenerator_AscendMemoryConversion verifies the container memory usage
+// conversion: taskMemoryUsed returns bytes, downstream /1024/1024 produces MiB.
+func TestMetricsGenerator_AscendMemoryConversion(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8589934592"))
+	defer cleanup()
+
+	// Simulate the GenerateContainerMetrics memory conversion for Ascend:
+	// taskMemoryUsed returns raw bytes (no *1000*1000 MB conversion).
+	rawBytes, err := gen.taskMemoryUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
+	if err != nil {
+		t.Fatalf("taskMemoryUsed failed: %v", err)
+	}
+	// Downstream: HamiContainerMemoryUsed = taskMemoryUsed / 1024 / 1024 (bytes → MiB)
+	containerMemoryUsedMiB := float64(rawBytes) / 1024 / 1024
+	// 8 GiB = 8192 MiB
+	expected := float64(8192)
+	if containerMemoryUsedMiB != expected {
+		t.Errorf("expected container memory %.0f MiB, got %.0f MiB", expected, containerMemoryUsedMiB)
+	}
+}
+
+// TestMetricsGenerator_AscendCoreConversion verifies the container core usage
+// conversion: used = taskCoreUsed / 100 * core, util = taskCoreUsed.
+func TestMetricsGenerator_AscendCoreConversion(t *testing.T) {
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "42.5"))
+	defer cleanup()
+
+	taskCoreUtil, err := gen.taskCoreUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
+	if err != nil {
+		t.Fatalf("taskCoreUsed failed: %v", err)
+	}
+	if taskCoreUtil != 42.5 {
+		t.Errorf("expected 42.5, got %v", taskCoreUtil)
+	}
+
+	// Simulate the GenerateContainerMetrics Ascend core conversion:
+	// used = float64(taskCoreUsed) / 100 * float64(core)
+	// util = float64(taskCoreUsed)
+	const allocatedCore int32 = 50
+	used := float64(taskCoreUtil) / 100 * float64(allocatedCore)
+	util := float64(taskCoreUtil)
+
+	if used != 21.25 {
+		t.Errorf("expected used=21.25, got %v", used)
+	}
+	if util != 42.5 {
+		t.Errorf("expected util=42.5, got %v", util)
 	}
 }

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -74,15 +74,16 @@ func TestMetricsGenerator_taskCoreUsed_Ascend(t *testing.T) {
 }
 
 func TestMetricsGenerator_taskMemoryUsed_Ascend(t *testing.T) {
-	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8589934592"))
+	// npu_chip_info_hbm_used_memory returns MB, e.g., 8192 for 8 GB HBM
+	gen, cleanup := newTestGenerator(t, testPromHandler(t, "8192"))
 	defer cleanup()
 
 	result, err := gen.taskMemoryUsed(context.Background(), biz.AscendGPUDevice, "ns", "pod", "ctr", "pod-uuid", "dev-uuid", "host", 0)
 	if err != nil {
 		t.Fatalf("taskMemoryUsed failed: %v", err)
 	}
-	if result != 8589934592 {
-		t.Errorf("expected 8589934592, got %v", result)
+	if result != 8192 {
+		t.Errorf("expected 8192 (MB), got %v", result)
 	}
 }
 

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -281,21 +281,30 @@ func DecodeMetaxContainerDevices(str string) (ContainerDevices, error) {
 	return contdev, nil
 }
 
-func GetContainerPriorities(pod *corev1.Pod) []string {
-	var priorities []string
-
+func getContainerPriority(ctr corev1.Container) string {
 	nvidiaPriority := corev1.ResourceName(NVIDIAPriority)
-	for _, ctr := range pod.Spec.Containers {
-		priority := ""
-		if limitPriority, ok := ctr.Resources.Limits[nvidiaPriority]; ok {
-			priority = limitPriority.String()
-		} else if requestPriority, ok := ctr.Resources.Requests[nvidiaPriority]; ok {
-			priority = requestPriority.String()
-		}
-		priorities = append(priorities, priority)
+	if limitPriority, ok := ctr.Resources.Limits[nvidiaPriority]; ok {
+		return limitPriority.String()
 	}
+	if requestPriority, ok := ctr.Resources.Requests[nvidiaPriority]; ok {
+		return requestPriority.String()
+	}
+	return ""
+}
 
+func GetContainerPriorities(pod *corev1.Pod) []string {
+	priorities := make([]string, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
+	for _, ctr := range pod.Spec.InitContainers {
+		priorities = append(priorities, getContainerPriority(ctr))
+	}
+	for _, ctr := range pod.Spec.Containers {
+		priorities = append(priorities, getContainerPriority(ctr))
+	}
 	return priorities
+}
+
+func podContainerCount(pod *corev1.Pod) int {
+	return len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
 }
 
 func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
@@ -339,7 +348,7 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 			pd[devType] = append(pd[devType], cd)
 		case NvidiaGPUDevice:
 			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
-				if i >= len(pod.Spec.Containers) {
+				if i >= podContainerCount(pod) {
 					break
 				}
 				if s == "" {
@@ -350,14 +359,11 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 				if err != nil {
 					return PodDevices{}, nil
 				}
-				if len(cd) == 0 {
-					continue
-				}
 				pd[devType] = append(pd[devType], cd)
 			}
 		case HygonGPUDevice:
 			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
-				if i >= len(pod.Spec.Containers) {
+				if i >= podContainerCount(pod) {
 					break
 				}
 				if s == "" {
@@ -368,14 +374,11 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 				if err != nil {
 					return PodDevices{}, nil
 				}
-				if len(cd) == 0 {
-					continue
-				}
 				pd[devType] = append(pd[devType], cd)
 			}
 		case MetaxGPUDevice, MetaxSGPUDevice:
 			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
-				if i >= len(pod.Spec.Containers) {
+				if i >= podContainerCount(pod) {
 					break
 				}
 				if s == "" {
@@ -385,9 +388,6 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 				cd, err := DecodeMetaxContainerDevices(s)
 				if err != nil {
 					return PodDevices{}, nil
-				}
-				if len(cd) == 0 {
-					continue
 				}
 				pd[devType] = append(pd[devType], cd)
 			}

--- a/server/internal/provider/util/util_test.go
+++ b/server/internal/provider/util/util_test.go
@@ -16,8 +16,12 @@ limitations under the License.
 package util
 
 import (
-	"github.com/go-kratos/kratos/v2/log"
 	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var inRequestDevices map[string]string
@@ -343,5 +347,57 @@ func Test_DecodePodDevices(t *testing.T) {
 			//assert.DeepEqual(t, test.wantErr, gotErr)
 			//assert.DeepEqual(t, test.want, got)
 		})
+	}
+}
+
+func TestDecodePodDevicesWithInitContainers(t *testing.T) {
+	SupportDevices["NVIDIA"] = "hami.io/vgpu-devices-allocated"
+	logger := log.NewHelper(log.DefaultLogger)
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init"},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceName(NVIDIAPriority): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				SupportDevices["NVIDIA"]: ";GPU-962d9630-a4ef-dc16-a50d-b2effb90239d,NVIDIA,6144,30:;",
+			},
+		},
+	}
+
+	got, err := DecodePodDevices(pod, logger)
+	if err != nil {
+		t.Fatalf("DecodePodDevices() error = %v", err)
+	}
+	nvidiaDevices, ok := got["NVIDIA"]
+	if !ok {
+		t.Fatal("expected NVIDIA devices")
+	}
+	if len(nvidiaDevices) != 2 {
+		t.Fatalf("expected 2 container slots, got %d", len(nvidiaDevices))
+	}
+	if len(nvidiaDevices[0]) != 0 {
+		t.Fatalf("expected empty init container devices, got %+v", nvidiaDevices[0])
+	}
+	if len(nvidiaDevices[1]) != 1 {
+		t.Fatalf("expected 1 device on main container, got %+v", nvidiaDevices[1])
+	}
+	if nvidiaDevices[1][0].UUID != "GPU-962d9630-a4ef-dc16-a50d-b2effb90239d" {
+		t.Fatalf("unexpected device UUID: %s", nvidiaDevices[1][0].UUID)
+	}
+	if nvidiaDevices[1][0].Priority != "1" {
+		t.Fatalf("unexpected priority: %s", nvidiaDevices[1][0].Priority)
 	}
 }


### PR DESCRIPTION
## Description

Fix Ascend NPU container metrics always returning 0 in exporter, and enable monitoring charts for non-NVIDIA/MXC vendors.

### Backend changes
- `taskCoreUsed`: replace `return 0, nil` with `npu_chip_info_utilization` PromQL query
- `taskMemoryUsed`: replace `return 0, nil` with `npu_chip_info_hbm_used_memory` PromQL query
- `GenerateContainerMetrics`: add `AscendGPUDevice` case for core unit conversion
- Unit tests for Ascend exporter paths

### Frontend changes
- Remove NVIDIA/MXC type guards in trend-time-filter and chart display
- All vendors now show monitoring charts (data depends on Prometheus availability)

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task detail trend charts now consistently render when chart data is available, with placeholders shown only when data is missing.
  * Monitoring metrics for Ascend workloads now use correct device-scoped PromQL queries, with accurate compute/memory handling and safer clearing of chart data on query failures.
* **Tests**
  * Expanded automated coverage for Ascend metric generation and conversions, including empty-result scenarios and updated raw-bytes memory semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->