### PR TITLE
fix(release): test candidate manifest sealing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -295,33 +295,14 @@ jobs:
           SOURCE_SHA: ${{ needs.candidate-preflight.outputs.source_sha }}
           CANDIDATE_TAG: ${{ needs.candidate-preflight.outputs.candidate_tag }}
         run: |
-          set -euo pipefail
-          [[ -f candidate-parts/frontend.json ]]
-          [[ -f candidate-parts/backend.json ]]
-          jq -e -s \
-            --arg repository "${GITHUB_REPOSITORY}" \
-            --arg source_sha "${SOURCE_SHA}" \
-            --arg candidate_tag "${CANDIDATE_TAG}" \
-            --arg run_id "${GITHUB_RUN_ID}" \
-            --arg run_attempt "${GITHUB_RUN_ATTEMPT}" '
-              if length != 2 or
-                 any(.[]; .sourceSha != $source_sha or .candidateTag != $candidate_tag) or
-                 ([.[].component] | sort != ["backend", "frontend"])
-              then error("candidate image metadata is incomplete or inconsistent")
-              else {
-                schemaVersion: 1,
-                repository: $repository,
-                workflow: ".github/workflows/release.yaml",
-                sourceSha: $source_sha,
-                candidateTag: $candidate_tag,
-                runId: $run_id,
-                runAttempt: $run_attempt,
-                images: reduce .[] as $image ({};
-                  .[$image.component] = $image.registries)
-              }
-              end
-            ' candidate-parts/*.json >candidate.json
-          jq -e . candidate.json >/dev/null
+          bash scripts/release/seal-candidate-manifest.sh \
+            candidate-parts \
+            candidate.json \
+            "${GITHUB_REPOSITORY}" \
+            "${SOURCE_SHA}" \
+            "${CANDIDATE_TAG}" \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_RUN_ATTEMPT}"
 
       - name: Upload sealed candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/scripts/release/seal-candidate-manifest.sh
+++ b/scripts/release/seal-candidate-manifest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/lib.sh
+source "${script_dir}/lib.sh"
+
+parts_dir="${1:?candidate parts directory is required}"
+output_path="${2:?candidate manifest output path is required}"
+repository="${3:?GitHub repository is required}"
+source_sha="${4:?source SHA is required}"
+candidate_tag="${5:?candidate tag is required}"
+run_id="${6:?candidate run ID is required}"
+run_attempt="${7:?candidate run attempt is required}"
+
+release_require_command jq
+release_validate_commit "${source_sha}"
+[[ "${run_id}" =~ ^[0-9]+$ ]] || release_die "candidate run ID must be numeric"
+[[ "${run_attempt}" =~ ^[0-9]+$ ]] || release_die "candidate run attempt must be numeric"
+expected_tag="candidate-${source_sha:0:12}-${run_id}-${run_attempt}"
+[[ "${candidate_tag}" == "${expected_tag}" ]] || \
+  release_die "candidate tag does not bind the source, run, and attempt"
+[[ -f "${parts_dir}/frontend.json" && -f "${parts_dir}/backend.json" ]] || \
+  release_die "frontend and backend candidate metadata are both required"
+[[ "$(find "${parts_dir}" -maxdepth 1 -name '*.json' -type f | wc -l | tr -d ' ')" == "2" ]] || \
+  release_die "candidate metadata must contain exactly two JSON parts"
+
+jq -e -s \
+  --arg repository "${repository}" \
+  --arg source_sha "${source_sha}" \
+  --arg candidate_tag "${candidate_tag}" \
+  --arg run_id "${run_id}" \
+  --arg run_attempt "${run_attempt}" '
+    if length != 2 or
+       any(.[]; .sourceSha != $source_sha or .candidateTag != $candidate_tag) or
+       ([.[].component] | sort != ["backend", "frontend"]) or
+       any(.[]; (.registries | keys | sort) != ["dockerhub", "ghcr"])
+    then error("candidate image metadata is incomplete or inconsistent")
+    else {
+      schemaVersion: 1,
+      repository: $repository,
+      workflow: ".github/workflows/release.yaml",
+      sourceSha: $source_sha,
+      candidateTag: $candidate_tag,
+      runId: $run_id,
+      runAttempt: $run_attempt,
+      images: (reduce .[] as $image ({};
+        .[$image.component] = $image.registries))
+    }
+    end
+  ' "${parts_dir}/frontend.json" "${parts_dir}/backend.json" >"${output_path}"
+
+jq -e . "${output_path}" >/dev/null
+echo "Candidate manifest sealed from exactly two image records."

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -69,6 +69,40 @@ jq -n \
     }
   ' >"${contract_repo}/candidate.json"
 
+# Exercise the exact candidate-sealing code used by the workflow. This catches
+# jq compile errors and rejects inconsistent image metadata before release use.
+candidate_parts="${work_dir}/candidate-parts"
+mkdir -p "${candidate_parts}"
+jq '{
+  component: "frontend",
+  sourceSha,
+  candidateTag,
+  registries: .images.frontend
+}' "${contract_repo}/candidate.json" >"${candidate_parts}/frontend.json"
+jq '{
+  component: "backend",
+  sourceSha,
+  candidateTag,
+  registries: .images.backend
+}' "${contract_repo}/candidate.json" >"${candidate_parts}/backend.json"
+bash "${release_dir}/seal-candidate-manifest.sh" \
+  "${candidate_parts}" "${work_dir}/sealed-candidate.json" \
+  Project-HAMi/HAMi-WebUI "${candidate_sha}" \
+  "candidate-${candidate_sha:0:12}-42-1" 42 1
+jq -S . "${contract_repo}/candidate.json" >"${work_dir}/expected-candidate.json"
+jq -S . "${work_dir}/sealed-candidate.json" >"${work_dir}/actual-candidate.json"
+cmp "${work_dir}/expected-candidate.json" "${work_dir}/actual-candidate.json"
+
+cp -R "${candidate_parts}" "${work_dir}/bad-candidate-parts"
+jq '.sourceSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
+  "${work_dir}/bad-candidate-parts/backend.json" >"${work_dir}/bad-backend.json"
+mv "${work_dir}/bad-backend.json" "${work_dir}/bad-candidate-parts/backend.json"
+require_failure "inconsistent candidate image metadata" \
+  bash "${release_dir}/seal-candidate-manifest.sh" \
+    "${work_dir}/bad-candidate-parts" "${work_dir}/bad-candidate.json" \
+    Project-HAMi/HAMi-WebUI "${candidate_sha}" \
+    "candidate-${candidate_sha:0:12}-42-1" 42 1
+
 VERSION=1.2.1 DIGEST="${digest_a}" yq -i '
   .version = strenv(VERSION) |
   .appVersion = strenv(VERSION)


### PR DESCRIPTION
Candidate run [33237576699](https://github.com/Project-HAMi/HAMi-WebUI/actions/runs/33237576699) built and pushed all four image references successfully, then failed before sealing `candidate.json` because the inline jq object value used `images: reduce ...` without parentheses.

Move candidate sealing into a dedicated script, use the valid parenthesized reduce expression, and execute that exact script in the release-controller regression suite. The tests also reject inconsistent frontend/backend metadata.

No stable tag or release artifact was published by the failed run. Because this fix changes `main` after that run, a fresh candidate will be built after merge rather than reusing metadata from a different source commit.

Verified with actionlint, ShellCheck, and the full release-controller regression suite.