### PR TITLE
fix(ascend): show 910B4 devices in HAMi-WebUI

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -14,6 +14,7 @@ import (
 	"vgpu/internal/data/prom"
 	"vgpu/internal/provider/metax"
 	"vgpu/internal/provider/mlu"
+	putil "vgpu/internal/provider/util"
 	"vgpu/internal/service"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -375,7 +376,10 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				vGPU = vGPU + 1
 				core = core + cd.Usedcores
 				memory = memory + cd.Usedmem
-				provider = cd.Type
+				// Ascend container devices carry the chip commonWord (e.g.
+				// "Ascend910B4") as their type; provider dispatch below needs
+				// the vendor constant.
+				provider = putil.VendorOf(cd.Type)
 			}
 			if provider == "" || provider == metax.MetaxGPUDevice {
 				continue

--- a/server/internal/provider/ascend/device.go
+++ b/server/internal/provider/ascend/device.go
@@ -1,6 +1,10 @@
 package ascend
 
-import "vgpu/internal/provider/util"
+import (
+	"fmt"
+
+	"vgpu/internal/provider/util"
+)
 
 const (
 	AscendDevice          = "Ascend"
@@ -21,10 +25,28 @@ var (
 	AscendNodeRegisterAnnos []string
 )
 
+// ascendCommonWords lists the HAMi commonWords of the Ascend chip variants
+// this build recognizes, in addition to the legacy Ascend910B/Ascend310P
+// constants above. HAMi derives every Ascend annotation from the commonWord:
+// node side "hami.io/node-register-<commonWord>", pod side
+// "hami.io/<commonWord>-devices-to-allocate" / "-allocated".
+var ascendCommonWords = []string{
+	"Ascend910A",
+	"Ascend910B2",
+	"Ascend910B3",
+	"Ascend910B4",
+	"Ascend910B4-1",
+}
+
 func init() {
 	AscendNodeRegisterAnnos = []string{Ascend910BNodeRegisterAnno, Ascend310PNodeRegisterAnno}
 	util.InRequestDevices[AscendDevice] = "hami.io/Ascend910B-devices-to-allocate"
 	util.SupportDevices[AscendDevice] = "hami.io/Ascend910B-devices-allocated"
 	util.InRequestDevices[Ascend310PDevice] = "hami.io/Ascend310P-devices-to-allocate"
 	util.SupportDevices[Ascend310PDevice] = "hami.io/Ascend310P-devices-allocated"
+	for _, cw := range ascendCommonWords {
+		AscendNodeRegisterAnnos = append(AscendNodeRegisterAnnos, fmt.Sprintf("hami.io/node-register-%s", cw))
+		util.InRequestDevices[cw] = fmt.Sprintf("hami.io/%s-devices-to-allocate", cw)
+		util.SupportDevices[cw] = fmt.Sprintf("hami.io/%s-devices-allocated", cw)
+	}
 }

--- a/server/internal/provider/ascend/device.go
+++ b/server/internal/provider/ascend/device.go
@@ -36,6 +36,7 @@ var ascendCommonWords = []string{
 	"Ascend910B3",
 	"Ascend910B4",
 	"Ascend910B4-1",
+	"Ascend910C",
 }
 
 func init() {

--- a/server/internal/provider/ascend/device_test.go
+++ b/server/internal/provider/ascend/device_test.go
@@ -30,6 +30,7 @@ func TestAscendVariantRegistration(t *testing.T) {
 		"hami.io/node-register-Ascend910B3",
 		"hami.io/node-register-Ascend910B4",
 		"hami.io/node-register-Ascend910B4-1",
+		"hami.io/node-register-Ascend910C",
 	}
 	got := map[string]bool{}
 	for _, a := range AscendNodeRegisterAnnos {

--- a/server/internal/provider/ascend/device_test.go
+++ b/server/internal/provider/ascend/device_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ascend
+
+import (
+	"testing"
+
+	"vgpu/internal/provider/util"
+)
+
+func TestAscendVariantRegistration(t *testing.T) {
+	wantAnnos := []string{
+		"hami.io/node-register-Ascend910B",
+		"hami.io/node-register-Ascend310P",
+		"hami.io/node-register-Ascend910A",
+		"hami.io/node-register-Ascend910B2",
+		"hami.io/node-register-Ascend910B3",
+		"hami.io/node-register-Ascend910B4",
+		"hami.io/node-register-Ascend910B4-1",
+	}
+	got := map[string]bool{}
+	for _, a := range AscendNodeRegisterAnnos {
+		got[a] = true
+	}
+	for _, want := range wantAnnos {
+		if !got[want] {
+			t.Errorf("AscendNodeRegisterAnnos missing %s", want)
+		}
+	}
+
+	for _, cw := range ascendCommonWords {
+		if util.SupportDevices[cw] != "hami.io/"+cw+"-devices-allocated" {
+			t.Errorf("SupportDevices[%s] = %q", cw, util.SupportDevices[cw])
+		}
+		if util.InRequestDevices[cw] != "hami.io/"+cw+"-devices-to-allocate" {
+			t.Errorf("InRequestDevices[%s] = %q", cw, util.InRequestDevices[cw])
+		}
+	}
+}

--- a/server/internal/provider/ascend/provider.go
+++ b/server/internal/provider/ascend/provider.go
@@ -71,16 +71,17 @@ func (a *Ascend) GetDevicesFromPrometheus(node *corev1.Node) map[string]*util.De
 }
 
 func (a *Ascend) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
-	for _, anno := range AscendNodeRegisterAnnos {
-		tmpDevice := a.GetDevicesFromPrometheus(node)
-		anno, ok := node.Annotations[anno]
+	tmpDevice := a.GetDevicesFromPrometheus(node)
+	var devices []*util.DeviceInfo
+	for _, annoKey := range AscendNodeRegisterAnnos {
+		anno, ok := node.Annotations[annoKey]
 		if !ok {
-			log.Infof("anno %s not found", anno)
+			log.Infof("anno %s not found", annoKey)
 			continue
 		}
 		nodeDevices, err := util.UnMarshalNodeDevices(anno)
 		if err != nil {
-			return []*util.DeviceInfo{}, err
+			return []*util.DeviceInfo{}, fmt.Errorf("unmarshal %s of node %s: %w", annoKey, node.Name, err)
 		}
 		for i, nodedevice := range nodeDevices {
 			nodeDevices[i].AliasId = nodedevice.ID
@@ -90,7 +91,7 @@ func (a *Ascend) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
 				log.Infof("Key %d not found in tmpDevice", i)
 			}
 		}
-		return nodeDevices, nil
+		devices = append(devices, nodeDevices...)
 	}
-	return []*util.DeviceInfo{}, fmt.Errorf("")
+	return devices, nil
 }

--- a/server/internal/provider/util/ascend_variants_test.go
+++ b/server/internal/provider/util/ascend_variants_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVendorOf(t *testing.T) {
+	cases := map[string]string{
+		"Ascend":        AscendGPUDevice,
+		"Ascend310P":    AscendGPUDevice,
+		"Ascend910B":    AscendGPUDevice,
+		"Ascend910B4":   AscendGPUDevice,
+		"Ascend910B4-1": AscendGPUDevice,
+		NvidiaGPUDevice: NvidiaGPUDevice,
+		HygonGPUDevice:  HygonGPUDevice,
+		MetaxGPUDevice:  MetaxGPUDevice,
+		MetaxSGPUDevice: MetaxSGPUDevice,
+	}
+	for in, want := range cases {
+		if got := VendorOf(in); got != want {
+			t.Errorf("VendorOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDecodePodDevicesAscend910B4(t *testing.T) {
+	SupportDevices["Ascend910B4"] = "hami.io/Ascend910B4-devices-allocated"
+	defer delete(SupportDevices, "Ascend910B4")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"hami.io/Ascend910B4-devices-allocated": "Ascend910B4-0,Ascend910B4,32768,100:;Ascend910B4-1,Ascend910B4,8192,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}},
+		},
+	}
+
+	pd, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger))
+	if err != nil {
+		t.Fatalf("DecodePodDevices: %v", err)
+	}
+	devs, ok := pd["Ascend910B4"]
+	if !ok {
+		t.Fatalf("pod devices missing Ascend910B4 key, got %v", pd)
+	}
+	if len(devs) != 2 {
+		t.Fatalf("expected 2 container device sets, got %d", len(devs))
+	}
+	full := devs[0][0]
+	if full.UUID != "Ascend910B4-0" || full.Type != "Ascend910B4" || full.Usedmem != 32768 || full.Usedcores != 100 {
+		t.Errorf("whole-card device decoded wrong: %+v", full)
+	}
+	slice := devs[1][0]
+	if slice.Usedmem != 8192 || slice.Usedcores != 25 {
+		t.Errorf("vNPU template 8192 should map to 25 cores, got %+v", slice)
+	}
+}

--- a/server/internal/provider/util/ascend_variants_test.go
+++ b/server/internal/provider/util/ascend_variants_test.go
@@ -65,8 +65,8 @@ func TestDecodePodDevicesAscend910B4(t *testing.T) {
 	if !ok {
 		t.Fatalf("pod devices missing Ascend910B4 key, got %v", pd)
 	}
-	if len(devs) != 2 {
-		t.Fatalf("expected 2 container device sets, got %d", len(devs))
+	if len(devs) != 3 {
+		t.Fatalf("expected 3 container positions, got %d", len(devs))
 	}
 	full := devs[0][0]
 	if full.UUID != "Ascend910B4-0" || full.Type != "Ascend910B4" || full.Usedmem != 32768 || full.Usedcores != 100 {
@@ -75,5 +75,8 @@ func TestDecodePodDevicesAscend910B4(t *testing.T) {
 	slice := devs[1][0]
 	if slice.Usedmem != 8192 || slice.Usedcores != 25 {
 		t.Errorf("vNPU template 8192 should map to 25 cores, got %+v", slice)
+	}
+	if len(devs[2]) != 0 {
+		t.Errorf("trailing empty container position was not preserved: %+v", devs[2])
 	}
 }

--- a/server/internal/provider/util/ascend_variants_test.go
+++ b/server/internal/provider/util/ascend_variants_test.go
@@ -30,6 +30,7 @@ func TestVendorOf(t *testing.T) {
 		"Ascend910B":    AscendGPUDevice,
 		"Ascend910B4":   AscendGPUDevice,
 		"Ascend910B4-1": AscendGPUDevice,
+		"Ascend910C":    AscendGPUDevice,
 		NvidiaGPUDevice: NvidiaGPUDevice,
 		HygonGPUDevice:  HygonGPUDevice,
 		MetaxGPUDevice:  MetaxGPUDevice,
@@ -75,6 +76,43 @@ func TestDecodePodDevicesAscend910B4(t *testing.T) {
 	slice := devs[1][0]
 	if slice.Usedmem != 8192 || slice.Usedcores != 25 {
 		t.Errorf("vNPU template 8192 should map to 25 cores, got %+v", slice)
+	}
+	if len(devs[2]) != 0 {
+		t.Errorf("trailing empty container position was not preserved: %+v", devs[2])
+	}
+}
+
+func TestDecodePodDevicesAscend910C(t *testing.T) {
+	SupportDevices["Ascend910C"] = "hami.io/Ascend910C-devices-allocated"
+	defer delete(SupportDevices, "Ascend910C")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"hami.io/Ascend910C-devices-allocated": "Ascend910C-0,Ascend910C,16384,0:;Ascend910C-1,Ascend910C,32768,0:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}, {Name: "c1"}},
+		},
+	}
+
+	pd, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger))
+	if err != nil {
+		t.Fatalf("DecodePodDevices: %v", err)
+	}
+	devs, ok := pd["Ascend910C"]
+	if !ok {
+		t.Fatalf("pod devices missing Ascend910C key, got %v", pd)
+	}
+	if len(devs) != 3 {
+		t.Fatalf("expected 3 container positions, got %d", len(devs))
+	}
+	if devs[0][0].Usedmem != 16384 || devs[0][0].Usedcores != 25 {
+		t.Errorf("910C 16G template decoded wrong: %+v", devs[0][0])
+	}
+	if devs[1][0].Usedmem != 32768 || devs[1][0].Usedcores != 50 {
+		t.Errorf("910C 32G template decoded wrong: %+v", devs[1][0])
 	}
 	if len(devs[2]) != 0 {
 		t.Errorf("trailing empty container position was not preserved: %+v", devs[2])

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -368,9 +368,9 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 				if err != nil {
 					return PodDevices{}, nil
 				}
-				if len(cd) == 0 {
-					continue
-				}
+				// Keep empty container positions. The annotation is indexed by
+				// init containers followed by regular containers, and fetchContainerInfo
+				// uses that same index to attach devices to the right container.
 				pd[devType] = append(pd[devType], cd)
 			}
 		case CambriconGPUDevice:

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -87,6 +87,10 @@ func init() {
 			16384: {Usedmem: 16384, Usedcores: 25},
 			32768: {Usedmem: 32768, Usedcores: 50},
 		},
+		"Ascend910C": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+		},
 		"Ascend310P": {
 			3072:  {Usedmem: 3072, Usedcores: 13},
 			6144:  {Usedmem: 6144, Usedcores: 25},

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -31,6 +31,17 @@ const (
 	NVIDIAPriority = "nvidia.com/priority"
 )
 
+// VendorOf maps a device type string to the vendor constant used for provider
+// dispatch. Ascend device types carry the HAMi commonWord of the chip variant
+// (e.g. "Ascend910B4", "Ascend310P"), so anything with the Ascend prefix is
+// one vendor; every other type string already is its vendor constant.
+func VendorOf(devType string) string {
+	if strings.HasPrefix(devType, AscendGPUDevice) {
+		return AscendGPUDevice
+	}
+	return devType
+}
+
 type ascendDeviceConfig struct {
 	Usedmem   int32
 	Usedcores int32
@@ -45,8 +56,34 @@ var (
 func init() {
 	InRequestDevices = make(map[string]string)
 	SupportDevices = make(map[string]string)
+	// Per-variant vNPU templates from HAMi's device config (charts/hami
+	// device-configmap vnpus[].templates); Usedcores = template aiCore as a
+	// percentage of the chip's aiCore.
 	ascendDeviceConfigs = map[string]map[int32]ascendDeviceConfig{
+		"Ascend910A": {
+			2184:  {Usedmem: 2184, Usedcores: 7},
+			4369:  {Usedmem: 4369, Usedcores: 13},
+			8738:  {Usedmem: 8738, Usedcores: 27},
+			17476: {Usedmem: 17476, Usedcores: 53},
+		},
 		"Ascend910B": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+		},
+		"Ascend910B2": {
+			8192:  {Usedmem: 8192, Usedcores: 13},
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+		},
+		"Ascend910B3": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+		},
+		"Ascend910B4": {
+			8192:  {Usedmem: 8192, Usedcores: 25},
+			16384: {Usedmem: 16384, Usedcores: 50},
+		},
+		"Ascend910B4-1": {
 			16384: {Usedmem: 16384, Usedcores: 25},
 			32768: {Usedmem: 32768, Usedcores: 50},
 		},
@@ -324,7 +361,7 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 			continue
 		}
 		pd[devType] = make(PodSingleDevice, 0)
-		switch devType {
+		switch VendorOf(devType) {
 		case AscendGPUDevice, Ascend310PGPUDevice:
 			for _, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
 				cd, err := DecodeNpuContainerDevices(s)

--- a/server/internal/provider/util/util_test.go
+++ b/server/internal/provider/util/util_test.go
@@ -401,3 +401,36 @@ func TestDecodePodDevicesWithInitContainers(t *testing.T) {
 		t.Fatalf("unexpected priority: %s", nvidiaDevices[1][0].Priority)
 	}
 }
+
+func TestDecodePodDevicesPreservesAscendContainerPositions(t *testing.T) {
+	const deviceKey = "hami.io/Ascend910B4-devices-allocated"
+	const uuid = "C416F664-0100A346-17955433-808080E0-104301E3"
+
+	SupportDevices["Ascend910B4"] = deviceKey
+	t.Cleanup(func() { delete(SupportDevices, "Ascend910B4") })
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "modelcar-init"}},
+			Containers:     []corev1.Container{{Name: "kserve-container"}, {Name: "modelcar"}},
+		},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			deviceKey: ";" + uuid + ",Ascend910B4,32768,0:;;",
+		}},
+	}
+
+	got, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger))
+	if err != nil {
+		t.Fatalf("DecodePodDevices() error = %v", err)
+	}
+	devices := got["Ascend910B4"]
+	if len(devices) != 4 {
+		t.Fatalf("Ascend container positions = %d, want 4", len(devices))
+	}
+	if len(devices[0]) != 0 || len(devices[2]) != 0 || len(devices[3]) != 0 {
+		t.Fatalf("empty container positions were not preserved: %#v", devices)
+	}
+	if len(devices[1]) != 1 || devices[1][0].UUID != uuid {
+		t.Fatalf("device position = %#v, want UUID %q at index 1", devices[1], uuid)
+	}
+}


