### PR TITLE
fix(chart): scrape bundled kube-state-metrics

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -83,6 +83,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | kube-prometheus-stack.defaultRules.create | bool | `false`                                                                            |  |
 | kube-prometheus-stack.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.grafana.enabled | bool | `false`                                                                            |  |
+| kube-prometheus-stack.kube-state-metrics.prometheus.monitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          | Allow the bundled Prometheus to scrape kube-state-metrics for cluster CPU and memory totals. |
 | kube-prometheus-stack.kubernetesServiceMonitors.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.nodeExporter.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelector.matchLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
@@ -189,5 +190,7 @@ You must also modify all ...ServiceMonitor.additionalLabels in your values.yaml 
   additionalLabels:
     <jobRelease-label-key>: <jobRelease-label-value>
 ```
+
+This includes `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.additionalLabels`.
 
 This ensures that Prometheus will correctly discover all the ServiceMonitor configurations based on the updated labels.

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -157,6 +157,11 @@ kube-prometheus-stack:
     enabled: false
   nodeExporter:
     enabled: false
+  kube-state-metrics:
+    prometheus:
+      monitor:
+        additionalLabels:
+          jobRelease: hami-webui-prometheus
   prometheusOperator:
     enabled: false
   prometheus:

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -56,6 +56,21 @@ assert_internal_prometheus_address test hami-webui-test \
   --set-string 'kube-prometheus-stack.namespaceOverride=metrics-system' \
   --set 'kube-prometheus-stack.prometheus.service.port=19090'
 
+prometheus_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --set 'kube-prometheus-stack.enabled=true' \
+  --show-only charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml)"
+kube_state_metrics_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --set 'kube-prometheus-stack.enabled=true' \
+  --show-only charts/kube-prometheus-stack/charts/kube-state-metrics/templates/servicemonitor.yaml)"
+selector_label='jobRelease: hami-webui-prometheus'
+if ! grep -Fq "${selector_label}" <<<"${prometheus_render}" ||
+  ! grep -Fq "${selector_label}" <<<"${kube_state_metrics_render}"; then
+  echo "Bundled Prometheus does not select the kube-state-metrics ServiceMonitor" >&2
+  exit 1
+fi
+
 external_address='http://external-prometheus.observability.svc.cluster.local:9090'
 external_render="$(helm template test "${work_dir}/hami-webui" \
   --set 'externalPrometheus.enabled=true' \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The resources overview reports `0` CPU cores and system memory when HAMi-WebUI deploys its bundled Prometheus.

Prometheus selects ServiceMonitors with `jobRelease: hami-webui-prometheus`, but the bundled kube-state-metrics ServiceMonitor did not carry that label. Its `kube_node_status_allocatable` metrics were therefore never scraped, and empty queries were displayed as zero.

This adds the matching label and a chart regression check that keeps the Prometheus selector and kube-state-metrics ServiceMonitor aligned.

**Verification**:

- `bash scripts/verify-chart.sh`
- Exact chart rendering confirms the kube-state-metrics ServiceMonitor now has `jobRelease: hami-webui-prometheus`

Discovered during the v1.3.0 acceptance run tracked in #147. The candidate remains blocked until this is merged and revalidated on the two-node GPU environment.
