### PR TITLE
docs: add HAMi-WebUI contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a problem encountered while using HAMi-WebUI
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- Relevant, time-bounded excerpts from the browser console and network panel
+- Relevant, time-bounded excerpts from the HAMi-WebUI frontend and backend logs
+- Relevant, redacted API responses or Kubernetes events
+- The relevant Helm values, ConfigMaps, environment variables, or deployment manifests
+- Cropped screenshots or recordings showing the affected UI state
+
+Before posting, remove or mask credentials, tokens, cookies, authorization headers, user data, cluster names, node names, internal URLs, and other sensitive information from logs, responses, configuration, screenshots, and recordings.
+
+**Environment**:
+- HAMi-WebUI version, commit, or frontend/backend image tags:
+- HAMi version:
+- Kubernetes version:
+- Installation method and Helm chart version:
+- Browser and version:
+- Operating system:
+- Affected page or feature:
+- Node.js, pnpm, and Go versions, if running locally:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to HAMi-WebUI
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,23 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Who can take this task**:
+
+This issue is intended for a first-time contributor beginning their contribution journey.
+
+**How to take the task**:
+
+Reply to the issue and state that you would like to work on it. A maintainer can assign it to you.
+
+**How to ask for help**:
+
+If you need assistance or have questions, ask in the issue. The issue author or another community member can provide guidance.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: Question
+about: Ask a question about HAMi-WebUI
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+Before posting, include only relevant, time-bounded excerpts and remove or mask credentials, tokens, cookies, authorization headers, user data, cluster or node names, and internal URLs.
+
+**Environment**:
+
+- HAMi-WebUI version, commit, or image tags:
+- HAMi and Kubernetes versions:
+- Installation method and Helm chart version:
+- Browser and operating system:
+- Affected page or feature:
+- Node.js, pnpm, and Go versions, if running locally:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**:
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:

Adds concise, repository-specific templates for bug reports, enhancements, good first issues, questions, and pull requests. This helps reports collect consistent browser, frontend, backend, HAMi, deployment, and reproduction details while keeping application behavior unchanged.

**Which issue(s) this PR fixes**:
Fixes #120

**Special notes for your reviewer**:

This is a documentation-only change. The issue-template front matter was parsed locally, uses existing repository labels, and all five Markdown files were checked for whitespace errors. Diagnostic prompts request only relevant, time-bounded excerpts and require sensitive browser, user, cluster, and deployment data to be masked.

**Does this PR introduce a user-facing change?**:

Yes. Contributors will see repository-specific prompts when opening issues and pull requests.

**AI Disclosure**:

AI was used only for formatting purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized templates for bug reports, feature requests, questions, and good-first issues.
  * Added a pull request template covering change details, linked issues, reviewer notes, user-facing impact, and AI assistance disclosure.
  * Included guidance for providing useful diagnostics while removing sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->