### PR TITLE
docs(release): document deployable tag rules

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -208,9 +208,12 @@ Before setting `STABLE_RELEASES_ENABLED=true`:
   `gh-pages`, then explicitly deploys them because pushes made with
   `GITHUB_TOKEN` do not trigger legacy branch builds;
 - serve the deployed site at `https://project-hami.github.io/HAMi-WebUI`;
-- split tag protection so GitHub Actions App may bypass only creation for `v*`,
-  while update and deletion of `v*` have no bypass; keep creation, update, and
-  deletion of legacy `hami-webui-*` tags blocked with no bypass;
+- block update and deletion of both `v*` and legacy `hami-webui-*` tags with no
+  bypass, and block creation of legacy `hami-webui-*` tags. Leave new `v*` tag
+  creation under repository write permission: this repository cannot select the
+  built-in GitHub Actions App as a ruleset bypass actor. The protected controller
+  uses a strict SemVer name, performs a create-only API call, and rejects any
+  existing tag that does not already resolve to the verified commit;
 - enable immutable releases. Immediately before approving a stable publish, an
   administrator must verify `GET /repos/Project-HAMi/HAMi-WebUI/immutable-releases`
   returns `enabled: true`, or enforce immutable releases for this repository at


### PR DESCRIPTION
The live repository-rules API rejects the built-in GitHub Actions App as a repository ruleset bypass actor because it is not an installed app in the ruleset source organization.

Document the deployable policy now configured on the repository:

- `v*` and legacy release tags cannot be updated or deleted by anyone;
- legacy `hami-webui-*` tag creation is blocked;
- new `v*` creation remains subject to repository write permission, while the protected release controller validates strict SemVer, uses a create-only call, and fails on any conflicting existing tag.

This removes an undeployable setup instruction without weakening existing release-tag immutability.