### PR TITLE
release: pin v1.3.0 candidate images

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -62,11 +62,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `"sha256:82b1e6078150130041d19c9320bab3c19f42496e17774336e99f208881eafc41"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
+| image.backend.digest | string | `"sha256:e6f2635f501f673045906dfced32eb7274add19ea9cfb2a4ce40c33532097b36"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
 | image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
 | image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
 | image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `"sha256:c0c04b3885cf203f82f4f15ac5cd5cf8d77b9e3d2308fa1bf2668297abb54690"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
+| image.frontend.digest | string | `"sha256:bb538e3c9f9b3df7b62bb99afe5bb890a6c6c48cc6a5c3fc2d04963445514695"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
 | image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
 | image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
 | image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -18,13 +18,13 @@ image:
     # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:c0c04b3885cf203f82f4f15ac5cd5cf8d77b9e3d2308fa1bf2668297abb54690"
+    digest: "sha256:bb538e3c9f9b3df7b62bb99afe5bb890a6c6c48cc6a5c3fc2d04963445514695"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:82b1e6078150130041d19c9320bab3c19f42496e17774336e99f208881eafc41"
+    digest: "sha256:e6f2635f501f673045906dfced32eb7274add19ea9cfb2a4ce40c33532097b36"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Pins the v1.3.0 chart defaults to the sealed Docker Hub digests from candidate run 33245713731.

Candidate source: `daa100b49802131a82fbb44a8ac3204a8a78b85c`
Frontend: `sha256:bb538e3c9f9b3df7b62bb99afe5bb890a6c6c48cc6a5c3fc2d04963445514695`
Backend: `sha256:e6f2635f501f673045906dfced32eb7274add19ea9cfb2a4ce40c33532097b36`

`verify-release-contract.sh` passes. Refs #147.

/kind cleanup