### PR TITLE
docs: require two-node release acceptance

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -116,10 +116,20 @@ The resulting `release-bundle-<run-id>` contains:
 The next job waits for approval on the protected `release` environment. Do not
 approve it yet.
 
-## T4/K3s acceptance gate
+## Two-node T4/K3s acceptance and maintainer UAT gate
 
 Download `release-bundle-<run-id>` from the waiting publish run and verify
 `SHA256SUMS`. Test that exact `.tgz`; do not run `helm package` locally.
+Keep the protected `release` job waiting and
+`STABLE_RELEASES_ENABLED=false` throughout acceptance.
+
+Use one disposable K3s cluster with two schedulable GPU nodes:
+
+- one node with two physical T4 GPUs;
+- a second node with at least one physical T4 GPU;
+- at least three concurrently running GPU workloads spread across both nodes,
+  including allocations on both GPUs of the two-GPU node and at least one
+  allocation on the second node.
 
 Minimum matrix:
 
@@ -131,13 +141,27 @@ Minimum matrix:
 5. uninstall and reinstall;
 6. verify each Pod spec uses the recorded multi-platform index digest, and that
    each runtime-resolved platform digest is a member of that index;
-7. verify node/device discovery, GPU allocation, workload display, non-zero
-   compute/memory utilization, filtering, refresh, and ordinary navigation;
-8. retain commands, screenshots, rendered manifests, events, and an acceptance
-   result, then delete the disposable GCP resources.
+7. verify both nodes, all three or more physical GPUs, their allocations, and
+   all concurrent workloads are represented correctly;
+8. expose this exact candidate WebUI to the maintainer's local browser through
+   a port-forward or tunnel, then verify non-zero compute/memory utilization,
+   task-to-node/device mapping, filtering, refresh, and ordinary navigation.
+   Screenshots and automated checks do not replace this inspection;
+9. retain commands, screenshots, rendered manifests, events, and the acceptance
+   result.
 
-Only after this matrix passes should an authorized reviewer approve the
-`release` environment job.
+After the automated matrix passes, pause and ask the maintainer to inspect the
+running WebUI. Passing tests, silence, or approval of an earlier release is not
+approval for this run.
+
+Only after the maintainer explicitly approves this exact release bundle and run
+may `STABLE_RELEASES_ENABLED` be changed to `true` and the pending protected
+`release` deployment be approved.
+
+Keep the cluster, workloads, and browser access running through stable
+publication. After publication, verify the public images, chart endpoints,
+GitHub Release, and the released WebUI against the retained cluster. Delete the
+disposable GCP resources only after those post-publication checks pass.
 
 ## Ordered publication
 
@@ -180,6 +204,8 @@ Before setting `STABLE_RELEASES_ENABLED=true`:
   aggregate context to `main` protection, and require it before merging future
   controller changes;
 - create a protected GitHub environment named `release`;
+- disable administrator bypass on that environment so maintainers cannot skip
+  the recorded acceptance approval;
 - deliberately keep the Pages deployment in that same `release` environment
   (rather than using `github-pages`) so one protected approval gates every
   stable write; the existing `github-pages` environment is not the release


### PR DESCRIPTION
**What this PR does / why we need it:**

Makes maintainer acceptance an explicit stable-release gate.

- requires a two-node K3s cluster with at least three T4 GPUs, including one two-GPU node;
- requires at least three concurrent GPU workloads across both nodes;
- opens the exact candidate WebUI in the maintainer's local browser;
- requires explicit approval for the exact bundle and run before enabling stable publication;
- keeps the cluster available through post-publication verification.

The protected `release` environment already records the approval. Administrator bypass has also been disabled, so no workflow change or self-reported UAT input is needed.

Part of #130.
