### PR TITLE
chore(release): prepare v1.3.0 metadata

### DIFF
--- a/charts/hami-webui/Chart.yaml
+++ b/charts/hami-webui/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.3.0"
 
 dependencies:
   - condition: dcgm-exporter.enabled

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -1,6 +1,6 @@
 # HAMi-WebUI
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 ## Get Repo Info
 
@@ -62,14 +62,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `""`                                                                                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
+| image.backend.digest | string | `"sha256:b37a24461b9289039dc6676d811c92c031abedf912d61f6371a2aa3909938cfe"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
 | image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
 | image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
-| image.backend.tag | string | `"v1.2.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `""`                                                                               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
+| image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
+| image.frontend.digest | string | `"sha256:efb77348f98d0aecb84b76d049f395b487544c03734ee8b7f98c75f6311a2489"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
 | image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
 | image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
-| image.frontend.tag | string | `"v1.2.0"`                                                                         | Used only when `image.frontend.digest` is empty. |
+| image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |
 | imagePullSecrets | list | `[]`                                                                               |  |
 | ingress.annotations | object | `{}`                                                                               |  |
 | ingress.className | string | `""`                                                                               |  |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -16,15 +16,15 @@ image:
     repository: projecthami/hami-webui-fe-oss
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
-    tag: "v1.2.0"
+    tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: ""
+    digest: "sha256:efb77348f98d0aecb84b76d049f395b487544c03734ee8b7f98c75f6311a2489"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
-    tag: "v1.2.0"
+    tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: ""
+    digest: "sha256:b37a24461b9289039dc6676d811c92c031abedf912d61f6371a2aa3909938cfe"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Prepare v1.3.0 from sealed candidate run 33238731012.

- bump Chart version and appVersion
- set v1.3.0 image tags and the verified Docker Hub multi-architecture digests
- keep the packaged Chart README in sync

This is a minor release because #97 adds user-visible workload/card filtering; the remaining changes are compatible fixes and maintenance. The Chart checks and strict candidate-to-release contract pass. No stable tag or artifact is published by this PR.