### PR TITLE
fix(vite-build): env file is supported in vite build

### DIFF
--- a/packages/web/.env.production
+++ b/packages/web/.env.production
@@ -3,6 +3,8 @@ ENV = 'production'
 
 # base api
 VUE_APP_BASE_API = './'
+VITE_APP_BASE_API = './'
 
 # axios global timeout in ms; override via build env or chart values.frontend.requestTimeout
 VUE_APP_REQUEST_TIMEOUT = 60000
+VITE_APP_REQUEST_TIMEOUT = 60000

--- a/packages/web/src/utils/request.js
+++ b/packages/web/src/utils/request.js
@@ -9,10 +9,10 @@ import i18n from '@/locales';
 // against a large VictoriaMetrics cluster) while still bounding hung requests.
 const DEFAULT_REQUEST_TIMEOUT = 60000;
 const requestTimeout =
-  Number.parseInt(process.env.VUE_APP_REQUEST_TIMEOUT, 10) || DEFAULT_REQUEST_TIMEOUT;
+  Number.parseInt(import.meta.env.VITE_APP_REQUEST_TIMEOUT, 10) || Number.parseInt(process.env.VUE_APP_REQUEST_TIMEOUT, 10) || DEFAULT_REQUEST_TIMEOUT;
 
 const service = axios.create({
-  baseURL: process.env.VUE_APP_BASE_API, // url = base url + request url
+  baseURL: import.meta.env.VITE_APP_BASE_API || process.env.VUE_APP_BASE_API, // url = base url + request url
   timeout: requestTimeout,
   validateStatus: function (status) {
     return (status >= 200 && status < 300) || status > 520;


### PR DESCRIPTION
1. 修改 `.env.production` 文件，支持使用 Vite 构建时，符合 Vite 环境变量定义规则，参考：https://v5.vite.dev/guide/env-and-mode.html#env-files
2. 修改 `packages/web/src/utils/request.js` 文件，支持使用 Vite 构建时，读取对应的环境变量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API configuration handling for modern builds.
  * Preserved the default 60-second request timeout while supporting updated environment settings.
  * Ensured requests consistently use the configured application API base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->