### PR TITLE
fix: correct task compute utilization metrics

### DIFF
--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -398,8 +398,8 @@ const _cardGaugeConfig = useInstantVector([
   {
     title: 'computeUsageRate',
     percent: 0,
-    query: `avg(sum(hami_core_util) by (instance))`,
-    percentQuery: `avg(sum(hami_core_util_avg) by (instance))`,
+    query: `avg(avg(hami_core_util) by (node, device_uuid))`,
+    percentQuery: `avg(avg(hami_core_util_avg) by (node, device_uuid))`,
     totalQuery: `avg(sum(hami_core_size) by (instance))`,
     total: 100,
     used: 0,

--- a/packages/web/projects/vgpu/views/node/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/node/admin/Detail.vue
@@ -229,8 +229,8 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.computeUsageRate',
     percent: 0,
-    query: `avg(sum(hami_core_util{node=~"$node"}) by (instance))`,
-    percentQuery: `avg(sum(hami_core_util_avg{node=~"$node"}) by (instance))`,
+    query: `avg(avg(hami_core_util{node=~"$node"}) by (node, device_uuid))`,
+    percentQuery: `avg(avg(hami_core_util_avg{node=~"$node"}) by (node, device_uuid))`,
     totalQuery: `avg(sum(hami_core_size{node=~"$node"}) by (instance))`,
     total: 100,
     used: 0,

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -353,12 +353,12 @@ const handleGpuJump = (uuid) => {
 const lineConfig = ref([
   {
     titleKey: 'task.computeUsageTrend',
-    query: `avg(sum(hami_container_core_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (instance))`,
+    query: `avg(avg(hami_container_core_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid))`,
     data: [],
   },
   {
     titleKey: 'task.memUsageTrend',
-    query: `avg(sum(hami_container_memory_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (instance))`,
+    query: `100 * sum(avg(hami_container_memory_used{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid)) / clamp_min(sum(avg(hami_container_vmemory_allocated{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid)), 1)`,
     data: [],
   },
 ]);

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -275,7 +275,7 @@ export default {
     appName: 'App Name',
     createTime: 'Creation Time',
     times: 'x',
-    computeUsageTrend: 'GPU Compute Utilization (%)',
+    computeUsageTrend: 'Allocated GPU Compute Utilization (%)',
     memUsageTrend: 'GPU Memory Utilization (%)',
     cpuUsageTrend: 'CPU Usage (%)',
     memoryUsageTrend: 'Memory Usage (%)',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -272,7 +272,7 @@ export default {
     appName: '应用名称',
     createTime: '创建时间',
     times: '倍',
-    computeUsageTrend: 'GPU 算力使用率（%）',
+    computeUsageTrend: 'GPU 算力配额利用率（%）',
     memUsageTrend: 'GPU 显存使用率（%）',
     cpuUsageTrend: 'CPU 使用率（%）',
     memoryUsageTrend: '内存使用率（%）',

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -30,6 +30,15 @@ const (
 	defaultGenerateTimeout  = 60 * time.Second
 )
 
+var (
+	errNoMetricData        = errors.New("prometheus query returned no data")
+	errInvalidCoreCapacity = errors.New("allocated core capacity must be greater than zero")
+)
+
+type instantQuerier interface {
+	QueryInstant(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error)
+}
+
 // MetricsGenerator owns the lifecycle of the background /metrics collector.
 //
 // It satisfies kratos transport.Server: Start spins up a single refresh goroutine that
@@ -43,7 +52,7 @@ type MetricsGenerator struct {
 	promClient     *prom.Client
 	nodeUsecase    *biz.NodeUsecase
 	podUsecase     *biz.PodUseCase
-	monitorService *service.MonitorService
+	monitorService instantQuerier
 
 	interval time.Duration
 	timeout  time.Duration
@@ -385,30 +394,8 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			s.set(HamiContainerVmemoryAllocated, float64(memory), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			// 查询任务在当前设备下的算力利用率
-			taskCoreUsed, err := s.taskCoreUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
+			used, util, err := s.containerCoreMetrics(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index, core)
 			if err == nil {
-				used := float64(0)
-				util := float64(0)
-				switch provider {
-				case biz.NvidiaGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case biz.CambriconGPUDevice:
-					used = float64(taskCoreUsed) / 100 * float64(core)
-					util = float64(taskCoreUsed)
-				case biz.HygonGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				case metax.MetaxSGPUDevice:
-					used = float64(taskCoreUsed)
-					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core))
-				default:
-				}
-				cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
-				if err == nil && used != 0 && cardCoreUtil > 95 {
-					used = float64(cardCoreUtil) / 100 * float64(core)
-					util = float64(cardCoreUtil)
-				}
 				s.set(HamiContainerCoreUsed, used, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
 				s.set(HamiContainerCoreUtil, util, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
 			}
@@ -430,16 +417,21 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 }
 
 func (s *MetricsGenerator) queryInstantVal(ctx context.Context, query string) (float32, error) {
-	res, err := s.monitorService.QueryInstant(context.TODO(), &pb.QueryInstantRequest{
+	val, _, err := s.queryInstantValWithPresence(ctx, query)
+	return val, err
+}
+
+func (s *MetricsGenerator) queryInstantValWithPresence(ctx context.Context, query string) (float32, bool, error) {
+	res, err := s.monitorService.QueryInstant(ctx, &pb.QueryInstantRequest{
 		Query: query,
 	})
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	if len(res.Data) > 0 {
-		return res.Data[0].Value, nil
+		return res.Data[0].Value, true, nil
 	}
-	return 0, nil
+	return 0, false, nil
 }
 
 // 卡显存已使用量
@@ -529,14 +521,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	query := ""
 	switch provider {
 	case biz.NvidiaGPUDevice:
-		//query = fmt.Sprintf("avg(hami_container_device_utilization_ratio{device_uuid=\"%s\", namespace=\"%s\", pod=\"%s\", container=\"%s\"})", deviceUUID, namespace, pod, container)
-		//		queryTemplate := `last_over_time((hami_container_device_utilization_ratio{device_uuid="%s", namespace="%s", pod="%s", container="%s"} != 0)[1m:])
-		//or
-		//last_over_time(hami_container_device_utilization_ratio{device_uuid="%s", namespace="%s", pod="%s", container="%s"}[1m:])`
-		//		query = fmt.Sprintf(queryTemplate, deviceUUID, namespace, pod, container, deviceUUID, namespace, pod, container)
-		queryTemplate := fmt.Sprintf("hami_container_device_utilization_ratio{device_uuid=\"%s\", namespace=\"%s\", pod=\"%s\", container=\"%s\"}", deviceUUID, namespace, pod, container)
-		query = fmt.Sprintf("sum_over_time(%s[1m]) == 0 or (sum_over_time(%s[10m:]) / count_over_time(( %s !=0)[10m:])) ", queryTemplate, queryTemplate, queryTemplate)
-		//query = queryTemplate
+		query = nvidiaTaskCoreUsedQuery(deviceUUID, namespace, pod, container)
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vcore\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
@@ -551,7 +536,64 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	return s.queryInstantVal(ctx, query)
+	val, present, err := s.queryInstantValWithPresence(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	if !present && provider == biz.NvidiaGPUDevice {
+		return 0, errNoMetricData
+	}
+	return val, nil
+}
+
+func nvidiaTaskCoreUsedQuery(deviceUUID, namespace, pod, container string) string {
+	selector := fmt.Sprintf("hami_container_device_utilization_ratio{device_uuid=\"%s\", namespace=\"%s\", pod=\"%s\", container=\"%s\"}", deviceUUID, namespace, pod, container)
+	return fmt.Sprintf("avg(avg_over_time(%s[1m]))", selector)
+}
+
+// containerCoreMetrics preserves each provider's existing task-compute conversion.
+// For NVIDIA, used estimates active allocated compute in vCore percentage points
+// and excludes elastic borrowing; util is allocated-compute activity (0-100), not
+// physical-card utilization.
+func (s *MetricsGenerator) containerCoreMetrics(ctx context.Context, provider, namespace, pod, container, podUUID, deviceUUID, hostname string, deviceIndex int, allocatedCore int32) (float64, float64, error) {
+	if allocatedCore <= 0 {
+		return 0, 0, errInvalidCoreCapacity
+	}
+
+	taskCoreUsed, err := s.taskCoreUsed(ctx, provider, namespace, pod, container, podUUID, deviceUUID, hostname, deviceIndex)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	used := float64(0)
+	util := float64(0)
+	switch provider {
+	case biz.NvidiaGPUDevice:
+		rawActivity := float64(taskCoreUsed)
+		if math.IsNaN(rawActivity) || math.IsInf(rawActivity, 0) {
+			return 0, 0, errNoMetricData
+		}
+		activity := math.Max(0, math.Min(100, rawActivity))
+		used = roundToTwoDecimal(math.Min(100, activity*float64(allocatedCore)/100))
+		util = roundToOneDecimal(activity)
+		return used, util, nil
+	case biz.CambriconGPUDevice:
+		used = float64(taskCoreUsed) / 100 * float64(allocatedCore)
+		util = float64(taskCoreUsed)
+	case biz.HygonGPUDevice, metax.MetaxSGPUDevice:
+		used = float64(taskCoreUsed)
+		util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(allocatedCore))
+	}
+
+	// Keep the legacy fallback for providers whose task-level metrics still need it.
+	// It must not be used for NVIDIA: physical-card activity cannot be attributed to
+	// one container when several workloads share the same GPU.
+	cardCoreUtil, err := s.deviceCoreUtil(ctx, provider, deviceUUID)
+	if err == nil && used != 0 && cardCoreUtil > 95 {
+		used = float64(cardCoreUtil) / 100 * float64(allocatedCore)
+		util = float64(cardCoreUtil)
+	}
+	return used, util, nil
 }
 
 // 任务显存使用量

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -1,0 +1,171 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	pb "vgpu/api/v1"
+	"vgpu/internal/biz"
+	"vgpu/internal/provider/metax"
+)
+
+type fakeInstantQuerier struct {
+	responses []*pb.InstantResponse
+	queries   []string
+}
+
+func (f *fakeInstantQuerier) QueryInstant(_ context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+	f.queries = append(f.queries, req.GetQuery())
+	if len(f.responses) == 0 {
+		return &pb.InstantResponse{}, nil
+	}
+	res := f.responses[0]
+	f.responses = f.responses[1:]
+	return res, nil
+}
+
+func TestNvidiaTaskCoreUsedQueryIncludesIdleSamples(t *testing.T) {
+	query := nvidiaTaskCoreUsedQuery("GPU-1", "research", "train", "worker")
+	want := `avg(avg_over_time(hami_container_device_utilization_ratio{device_uuid="GPU-1", namespace="research", pod="train", container="worker"}[1m]))`
+	if query != want {
+		t.Fatalf("query mismatch\nwant: %s\n got: %s", want, query)
+	}
+	if strings.Contains(query, "!=") || strings.Contains(query, "count_over_time") {
+		t.Fatalf("query must include valid zero samples: %s", query)
+	}
+}
+
+func TestTaskCoreUsedDistinguishesMissingFromIdle(t *testing.T) {
+	fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}
+	generator := &MetricsGenerator{monitorService: fake}
+
+	_, err := generator.taskCoreUsed(context.Background(), biz.NvidiaGPUDevice, "research", "train", "worker", "pod-uid", "GPU-1", "node-1", 0)
+	if !errors.Is(err, errNoMetricData) {
+		t.Fatalf("expected errNoMetricData, got %v", err)
+	}
+}
+
+func TestTaskCoreUsedKeepsLegacyEmptyBehaviorForOtherProviders(t *testing.T) {
+	fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}
+	generator := &MetricsGenerator{monitorService: fake}
+
+	value, err := generator.taskCoreUsed(context.Background(), biz.CambriconGPUDevice, "research", "train", "worker", "pod-uid", "MLU-1", "node-1", 0)
+	if err != nil || value != 0 {
+		t.Fatalf("Cambricon empty result = (%v, %v), want (0, nil)", value, err)
+	}
+}
+
+func TestNvidiaContainerCoreMetrics(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       float32
+		allocated int32
+		wantUsed  float64
+		wantUtil  float64
+	}{
+		{name: "idle", raw: 0, allocated: 50, wantUsed: 0, wantUtil: 0},
+		{name: "intermittent activity", raw: 70.93, allocated: 50, wantUsed: 35.47, wantUtil: 70.9},
+		{name: "force policy full activity", raw: 100, allocated: 20, wantUsed: 20, wantUtil: 100},
+		{name: "source activity is bounded", raw: 125, allocated: 50, wantUsed: 50, wantUtil: 100},
+		{name: "single-card estimate is bounded", raw: 100, allocated: 200, wantUsed: 100, wantUtil: 100},
+		{name: "negative source is bounded", raw: -5, allocated: 50, wantUsed: 0, wantUtil: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: tt.raw}}}}}
+			generator := &MetricsGenerator{monitorService: fake}
+
+			used, util, err := generator.containerCoreMetrics(context.Background(), biz.NvidiaGPUDevice, "research", "train", "worker", "pod-uid", "GPU-1", "node-1", 0, tt.allocated)
+			if err != nil {
+				t.Fatalf("containerCoreMetrics() error = %v", err)
+			}
+			if math.Abs(used-tt.wantUsed) > 0.001 || math.Abs(util-tt.wantUtil) > 0.001 {
+				t.Fatalf("containerCoreMetrics() = (%v, %v), want (%v, %v)", used, util, tt.wantUsed, tt.wantUtil)
+			}
+			if len(fake.queries) != 1 {
+				t.Fatalf("NVIDIA metrics made %d queries, want 1 (no device-level fallback)", len(fake.queries))
+			}
+			if strings.Contains(fake.queries[0], "DCGM_FI_DEV_GPU_UTIL") {
+				t.Fatalf("NVIDIA task metrics must not use card-level DCGM data: %s", fake.queries[0])
+			}
+		})
+	}
+}
+
+func TestNvidiaContainerCoreMetricsRejectsNonFiniteValues(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  float32
+	}{
+		{name: "NaN", raw: float32(math.NaN())},
+		{name: "positive infinity", raw: float32(math.Inf(1))},
+		{name: "negative infinity", raw: float32(math.Inf(-1))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: tt.raw}}}}}
+			generator := &MetricsGenerator{monitorService: fake}
+
+			_, _, err := generator.containerCoreMetrics(context.Background(), biz.NvidiaGPUDevice, "research", "train", "worker", "pod-uid", "GPU-1", "node-1", 0, 50)
+			if !errors.Is(err, errNoMetricData) {
+				t.Fatalf("expected errNoMetricData, got %v", err)
+			}
+		})
+	}
+}
+
+func TestContainerCoreMetricsRejectsZeroAllocation(t *testing.T) {
+	fake := &fakeInstantQuerier{}
+	generator := &MetricsGenerator{monitorService: fake}
+
+	_, _, err := generator.containerCoreMetrics(context.Background(), biz.NvidiaGPUDevice, "research", "train", "worker", "pod-uid", "GPU-1", "node-1", 0, 0)
+	if !errors.Is(err, errInvalidCoreCapacity) {
+		t.Fatalf("expected errInvalidCoreCapacity, got %v", err)
+	}
+	if len(fake.queries) != 0 {
+		t.Fatalf("invalid allocation should not query Prometheus, got %d queries", len(fake.queries))
+	}
+}
+
+func TestContainerCoreMetricsKeepsLegacyProviderConversions(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		taskValue float32
+		cardValue float32
+		allocated int32
+		wantUsed  float64
+		wantUtil  float64
+	}{
+		{name: "Cambricon task metric", provider: biz.CambriconGPUDevice, taskValue: 50, cardValue: 50, allocated: 40, wantUsed: 20, wantUtil: 50},
+		{name: "Cambricon legacy card fallback", provider: biz.CambriconGPUDevice, taskValue: 50, cardValue: 100, allocated: 40, wantUsed: 40, wantUtil: 100},
+		{name: "Hygon task metric", provider: biz.HygonGPUDevice, taskValue: 25, cardValue: 50, allocated: 50, wantUsed: 25, wantUtil: 50},
+		{name: "Metax sGPU task metric", provider: metax.MetaxSGPUDevice, taskValue: 25, cardValue: 50, allocated: 50, wantUsed: 25, wantUtil: 50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{
+				{Data: []*pb.Sample{{Value: tt.taskValue}}},
+				{Data: []*pb.Sample{{Value: tt.cardValue}}},
+			}}
+			generator := &MetricsGenerator{monitorService: fake}
+
+			used, util, err := generator.containerCoreMetrics(context.Background(), tt.provider, "research", "train", "worker", "pod-uid", "device-1", "node-1", 0, tt.allocated)
+			if err != nil {
+				t.Fatalf("containerCoreMetrics() error = %v", err)
+			}
+			if used != tt.wantUsed || util != tt.wantUtil {
+				t.Fatalf("containerCoreMetrics() = (%v, %v), want (%v, %v)", used, util, tt.wantUsed, tt.wantUtil)
+			}
+			if len(fake.queries) != 2 {
+				t.Fatalf("legacy provider made %d queries, want 2", len(fake.queries))
+			}
+		})
+	}
+}

