### PR TITLE
chore(release): refresh v1.3.0 candidate digests

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -62,11 +62,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `"sha256:b37a24461b9289039dc6676d811c92c031abedf912d61f6371a2aa3909938cfe"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
+| image.backend.digest | string | `"sha256:82b1e6078150130041d19c9320bab3c19f42496e17774336e99f208881eafc41"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
 | image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
 | image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
 | image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `"sha256:efb77348f98d0aecb84b76d049f395b487544c03734ee8b7f98c75f6311a2489"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
+| image.frontend.digest | string | `"sha256:c0c04b3885cf203f82f4f15ac5cd5cf8d77b9e3d2308fa1bf2668297abb54690"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
 | image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
 | image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
 | image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -18,13 +18,13 @@ image:
     # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:efb77348f98d0aecb84b76d049f395b487544c03734ee8b7f98c75f6311a2489"
+    digest: "sha256:c0c04b3885cf203f82f4f15ac5cd5cf8d77b9e3d2308fa1bf2668297abb54690"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:b37a24461b9289039dc6676d811c92c031abedf912d61f6371a2aa3909938cfe"
+    digest: "sha256:82b1e6078150130041d19c9320bab3c19f42496e17774336e99f208881eafc41"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Refresh the two default image digests for the v1.3.0 release after #143 changed the candidate source.

Candidate run: `33240764755`
Source: `a3512d3b53906011ca0ef5690ac84dad61a4bf8f`

Only the Docker Hub digests in `values.yaml` and their generated README entries change. Version, appVersion, image tags, and all runtime configuration remain unchanged.

`verify-release-contract.sh` and the full Chart verification pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documented container image digests for the frontend and backend images.
  * Updated Helm chart image digests for version `v1.3.0`.
  * Image repositories, tags, pull policies, and digest precedence remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->