### PR DESCRIPTION
## Summary

Fix HAMi-WebUI Ascend variant consumption so nodes using Ascend910B4 (and related 910 variants) are visible in the WebUI, and add Ascend910C template decoding.

## Changes

- Register Node and Pod annotation keys derived from Ascend commonWords, including `Ascend910B4`, `Ascend910B4-1`, and `Ascend910C`.
- Dispatch Ascend Pod devices by vendor while preserving the concrete chip type for device/metric data.
- Preserve empty initContainer/container allocation slots so devices remain attached to the correct container.
- Add fixed-template core mappings for Ascend variants, including Ascend910C:
  - 16384 MiB -> 25% core
  - 32768 MiB -> 50% core
- Add unit coverage for variant registration, container slot preservation, and Ascend910C decoding.

## Validation

```text
go test -count=1 ./...
go vet ./...
```

Both pass in `server/`.

## Scope

This keeps the existing project assumption that a Node uses one Ascend model. Mixed Ascend variants on the same Node and dynamic custom-core semantics are outside this PR.

Fixes #124
Related to #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Ascend device variants, including 910B4 and 910C.
  * Improved device detection and resource reporting across Ascend configurations.
  * Preserved container device positions, including empty slots, during device decoding.

* **Bug Fixes**
  * Fixed device discovery to collect resources from all configured registration annotations.
  * Improved error details when device data cannot be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->