--- a/server/internal/exporter/metrics.go
+++ b/server/internal/exporter/metrics.go
@@ -32,8 +32,8 @@ func init() {
 	prometheus.MustRegister(HamiContainerVcoreAllocated)   // 任务申请的vcore
 	prometheus.MustRegister(HamiContainerMemoryUsed)       // 任务实际使用的显存大小（MB）
 	prometheus.MustRegister(HamiContainerMemoryUtil)       // 任务实际使用的显存占任务申请的比例
-	prometheus.MustRegister(HamiContainerCoreUsed)         // 任务实际使用的算力占卡的百分比
-	prometheus.MustRegister(HamiContainerCoreUtil)         // 任务实际使用的算力占任务申请的比例
+	prometheus.MustRegister(HamiContainerCoreUsed)         // 任务算力使用量（厂商语义；NVIDIA 为活跃分配 vCore 估算）
+	prometheus.MustRegister(HamiContainerCoreUtil)         // 任务算力利用率（NVIDIA 为已分配算力活跃度）
 
 	// 资源池维度指标
 	prometheus.MustRegister(HamiPoolVcoreSize)   // 资源池总算力大小
@@ -42,7 +42,6 @@ func init() {
 
 	prometheus.MustRegister(HamiSystemComponentHealth) // 系统组件健康状态
 }
-
 
 var (
 	HamiVCoreScaling = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -167,12 +166,12 @@ var (
 
 	HamiContainerCoreUsed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_container_core_used",
-		Help: "task used core ",
+		Help: "task compute usage in provider-specific core units; NVIDIA estimates active allocated vCore percentage points and excludes elastic borrowing",
 	}, []string{"node", "provider", "device_type", "device_uuid", "pod_name", "container_name", "namespace_name"})
 
 	HamiContainerCoreUtil = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_container_core_util",
-		Help: "task core util percent 0-100",
+		Help: "task compute utilization percent; NVIDIA reports allocated-compute activity 0-100, not physical-card utilization",
 	}, []string{"node", "provider", "device_type", "device_uuid", "pod_name", "container_name", "namespace_name"})
 
 	HamiPoolVgpuCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Corrects NVIDIA task compute metrics and percentage aggregation.

