### PR TITLE
fix(chart): resolve embedded Prometheus service address

### DIFF
--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -55,6 +55,21 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/*
+Resolve the Prometheus address. When the embedded stack is enabled, use the
+dependency chart's own helpers so its naming and override rules cannot drift.
+*/}}
+{{- define "hami-webui.prometheusAddress" -}}
+{{- if .Values.externalPrometheus.enabled -}}
+{{- .Values.externalPrometheus.address -}}
+{{- else if (index .Values "kube-prometheus-stack").enabled -}}
+{{- $stack := index .Subcharts "kube-prometheus-stack" -}}
+{{- printf "http://%s-prometheus.%s.svc.cluster.local:%v" (include "kube-prometheus-stack.fullname" $stack) (include "kube-prometheus-stack.namespace" $stack) $stack.Values.prometheus.service.port -}}
+{{- else -}}
+{{- printf "http://%s-kube-prometh-prometheus.%s.svc.cluster.local:9090" (include "hami-webui.fullname" .) (include "hami-webui.namespace" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "hami-webui.chart" -}}

--- a/charts/hami-webui/templates/configmap.yaml
+++ b/charts/hami-webui/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
         addr: 0.0.0.0:9000
         timeout: {{ .Values.backend.grpc.timeout | default "60s" }}
     prometheus:
-      address: {{ ternary .Values.externalPrometheus.address (printf "http://%s-kube-prometh-prometheus.%s.svc.cluster.local:9090" (include "hami-webui.fullname" .) (include "hami-webui.namespace" .)) .Values.externalPrometheus.enabled }}
+      address: {{ include "hami-webui.prometheusAddress" . }}
       timeout: {{ .Values.externalPrometheus.timeout | default "1m" }}
     exporter:
       interval: {{ .Values.metricsExporter.interval | default "30s" }}

--- a/charts/hami-webui/templates/deployment.yaml
+++ b/charts/hami-webui/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.podAnnotations) (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,10 +15,8 @@ spec:
       app.kubernetes.io/component: "hami-webui"
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- toYaml $podAnnotations | nindent 8 }}
       labels:
         {{- include "hami-webui.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "hami-webui"

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -17,6 +17,74 @@ cp -R "${repo_root}/charts/hami-webui" "${work_dir}/hami-webui"
 helm dependency build --skip-refresh "${work_dir}/hami-webui"
 helm lint "${work_dir}/hami-webui"
 
+assert_internal_prometheus_address() {
+  local release_name="$1"
+  local release_namespace="$2"
+  shift 2
+
+  local -a render_args=(
+    --namespace "${release_namespace}"
+    --set 'kube-prometheus-stack.enabled=true'
+    --set 'kube-prometheus-stack.prometheus.enabled=true'
+    "$@"
+  )
+  local service_render config_render service_name service_namespace service_port config_address expected
+
+  service_render="$(helm template "${release_name}" "${work_dir}/hami-webui" \
+    "${render_args[@]}" \
+    --show-only charts/kube-prometheus-stack/templates/prometheus/service.yaml)"
+  config_render="$(helm template "${release_name}" "${work_dir}/hami-webui" \
+    "${render_args[@]}" \
+    --show-only templates/configmap.yaml)"
+
+  service_name="$(awk '/^metadata:$/ { metadata = 1; next } metadata && /^  name:/ { print $2; exit }' <<<"${service_render}")"
+  service_namespace="$(awk '/^metadata:$/ { metadata = 1; next } metadata && /^  namespace:/ { print $2; exit }' <<<"${service_render}")"
+  service_port="$(awk '/^  ports:$/ { ports = 1; next } ports && /^    port:/ { print $2; exit }' <<<"${service_render}")"
+  config_address="$(awk '$1 == "address:" { print $2; exit }' <<<"${config_render}")"
+  expected="http://${service_name}.${service_namespace}.svc.cluster.local:${service_port}"
+
+  if [[ -z "${service_name}" || -z "${service_namespace}" || -z "${service_port}" || "${config_address}" != "${expected}" ]]; then
+    echo "embedded Prometheus address does not match its rendered Service: ${expected}" >&2
+    exit 1
+  fi
+}
+
+assert_internal_prometheus_address test hami-webui-test
+assert_internal_prometheus_address hami-webui-prometheus-address-regression-release-1234 hami-webui-test
+assert_internal_prometheus_address test hami-webui-test \
+  --set-string 'kube-prometheus-stack.fullnameOverride=metrics-core' \
+  --set-string 'kube-prometheus-stack.namespaceOverride=metrics-system' \
+  --set 'kube-prometheus-stack.prometheus.service.port=19090'
+
+external_address='http://external-prometheus.observability.svc.cluster.local:9090'
+external_render="$(helm template test "${work_dir}/hami-webui" \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=${external_address}" \
+  --set 'kube-prometheus-stack.enabled=true' \
+  --set 'kube-prometheus-stack.prometheus.enabled=true' \
+  --show-only templates/configmap.yaml)"
+grep -Fq "address: ${external_address}" <<<"${external_render}"
+
+deployment_with_address() {
+  helm template test "${work_dir}/hami-webui" \
+    --set 'externalPrometheus.enabled=true' \
+    --set-string "externalPrometheus.address=$1" \
+    --set-string 'podAnnotations.example\.com/team=release' \
+    --set-string 'podAnnotations.checksum/config=user-value' \
+    --show-only templates/deployment.yaml
+}
+
+deployment_a="$(deployment_with_address 'http://prometheus-a.example:9090')"
+deployment_b="$(deployment_with_address 'http://prometheus-b.example:9090')"
+checksum_a="$(awk '$1 == "checksum/config:" { print $2; exit }' <<<"${deployment_a}")"
+checksum_b="$(awk '$1 == "checksum/config:" { print $2; exit }' <<<"${deployment_b}")"
+if [[ ! "${checksum_a}" =~ ^[a-f0-9]{64}$ || ! "${checksum_b}" =~ ^[a-f0-9]{64}$ || "${checksum_a}" == "${checksum_b}" ]] ||
+  [[ "$(grep -c 'checksum/config:' <<<"${deployment_a}")" -ne 1 ]] ||
+  ! grep -Fq 'example.com/team: release' <<<"${deployment_a}"; then
+  echo "Deployment config checksum does not change with the Prometheus address" >&2
+  exit 1
+fi
+
 app_version="$(helm show chart "${work_dir}/hami-webui" | awk -F': *' '$1 == "appVersion" {gsub(/\"/, "", $2); print $2}')"
 expected_tag="v${app_version#v}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

The WebUI assembled the embedded Prometheus address from the parent Chart name, while `kube-prometheus-stack` names its Service with a separately truncated subchart fullname. The backend therefore queried a non-existent DNS name and task utilization metrics stayed absent.

Reuse the dependency Chart helpers and configured Service port so the address always matches the rendered Service. Add a ConfigMap checksum to the Deployment because the backend loads this address only at startup, ensuring upgrades apply the fix. External Prometheus behavior and the disabled-stack fallback stay unchanged.

**Verification**

- Chart verification passes on Helm 3.21.4 and 4.2.4, including long release names, subchart overrides, custom ports, external Prometheus, and annotation merging.
- A K3s + HAMi 2.10 workload on a T4 rolled to a new WebUI Pod after upgrade. The exporter then returned `core_used=50`, `core_util=100`, and `memory_used=138` for the allocated container, with no Prometheus DNS errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus address resolution across embedded, external, and customized service configurations.
  * Ensured configuration changes trigger application pod updates automatically.
  * Preserved existing pod annotations while adding configuration change tracking.

* **Tests**
  * Added validation for Prometheus connectivity settings, custom naming and ports, external addresses, and configuration-based pod refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->