### PR TITLE
fix: distinguish unlimited task resources

### DIFF
--- a/packages/web/projects/vgpu/hooks/useInstantVector.js
+++ b/packages/web/projects/vgpu/hooks/useInstantVector.js
@@ -26,7 +26,12 @@ const useInstantVector = (configs, parseQuery = (query) => query, times) => {
             query: parsedQuery,
           });
 
-          const used = usedData.data.length ? usedData.data[0]?.value : 0;
+          // Preserve whether Prometheus returned a series. Some consumers need
+          // to distinguish a real zero from an empty vector (for example, an
+          // existing container with no CPU or memory limit).
+          const hasData = usedData.data.length > 0;
+          const used = hasData ? usedData.data[0]?.value : 0;
+          data.value[index].hasData = hasData;
           data.value[index].count = used;
           data.value[index].used = used;
         }

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -313,6 +313,11 @@ const resourceOverviewData = useInstantVector(
       query:
         `sum(kube_pod_container_resource_limits{resource="memory", namespace="$namespace", pod=~"$pod", container="$container"}) / 1024 / 1024 / 1024`,
     },
+    {
+      key: 'containerInfo',
+      query:
+        `count(kube_pod_container_info{namespace="$namespace", pod=~"$pod", container="$container"})`,
+    },
   ],
   (query) =>
     query
@@ -325,18 +330,31 @@ const toNumOrUndefined = (v) => {
   return Number.isFinite(n) ? n : undefined;
 };
 const resourceOverviewTexts = computed(() => {
-  const get = (key) => resourceOverviewData.value.find((item) => item.key === key)?.count;
+  const getMetric = (key) => resourceOverviewData.value.find((item) => item.key === key);
+  const get = (key) => getMetric(key)?.count;
+  const containerInfo = getMetric('containerInfo');
+  const hasContainerInfo =
+    containerInfo?.hasData === true && Number(containerInfo.count) > 0;
+  const formatLimit = (key, formatter) => {
+    const metric = getMetric(key);
+    if (metric?.hasData === true) {
+      const value = toNumOrUndefined(metric.count);
+      return value === undefined ? '--' : formatter(value);
+    }
+    if (metric?.hasData === false && hasContainerInfo) {
+      return t('common.notLimited');
+    }
+    return '--';
+  };
   const gpuCards = toNumOrUndefined(get('gpuCards'));
   const computeLimit = toNumOrUndefined(get('computeLimit'));
   const singleCardMemory = toNumOrUndefined(get('singleCardMemory'));
-  const cpuLimit = toNumOrUndefined(get('cpuLimit'));
-  const memoryLimit = toNumOrUndefined(get('memoryLimit'));
   return {
     gpuCards: gpuCards === undefined ? '--' : `${Math.round(gpuCards)}`,
     computeLimit: computeLimit === undefined ? '--' : `${roundToDecimal(computeLimit / 100, 1)}`,
     singleCardMemory: singleCardMemory === undefined ? '--' : `${singleCardMemory.toFixed(1)} GiB`,
-    cpuLimit: cpuLimit === undefined ? '--' : `${Math.round(cpuLimit)} Core`,
-    memoryLimit: memoryLimit === undefined ? '--' : `${memoryLimit.toFixed(1)} GiB`,
+    cpuLimit: formatLimit('cpuLimit', (value) => `${roundToDecimal(value, 3)} Core`),
+    memoryLimit: formatLimit('memoryLimit', (value) => `${value.toFixed(1)} GiB`),
   };
 });
 

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -39,6 +39,7 @@ export default {
     fieldRequired: 'This field is required',
     yes: 'Yes',
     no: 'No',
+    notLimited: 'Not limited',
     unitCount: '',
     unitSheet: '',
     paginationTotal: '{total} items',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -39,6 +39,7 @@ export default {
     fieldRequired: '该字段是必填字段',
     yes: '是',
     no: '否',
+    notLimited: '未限制',
     unitCount: '个',
     unitSheet: '张',
     paginationTotal: '共 {total} 条数据',


### PR DESCRIPTION
/kind bug

Task details currently show `0 Core` and `0.0 GiB` when a container has no CPU or memory limit. An empty Prometheus vector was being flattened to zero, which also made missing data indistinguishable from an intentionally unlimited container.

This change preserves whether the query returned a series and uses `kube_pod_container_info` as positive evidence that the container exists:

- configured limits keep their numeric values;
- an existing container without a limit shows `Not limited` / `未限制`;
- unavailable or unknown data remains `--`.

It also keeps fractional CPU limits, so `500m` is shown as `0.5 Core` instead of being rounded to an integer.

Verification:

- targeted ESLint and production frontend build pass;
- live UAT: no-limit Pod shows `Not limited` / `未限制`;
- live UAT: `500m` / `512Mi` Pod shows `0.5 Core` / `0.5 GiB`.

Related to #147.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer CPU and memory limit reporting in task details.
  * Displays “Not limited” when containers have no configured resource limits.
  * Added localized support for the new resource-limit status in English and Chinese.

* **Bug Fixes**
  * Improved handling of empty Prometheus vector results while preserving zero usage values.
  * Distinguishes unavailable, invalid, reported, and unconfigured resource limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->