### PR TITLE
chore(governance): restore Prow ownership and merge flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,17 @@ For more ways to contribute, check out the [Open Source Guides](https://opensour
 
 ### Report bugs
 
-Before submitting a new issue, try to make sure someone hasn't already reported the problem. Look through the [existing issues](https://github.com/Project-HAMi/HAMi-UI/issues) for similar issues.
+Before submitting a new issue, try to make sure someone hasn't already reported the problem. Look through the [existing issues](https://github.com/Project-HAMi/HAMi-WebUI/issues) for similar issues.
 
-Report a bug by submitting a [bug report](https://github.com/Project-HAMi/HAMi-UI/issues/new?labels=type%3A+bug&template=1-bug_report.md). Make sure that you provide as much information as possible on how to reproduce the bug.
+Report a bug by [opening an issue](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=bug). Make sure that you provide as much information as possible on how to reproduce the bug.
 
 For authentication and alerting HAMi-WebUI server logs are useful.
 
 ### Suggest enhancements
 
-If you have an idea of how to improve HAMi-WebUI, submit a [feature request](https://github.com/Project-HAMi/HAMi-UI/issues/new?assignees=&labels=type%2Ffeature-request&projects=&template=1-feature_requests.md).
+If you have an idea of how to improve HAMi-WebUI, submit a [feature request](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=enhancement).
 
-We want to make HAMi-WebUI accessible to even more people. Submit an [accessibility issue](https://github.com/Project-HAMi/HAMi-UI/issues/new?labels=type%3A+accessibility&template=3-accessibility.md) to help us understand what we can improve.
+We want to make HAMi-WebUI accessible to even more people. [Open an issue](https://github.com/Project-HAMi/HAMi-WebUI/issues/new) to help us understand what we can improve.
 
 ### Write documentation
 
@@ -37,14 +37,24 @@ We want to make HAMi-WebUI accessible to even more people. Submit an [accessibil
 
 ### Your first contribution
 
-Unsure where to begin contributing to HAMi-WebUI? Start by browsing issues labeled `beginner friendly` or `help wanted`.
+Unsure where to begin contributing to HAMi-WebUI? Start by browsing issues labeled `good first issue` or `help wanted`.
 
-- [Beginner-friendly](https://github.com/Project-HAMi/HAMi-UI/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) issues are generally straightforward to complete.
-- [Help wanted](https://github.com/Project-HAMi/HAMi-UI/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues are problems we would like the community to help us with regardless of complexity.
+- [Good first issues](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are generally straightforward to complete.
+- [Help wanted](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues are problems we would like the community to help us with regardless of complexity.
 
 If you're looking to make a code change, see how to set up your environment for [local development](docs/contribute/developer-guide.md).
 
 When you're ready to contribute, it's time to create a pull request.
+
+### Pull request review and merge
+
+1. Sign off every commit to satisfy the Developer Certificate of Origin (DCO).
+2. Wait for the required frontend, backend, and DCO checks to pass.
+3. A reviewer records the code review in GitHub and writes `/lgtm` when the change is ready.
+4. An approver listed in the relevant `OWNERS` file approves the change. An approver can select **Approve** in the GitHub review and put `/lgtm` in the review body to grant both `lgtm` and `approved` in one step.
+5. After the required checks and both labels are present, Tide merges the pull request through `hami-robot`.
+
+Pull request authors do not approve or manually merge their own changes. A change authored by an approver still needs another approver. HAMi-WebUI uses Tide as its merge controller; do not enable GitHub native auto-merge for the same pull request.
 
 ## Where do I go from here?
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - Nimbus318
+approvers:
+  - Nimbus318
+  - archlitchi


### PR DESCRIPTION
/kind cleanup

Part of #128.

Adds the missing root `OWNERS` contract used by Prow and documents the repository's review-to-merge path: DCO and aggregate CI checks, `/lgtm`, approval by an OWNER, then Tide merge through `hami-robot`.

The contribution links also pointed to the old `HAMi-UI` repository; this updates them to HAMi-WebUI and its current labels.

This is the one-time bootstrap PR. It will be merged manually after checks pass; the next real PR will verify that `lgtm` and `approved` are applied and Tide performs the merge.

Validation: `OWNERS` parses as YAML and `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution links and issue-reporting guidance to reference the current repository.
  * Simplified bug, feature, and accessibility issue templates.
  * Updated guidance for first contributions and development environment setup.
  * Added pull request review, approval, DCO sign-off, required checks, and merge process instructions.

* **Chores**
  * Added repository review and approval ownership rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->