### PR TITLE
Fix/ascend pod device index out of range

### DIFF
--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -330,13 +330,13 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 				if i >= podContainerCount(pod) {
 					break
 				}
+				if s == "" {
+					pd[devType] = append(pd[devType], ContainerDevices{})
+					continue
+				}
 				cd, err := DecodeNpuContainerDevices(s)
 				if err != nil {
 					return PodDevices{}, nil
-				}
-				if len(cd) == 0 {
-					pd[devType] = append(pd[devType], ContainerDevices{})
-					continue
 				}
 				pd[devType] = append(pd[devType], cd)
 			}

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -326,12 +326,16 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 		pd[devType] = make(PodSingleDevice, 0)
 		switch devType {
 		case AscendGPUDevice, Ascend310PGPUDevice:
-			for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+				if i >= podContainerCount(pod) {
+					break
+				}
 				cd, err := DecodeNpuContainerDevices(s)
 				if err != nil {
 					return PodDevices{}, nil
 				}
 				if len(cd) == 0 {
+					pd[devType] = append(pd[devType], ContainerDevices{})
 					continue
 				}
 				pd[devType] = append(pd[devType], cd)


### PR DESCRIPTION
## Title

`fix: prevent index out of range panic in Ascend pod device annotation decoding`

## Description

### Problem

When a pod with Ascend (910B/310P) GPU devices has fewer device annotation entries than the total container count, the `DecodePodDevices` function produces a `PodSingleDevice` slice shorter than expected. This causes a `runtime error: index out of range [1] with length 1` panic in `fetchContainerInfo` at `pod.go`.

```
Observed a panic: runtime.boundsError (runtime error: index out of range [1] with length 1)
    vgpu/internal/data.(*podRepo).fetchContainerInfo(...)
        /src/internal/data/pod.go:147
```

### Root Cause

The Ascend/310P device branch in `DecodePodDevices` was missing three safeguards that Nvidia, DCU, and Metax already have:

1. **`podContainerCount` boundary check** — no `if i >= podContainerCount(pod) { break }`
2. **Empty string placeholder** — used `continue` to skip empty entries instead of appending an empty `ContainerDevices{}`, which misaligned the index
3. **Indexed loop** — used `for _, s := range` instead of `for i, s := range`

### Fix

Align the Ascend/310P branch with the Nvidia/DCU/Metax pattern:

```diff
- for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+ for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+     if i >= podContainerCount(pod) {
+         break
+     }
+     if s == "" {
+         pd[devType] = append(pd[devType], ContainerDevices{})
+         continue
+     }
      cd, err := DecodeNpuContainerDevices(s)
      ...
-     if len(cd) == 0 {
-         continue
-     }
```

### Verification

- `go vet` passes
- `TestDecodePodDevicesWithInitContainers` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device annotation handling for pods using Ascend/NPU resources.
  * Preserved empty device entries for containers without assigned devices.
  * Ignored annotation data beyond the pod’s actual container count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->