### PR TITLE
fix(util): preserve empty container slots in Ascend device index mapping

### DIFF
--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -325,17 +325,21 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 		}
 		pd[devType] = make(PodSingleDevice, 0)
 		switch devType {
-		case AscendGPUDevice, Ascend310PGPUDevice:
-			for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
-				cd, err := DecodeNpuContainerDevices(s)
-				if err != nil {
-					return PodDevices{}, nil
-				}
-				if len(cd) == 0 {
-					continue
-				}
-				pd[devType] = append(pd[devType], cd)
-			}
+                case AscendGPUDevice, Ascend310PGPUDevice:
+                        for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+                                if i >= podContainerCount(pod) {
+                                        break
+                                }
+                                if s == "" {
+                                        pd[devType] = append(pd[devType], ContainerDevices{})
+                                        continue
+                                }
+                                cd, err := DecodeNpuContainerDevices(s)
+                                if err != nil {
+                                        return PodDevices{}, nil
+                                }
+                                pd[devType] = append(pd[devType], cd)
+                        }
 		case CambriconGPUDevice:
 			instance := annos[DsmluProfileAndInstance]
 			cd, err := DecodeMLUContainerDevices(fmt.Sprintf("%s_%s", str, instance), nodeName)

--- a/server/internal/provider/util/util_test.go
+++ b/server/internal/provider/util/util_test.go
@@ -401,3 +401,38 @@ func TestDecodePodDevicesWithInitContainers(t *testing.T) {
 		t.Fatalf("unexpected priority: %s", nvidiaDevices[1][0].Priority)
 	}
 }
+
+func TestDecodePodDevicesAscendMultiContainer(t *testing.T) {
+	SupportDevices["Ascend"] = "hami.io/ascend-devices-allocated"
+	logger := log.NewHelper(log.DefaultLogger)
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "container-0"},
+				{Name: "container-1"},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"hami.io/ascend-devices-allocated": ";Ascend910B-0,Ascend910B,32768,100:;",
+			},
+		},
+	}
+	got, err := DecodePodDevices(pod, logger)
+	if err != nil {
+		t.Fatalf("DecodePodDevices() error = %v", err)
+	}
+	ascendDevices, ok := got["Ascend"]
+	if !ok {
+		t.Fatal("expected Ascend devices")
+	}
+	if len(ascendDevices) != 2 {
+		t.Fatalf("expected 2 container slots, got %d", len(ascendDevices))
+	}
+	if len(ascendDevices[0]) != 0 {
+		t.Fatalf("expected empty container-0 devices, got %+v", ascendDevices[0])
+	}
+	if len(ascendDevices[1]) != 1 {
+		t.Fatalf("expected 1 device on container-1, got %+v", ascendDevices[1])
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## Which issue(s) this PR fixes
Fixes #123

## What this PR does

Ascend and Ascend310P device decoding silently skipped empty container entries, breaking the container-to-device index mapping for multi-container pods.

For a 2-container pod where container-0 has no Ascend device and container-1 does, the device was incorrectly mapped to container-0.

## The Problem

```go
// Before: silently skips empty entries, corrupts index mapping
if len(cd) == 0 {
    continue
}
```

NVIDIA, Hygon, and MetaX all correctly preserve empty slots. Ascend was the only device type missing this.

## The Fix

Mirrors the existing pattern used by NVIDIA/Hygon/MetaX — check container count bound and append `ContainerDevices{}` for empty segments.

## Testing

Added `TestDecodePodDevicesAscendMultiContainer` which proves the correct index mapping is preserved. All existing tests pass.

## AI Disclosure

Used Claude for guidance. Did all implementation and testing myself. Understand the fix completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ascend device decoding for pods with multiple containers.
  * Preserved empty container positions and skipped empty device annotations.
  * Continued to report decoding failures safely without returning partial results.

* **Tests**
  * Added coverage for multi-container pods where devices are assigned only to the appropriate container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
