### PR TITLE
release: refresh v1.3.0 candidate images

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -62,11 +62,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `"sha256:e6f2635f501f673045906dfced32eb7274add19ea9cfb2a4ce40c33532097b36"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
+| image.backend.digest | string | `"sha256:4f3fa02710d56fea1e9a0d57587deb5fe86411b9471004c1f358a77437c62797"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
 | image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
 | image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
 | image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `"sha256:bb538e3c9f9b3df7b62bb99afe5bb890a6c6c48cc6a5c3fc2d04963445514695"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
+| image.frontend.digest | string | `"sha256:2a11f990d47833196869a3674ea64534eb2c817e231a1d2f2899a47b595002de"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
 | image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
 | image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
 | image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -18,13 +18,13 @@ image:
     # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:bb538e3c9f9b3df7b62bb99afe5bb890a6c6c48cc6a5c3fc2d04963445514695"
+    digest: "sha256:2a11f990d47833196869a3674ea64534eb2c817e231a1d2f2899a47b595002de"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:e6f2635f501f673045906dfced32eb7274add19ea9cfb2a4ce40c33532097b36"
+    digest: "sha256:4f3fa02710d56fea1e9a0d57587deb5fe86411b9471004c1f358a77437c62797"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Refreshes the v1.3.0 chart defaults to the sealed candidate built after #151.

Candidate run: https://github.com/Project-HAMi/HAMi-WebUI/actions/runs/33247672898  
Candidate source: `c56b6dc600016318186fb439b13d5b983f2b579d`

Only the four documented frontend/backend digest fields change. No application or chart behavior changes after the candidate build.

**Verification**:

- `bash scripts/release/verify-release-contract.sh ...` → `Release contract is valid for v1.3.0.`
- `bash scripts/verify-chart.sh`

The resulting bundle will replace the superseded acceptance candidate tracked in #147.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart’s frontend and backend container image digests for version 1.3.0.
  * Synchronized the documented image digests with the deployment configuration.
  * Image repositories, tags, and digest precedence behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->