### PR TITLE
fix(release): publish ignored Pages chart packages

### DIFF
--- a/scripts/release/publish-pages.sh
+++ b/scripts/release/publish-pages.sh
@@ -55,9 +55,10 @@ else
   [[ "${indexed_url}" == "${expected_url}" ]] || release_die "generated index URL is incorrect"
 fi
 
-if ! git -C "${pages_dir}" diff --quiet -- "${chart_file}" index.yaml || \
-   [[ -n "$(git -C "${pages_dir}" status --short -- "${chart_file}" index.yaml)" ]]; then
-  git -C "${pages_dir}" add "${chart_file}" index.yaml
+git -C "${pages_dir}" add --force -- "${chart_file}"
+git -C "${pages_dir}" add -- index.yaml
+
+if ! git -C "${pages_dir}" diff --cached --quiet -- "${chart_file}" index.yaml; then
   git -C "${pages_dir}" commit -m "release(chart): publish ${version}"
   [[ -n "${GITHUB_TOKEN:-}" ]] || release_die "GITHUB_TOKEN is required to publish gh-pages"
   auth_header="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -409,6 +409,51 @@ require_failure "conflicting OCI chart found after all image checks" \
     "${preflight_bundle}" Project-HAMi/HAMi-WebUI "${pages}" \
     https://project-hami.github.io/HAMi-WebUI
 
+# A generated Pages branch may ignore chart archives globally. The publisher
+# owns this validated artifact, so it must still commit the package and index
+# together instead of failing at git add.
+pages_chart_dir="${work_dir}/pages-chart"
+pages_publish_dir="${work_dir}/pages-publish"
+pages_remote_dir="${work_dir}/pages-remote.git"
+mkdir -p "${pages_chart_dir}" "${pages_publish_dir}"
+cat >"${pages_chart_dir}/Chart.yaml" <<'PAGES_CHART'
+apiVersion: v2
+name: hami-webui
+type: application
+version: 9.9.9
+appVersion: "9.9.9"
+PAGES_CHART
+helm package "${pages_chart_dir}" --destination "${work_dir}" >/dev/null
+
+git -C "${pages_publish_dir}" init -q -b gh-pages
+git -C "${pages_publish_dir}" config user.name release-test
+git -C "${pages_publish_dir}" config user.email release-test@example.invalid
+printf '*.tgz\n' >"${pages_publish_dir}/.gitignore"
+printf 'apiVersion: v1\nentries:\n  hami-webui: []\n' >"${pages_publish_dir}/index.yaml"
+git -C "${pages_publish_dir}" add .gitignore index.yaml
+git -C "${pages_publish_dir}" commit -qm 'initialize Pages source'
+git init -q --bare "${pages_remote_dir}"
+git -C "${pages_publish_dir}" remote add origin "${pages_remote_dir}"
+git -C "${pages_publish_dir}" push -q -u origin gh-pages
+
+GITHUB_TOKEN=test-token bash "${release_dir}/publish-pages.sh" \
+  "${work_dir}/hami-webui-9.9.9.tgz" 9.9.9 "${pages_publish_dir}" \
+  https://project-hami.github.io/HAMi-WebUI
+git --git-dir="${pages_remote_dir}" show \
+  gh-pages:hami-webui-9.9.9.tgz >"${work_dir}/published-pages-chart.tgz"
+cmp "${work_dir}/hami-webui-9.9.9.tgz" "${work_dir}/published-pages-chart.tgz"
+git --git-dir="${pages_remote_dir}" show gh-pages:index.yaml \
+  >"${work_dir}/published-pages-index.yaml"
+VERSION=9.9.9 yq -e '
+  [.entries."hami-webui"[] | select(.version == strenv(VERSION))] | length == 1
+' "${work_dir}/published-pages-index.yaml" >/dev/null
+[[ -z "$(git -C "${pages_publish_dir}" status --short)" ]]
+pages_publish_commit="$(git --git-dir="${pages_remote_dir}" rev-parse gh-pages)"
+GITHUB_TOKEN=test-token bash "${release_dir}/publish-pages.sh" \
+  "${work_dir}/hami-webui-9.9.9.tgz" 9.9.9 "${pages_publish_dir}" \
+  https://project-hami.github.io/HAMi-WebUI
+[[ "$(git --git-dir="${pages_remote_dir}" rev-parse gh-pages)" == "${pages_publish_commit}" ]]
+
 # Pages must never accept only half of the immutable package/index pair.
 cp "${preflight_bundle}/hami-webui-9.9.9.tgz" "${pages}/hami-webui-9.9.9.tgz"
 require_failure "Pages package without matching index entry" \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The v1.3.0 Pages step failed because the `gh-pages` branch ignored `*.tgz`, so a normal `git add` rejected the already-validated chart package.

Force-add only that exact package after its bytes and index entry are verified, stage `index.yaml` normally, and decide whether to publish from the staged diff. This keeps the release controller independent of deployment-branch ignore rules.

The regression test creates a Pages repository that ignores `*.tgz`, verifies the package and index are committed together, and verifies a second identical publish is a no-op.

**Verification:**

- `git diff --check`
- `bash -n scripts/release/publish-pages.sh scripts/release/tests/release-controller.sh`
- `shellcheck scripts/release/*.sh scripts/release/tests/*.sh`
- `bash scripts/release/tests/release-controller.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Helm chart publishing now reliably includes chart archives even when they are excluded by repository rules.
  * Repeated publishing avoids creating unnecessary commits when no changes are present.

* **Tests**
  * Added coverage verifying charts and index updates are committed together, version information is correct, the working tree remains clean, and repeated publishing is idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->