### PR TITLE
fix(release): checkout candidate sealing script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -283,6 +283,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout candidate source without persisted credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.candidate-preflight.outputs.source_sha }}
+          persist-credentials: false
+
       - name: Download image metadata
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -32,6 +32,18 @@ verify_contract_in_repo() {
 digest_a="sha256:$(printf 'candidate manifest fixture' | sha256sum | awk '{print $1}')"
 digest_b="sha256:$(printf 'conflicting stable fixture' | sha256sum | awk '{print $1}')"
 
+# Candidate sealing calls a repository script, so its job must fetch the exact
+# source commit with credentials disabled. Actionlint cannot infer this runtime
+# dependency.
+# shellcheck disable=SC2016
+yq -e '
+  [.jobs."candidate-manifest".steps[] |
+    select(.uses == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1") |
+    select(.with.ref == "${{ needs.candidate-preflight.outputs.source_sha }}") |
+    select(.with."persist-credentials" == false)] |
+  length == 1
+' .github/workflows/release.yaml >/dev/null
+
 # Build a minimal two-commit repository so the contract test exercises the
 # candidate-to-release comparison rather than relying on this checkout's history.
 contract_repo="${work_dir}/contract-repo"


### PR DESCRIPTION
Candidate run [33238018956](https://github.com/Project-HAMi/HAMi-WebUI/actions/runs/33238018956) built all four image references, then failed because `candidate-manifest` now invokes a repository script but the job did not check out the candidate source.

Add a credential-free checkout pinned to the exact candidate SHA before downloading image metadata. Also add a regression assertion that parses `release.yaml` and requires this checkout, because actionlint cannot infer a runtime script dependency.

No stable destination was touched. The complete actionlint, ShellCheck, and release-controller suite passes locally.