### PR TITLE
use exported_namespace/pod labels for NVIDIA task metrics queries

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -534,7 +534,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 		//or
 		//last_over_time(hami_container_device_utilization_ratio{device_uuid="%s", namespace="%s", pod="%s", container="%s"}[1m:])`
 		//		query = fmt.Sprintf(queryTemplate, deviceUUID, namespace, pod, container, deviceUUID, namespace, pod, container)
-		queryTemplate := fmt.Sprintf("hami_container_device_utilization_ratio{device_uuid=\"%s\", namespace=\"%s\", pod=\"%s\", container=\"%s\"}", deviceUUID, namespace, pod, container)
+		queryTemplate := fmt.Sprintf("hami_container_device_utilization_ratio{device_uuid=\"%s\", exported_namespace=\"%s\", exported_pod=\"%s\", container=\"%s\"}", deviceUUID, namespace, pod, container)
 		query = fmt.Sprintf("sum_over_time(%s[1m]) == 0 or (sum_over_time(%s[10m:]) / count_over_time(( %s !=0)[10m:])) ", queryTemplate, queryTemplate, queryTemplate)
 		//query = queryTemplate
 	case biz.CambriconGPUDevice:
@@ -559,7 +559,7 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 	query := ""
 	switch provider {
 	case biz.NvidiaGPUDevice:
-		query = fmt.Sprintf("avg(hami_vgpu_memory_used_bytes{device_uuid=\"%s\", namespace=\"%s\", pod=\"%s\", container=\"%s\"})", deviceUUID, namespace, pod, container)
+		query = fmt.Sprintf("avg(hami_vgpu_memory_used_bytes{device_uuid=\"%s\", exported_namespace=\"%s\", exported_pod=\"%s\", container=\"%s\"})", deviceUUID, namespace, pod, container)
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_memory_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vmemory\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced GPU admin tables with status filtering, role-based node filtering, richer allocation/usage visuals, and a compute configuration column with tooltip help.
  - Updated node role display across node overview/details.

- **Bug Fixes**
  - Corrected NVIDIA GPU task-level metric queries to use the correct exported label names.
  - Improved GPU and node utilization reporting accuracy and data consistency (including usage fields and limits).

- **API & Localization**
  - Extended API responses and filters (health, keyword/role, node IP, usage, and resource limits).
  - Updated English and Chinese UI labels to match the new fields and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->