### PR TITLE
ci(release): suspend legacy stable publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,9 @@ name: Build and Push Images
 
 on:
   push:
+    # Stable tag publishing is suspended until #129 provides one verified
+    # release path. This workflow only publishes the development channel.
     branches: [ "main" ]
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,76 +1,18 @@
-name: Helm Release
+# Stable Chart publishing is intentionally suspended while #129 replaces the
+# two independent tag workflows with one verified release process.
+name: Helm Release (Suspended)
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - v*
 
-env:
-  HELM_VERSION: "v3.20.0"
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+permissions: {}
 
 jobs:
-  helm-release:
-    permissions:
-      contents: write
-      packages: write
+  release-suspended:
+    name: Stable publishing is suspended
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
+      - name: Stop legacy publishing
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v5.0.0
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: Add Helm repos
-        run: |
-          helm repo add nvidia https://nvidia.github.io/dcgm-exporter/helm-charts
-          helm repo add prometheus https://prometheus-community.github.io/helm-charts
-          helm repo update
-
-      - name: Build chart dependencies
-        run: |
-          helm dependency build charts/hami-webui
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: charts
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Package Helm chart for GHCR
-        run: |
-          mkdir -p dist
-          helm package charts/hami-webui -d dist
-
-      - name: Normalize GHCR owner
-        run: |
-          echo "GHCR_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Helm chart to GHCR
-        run: |
-          for f in dist/*.tgz; do
-            echo "$f"
-            helm push "$f" "oci://ghcr.io/${GHCR_OWNER}/charts"
-          done
+          echo "::error::Stable publishing is suspended until #129 is complete."
+          exit 1


### PR DESCRIPTION
/kind cleanup

Part of #128 and #129.

Temporarily suspends the two legacy stable-release entry points while #129 replaces them with one verified release process:

- image CI no longer publishes version tags;
- the legacy Chart workflow has no write permissions and fails with an explicit suspension message;
- the active `protect-release-tags` ruleset blocks creation, update, and deletion of `v*` and `hami-webui-*` tags during the freeze.

Development images from `main` and normal pull-request builds continue unchanged. This PR deliberately does not implement the replacement publisher.

Validation: `actionlint` and `git diff --check` pass.