### PR TITLE
fix(task): show and search pod and container names

### DIFF
--- a/packages/web/projects/vgpu/views/task/admin/index.vue
+++ b/packages/web/projects/vgpu/views/task/admin/index.vue
@@ -162,7 +162,9 @@ const baseColumns = computed(() => [
     hideTooltip: true,
     render: ({ name, appName, podUid, namespace, namespaceName }) => {
       const to = `/admin/vgpu/task/admin/detail?name=${name}&podUid=${podUid}`;
-      const workloadName = appName || name || '--';
+      const workloadName = [appName, name]
+        .filter((value, index, values) => value && values.indexOf(value) === index)
+        .join(' / ') || '--';
       const workloadNamespace = namespace || namespaceName || '--';
       return (
         <span style={{ display: 'inline-flex', alignItems: 'flex-start', gap: '10px' }}>

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -44,6 +44,15 @@ func uniqueNonEmpty(values []string) []string {
 	return result
 }
 
+// matchesWorkloadName keeps the task-list search aligned with the UI, which
+// displays the workload/Pod name rather than the internal container name.
+func matchesWorkloadName(podName, filter string) bool {
+	if filter == "" {
+		return true
+	}
+	return strings.Contains(podName, filter)
+}
+
 func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllContainersReq) (*pb.ContainersReply, error) {
 	filters := req.Filters
 	containers, err := s.pod.ListAllContainers(ctx)
@@ -52,7 +61,7 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 	}
 	var res = &pb.ContainersReply{Items: []*pb.ContainerReply{}}
 	for _, container := range containers {
-		if filters.Name != "" && !strings.Contains(container.Name, filters.Name) {
+		if !matchesWorkloadName(container.PodName, filters.Name) {
 			continue
 		}
 		if filters.NodeName != "" && filters.NodeName != container.NodeName {

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -44,13 +44,14 @@ func uniqueNonEmpty(values []string) []string {
 	return result
 }
 
-// matchesWorkloadName keeps the task-list search aligned with the UI, which
-// displays the workload/Pod name rather than the internal container name.
-func matchesWorkloadName(podName, filter string) bool {
+// matchesWorkloadName searches both names shown in the task-list row. A Pod
+// can contain several containers, so neither name should be hidden from the
+// user-facing filter.
+func matchesWorkloadName(podName, containerName, filter string) bool {
 	if filter == "" {
 		return true
 	}
-	return strings.Contains(podName, filter)
+	return strings.Contains(podName, filter) || strings.Contains(containerName, filter)
 }
 
 func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllContainersReq) (*pb.ContainersReply, error) {
@@ -61,7 +62,7 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 	}
 	var res = &pb.ContainersReply{Items: []*pb.ContainerReply{}}
 	for _, container := range containers {
-		if !matchesWorkloadName(container.PodName, filters.Name) {
+		if !matchesWorkloadName(container.PodName, container.Name, filters.Name) {
 			continue
 		}
 		if filters.NodeName != "" && filters.NodeName != container.NodeName {

--- a/server/internal/service/container_test.go
+++ b/server/internal/service/container_test.go
@@ -1,6 +1,13 @@
 package service
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	pb "vgpu/api/v1"
+	"vgpu/internal/biz"
+)
 
 func TestMatchesWorkloadName(t *testing.T) {
 	tests := []struct {
@@ -30,9 +37,70 @@ func TestMatchesWorkloadName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := matchesWorkloadName(tt.podName, tt.filter); got != tt.want {
+			if got := matchesWorkloadName(tt.podName, "inference-container", tt.filter); got != tt.want {
 				t.Fatalf("matchesWorkloadName() = %v, want %v", got, tt.want)
 			}
 		})
 	}
+}
+
+func TestGetAllContainersMatchesPodOrContainerName(t *testing.T) {
+	containers := []*biz.Container{
+		{
+			Name:     "inference-container",
+			PodName:  "training-job-abc",
+			Status:   biz.ContainerStatusSuccess,
+			PodUID:   "pod-1",
+			NodeName: "node-1",
+			ContainerDevices: biz.ContainerDevices{
+				{UUID: "device-1"},
+			},
+		},
+	}
+	service := NewContainerService(
+		biz.NewNodeUsecase(&containerTestNodeRepo{}, log.DefaultLogger),
+		biz.NewPodUseCase(&containerTestPodRepo{containers: containers}, log.DefaultLogger),
+	)
+
+	for _, filter := range []string{"training-job", "inference-container"} {
+		reply, err := service.GetAllContainers(context.Background(), &pb.GetAllContainersReq{
+			Filters: &pb.GetAllContainersReq_Filters{Name: filter},
+		})
+		if err != nil {
+			t.Fatalf("GetAllContainers(%q): %v", filter, err)
+		}
+		if len(reply.Items) != 1 {
+			t.Fatalf("GetAllContainers(%q) returned %d items, want 1", filter, len(reply.Items))
+		}
+	}
+}
+
+type containerTestPodRepo struct {
+	containers []*biz.Container
+}
+
+func (r *containerTestPodRepo) ListAll(context.Context) ([]*biz.Container, error) {
+	return r.containers, nil
+}
+
+func (r *containerTestPodRepo) FindOne(context.Context, string, string) (*biz.Container, error) {
+	return nil, nil
+}
+
+type containerTestNodeRepo struct{}
+
+func (r *containerTestNodeRepo) ListAll(context.Context) ([]*biz.Node, error) {
+	return nil, nil
+}
+
+func (r *containerTestNodeRepo) GetNode(context.Context, string) (*biz.Node, error) {
+	return nil, nil
+}
+
+func (r *containerTestNodeRepo) ListAllDevices(context.Context) ([]*biz.DeviceInfo, error) {
+	return nil, nil
+}
+
+func (r *containerTestNodeRepo) FindDeviceByAliasId(aliasID string) (*biz.DeviceInfo, error) {
+	return &biz.DeviceInfo{Id: aliasID, AliasId: aliasID}, nil
 }

--- a/server/internal/service/container_test.go
+++ b/server/internal/service/container_test.go
@@ -1,0 +1,38 @@
+package service
+
+import "testing"
+
+func TestMatchesWorkloadName(t *testing.T) {
+	tests := []struct {
+		name    string
+		podName string
+		filter  string
+		want    bool
+	}{
+		{
+			name:    "empty filter matches all",
+			podName: "demo-workload-abc",
+			want:    true,
+		},
+		{
+			name:    "partial pod name matches",
+			podName: "demo-workload-abc",
+			filter:  "demo-workload",
+			want:    true,
+		},
+		{
+			name:    "unrelated name does not match",
+			podName: "demo-workload-abc",
+			filter:  "worker",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesWorkloadName(tt.podName, tt.filter); got != tt.want {
+				t.Fatalf("matchesWorkloadName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

- shows `PodName / ContainerName` in the task-list workload column (without repeating identical names)
- filters the task list when the search term matches either the Pod/workload name or the container name
- adds a regression test through `GetAllContainers`, covering both matching paths

## Why

The task list is one row per container, but the previous UI displayed only the Pod/workload name and the backend searched only the internal container name. Users could search either name and receive incomplete or empty results.

This follows the maintainer guidance in the discussion: keep the current one-row-per-container model, make both names visible, and match both names in search.

## Validation

- `go test -count=1 ./...` in `server/`
- `git diff --check`

Frontend lint was attempted with `pnpm --dir packages/web lint -- --no-fix`, but the current local dependency tree fails during ESLint/AJV initialization before linting files.

Fixes #117