HAMi reports zero as a valid idle sample, but the exporter averaged only non-zero samples over 10 minutes. That inflated intermittent workloads. It also replaced task usage with whole-card DCGM utilization above 95%, which cannot be attributed to one container on a shared GPU.

This change:

- uses a one-minute average that includes idle samples;
- for NVIDIA, defines `hami_container_core_used` as estimated active allocated compute in vCore percentage points, excluding elastic borrowing;
- for NVIDIA, keeps `hami_container_core_util` as allocated-compute activity in the `0..100` range, not physical-card utilization;
- does not publish NVIDIA task usage when Prometheus has no matching series;
- removes the NVIDIA whole-card fallback;
- averages per-device task, node, and cluster percentages after deduplicating HA exporter replicas;
- computes multi-device task memory usage as a weighted ratio instead of summing percentages.

On a T4 with a 50-core allocation, the old query reported `82.75 / 165.5%` for an intermittent workload while the average including idle samples was `70.93`.

A second T4 test used `gpuCorePolicy=force` with a 20-core allocation. The policy and `CUDA_DEVICE_SM_LIMIT=20` were present, while the HAMi container metric, host metric, and `nvidia-smi` all reported `100`. This test shows that the source is GPU activity time, not physical capacity consumed. The exporter interprets the raw `100` as full activity within the declared allocation: `20` vCore points used and `100%` allocation utilization. It does not infer physical-card consumption from this sample.

Current telemetry cannot quantify compute borrowed under the default elastic policy, so this change does not claim to report borrowed physical capacity. The one-minute window also intentionally smooths short bursts.

Issue #64 remains separate: it concerns device-level DCGM busy-time semantics, not `hami_container_*` task metrics.

**Verification:**

- `go test ./...`
- `go test -race ./internal/exporter`
- `go vet ./...`
- BFF build and tests
- Web build and lint

Part of #130.
