### PR TITLE
release: refresh v1.3.0 candidate images

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -62,11 +62,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `"sha256:4f3fa02710d56fea1e9a0d57587deb5fe86411b9471004c1f358a77437c62797"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
+| image.backend.digest | string | `"sha256:7057047c7c2f7838cd190b3dc7263d503bbcf5d8e52642bc703227d137bc029d"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
 | image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
 | image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
 | image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `"sha256:2a11f990d47833196869a3674ea64534eb2c817e231a1d2f2899a47b595002de"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
+| image.frontend.digest | string | `"sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
 | image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
 | image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
 | image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -18,13 +18,13 @@ image:
     # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:2a11f990d47833196869a3674ea64534eb2c817e231a1d2f2899a47b595002de"
+    digest: "sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e"
   backend:
     repository: projecthami/hami-webui-be-oss
     pullPolicy: IfNotPresent
     tag: "v1.3.0"
     # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:4f3fa02710d56fea1e9a0d57587deb5fe86411b9471004c1f358a77437c62797"
+    digest: "sha256:7057047c7c2f7838cd190b3dc7263d503bbcf5d8e52642bc703227d137bc029d"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
/kind cleanup

Refresh the v1.3.0 chart defaults to the Docker Hub digests sealed by [candidate run 33250523780](https://github.com/Project-HAMi/HAMi-WebUI/actions/runs/33250523780), built from `main@3b7ec1f4a87f05f3ca720425785171c62e173dc5` after #153.

Only the frontend/backend digests and their generated README entries change. The version and tags remain v1.3.0.

Verification:

- `scripts/verify-chart.sh`
- `verify-release-contract.sh` against the sealed `candidate.json`
