### PR TITLE
fix(chart): preserve HAMi workload labels in ServiceMonitor

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -58,7 +58,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullnameOverride | string | `""`                                                                               |  |
 | hamiServiceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
 | hamiServiceMonitor.enabled | bool | `true`                                                                             |  |
-| hamiServiceMonitor.honorLabels | bool | `false`                                                                            |  |
+| hamiServiceMonitor.honorLabels | bool | `true`                                                                            | Keep HAMi's workload namespace/pod/container labels when they collide with Prometheus scrape-target labels. |
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | "kube-system"                                                                      | Default is "kube-system", but it should be set according to the namespace where the HAMi components are installed. || image.backend.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -114,7 +114,9 @@ serviceMonitor:
 hamiServiceMonitor:
   enabled: true
   interval: 15s
-  honorLabels: false
+  # Preserve HAMi's namespace/pod/container workload labels when they collide
+  # with Prometheus scrape-target labels; required by the WebUI queries.
+  honorLabels: true
   additionalLabels:
     jobRelease: hami-webui-prometheus
   svcNamespace: kube-system

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -59,6 +59,33 @@ To set up the HAMi-WebUI Helm repository so that you download the correct HAMi-W
 
    You should get the expected both 'hami-webui' and 'hami-webui-dcgm-exporter' in running state if installation is successful.
 
+### Prometheus scrape labels
+
+HAMi's vgpu-monitor exposes workload identity as `namespace`, `pod`, and
+`container`. When Prometheus adds scrape-target labels with the same names and
+source labels are not honored, it renames the workload labels to `exported_*`.
+HAMi-WebUI's queries then return no series, and task utilization is reported as
+`0`.
+
+The included ServiceMonitor sets `hamiServiceMonitor.honorLabels: true`. If an
+external Prometheus discovers this ServiceMonitor, no additional scrape job is
+needed. For a separately managed scrape, set `honorLabels: true` on its
+ServiceMonitor or use the equivalent raw Prometheus setting:
+
+```yaml
+scrape_configs:
+  - job_name: hami-device-plugin-monitor
+    honor_labels: true
+    # ...
+```
+
+`Prometheus.spec.overrideHonorLabels: true` forces
+`honorLabels` off for every ServiceMonitor, including this one.
+
+If the same Prometheus selects both this chart's ServiceMonitor and HAMi's
+built-in device-plugin ServiceMonitor (`prometheus.enabled` in the HAMi chart),
+the endpoint is scraped twice. Configure that Prometheus to select only one.
+
 ### Access HAMi-WebUI
 
 1. Configure ~/.kube/config in your localhost to be able to connect your cluster.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

With `honorLabels: false`, Prometheus renames colliding HAMi workload labels
(`namespace`, `pod`, and `container`) to `exported_*`. The NVIDIA task queries
use the original names, so they return no series and `queryInstantVal` reports
`0`.

This PR sets `hamiServiceMonitor.honorLabels: true`, preserving the workload
labels and allowing the existing PromQL to work unchanged.

**Verification**

Tested with k3s, HAMi 2.10, and a CUDA workload:

- Workload selector: `0` series before, `1` after
- WebUI-generated core and memory metrics reported non-zero values
- `helm lint` passed
- `helm template` renders `true` by default
- An explicit `--set hamiServiceMonitor.honorLabels=false` still works

**Which issue(s) this PR fixes**:

Supersedes #114. It correctly identified the label mismatch, but only rewrites
`namespace` and `pod`. After Project-HAMi/HAMi#1990, `container` can also
collide, so that query still returns no series on the tested HAMi 2.10 setup.

Thanks to @Shenhan11 for identifying the issue.

**Special notes for your reviewer**:

`Prometheus.spec.overrideHonorLabels: true` overrides this setting. If the same
Prometheus selects both HAMi ServiceMonitors, the endpoint is scraped twice.
Both cases are documented in the installation guide.

The empty-result-to-`0` behavior should be addressed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved HAMi workload labels in Prometheus metrics so WebUI utilization queries return accurate results.
  * Added Helm guidance for configuring scrape labels and avoiding duplicate metric collection.

* **Documentation**
  * Documented label-collision behavior, recommended Prometheus settings, and related ServiceMonitor configuration considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->