### PR TITLE
chore: align Dependabot with toolchain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: "/"
@@ -22,6 +25,9 @@ updates:
     labels:
       - dependencies
       - kind/cleanup
+    # Dockerfile toolchain versions must stay aligned with .node-version and
+    # package.json, so image updates need a coordinated maintainer PR.
+    open-pull-requests-limit: 0
 
   - package-ecosystem: docker
     directory: "/server"
@@ -31,3 +37,6 @@ updates:
     labels:
       - dependencies
       - kind/cleanup
+    # Dockerfile toolchain versions must stay aligned with server/.go-version,
+    # so image updates need a coordinated maintainer PR.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
**What this PR does**

- groups only minor and patch GitHub Actions updates;
- leaves major Actions updates as separate reviewable PRs;
- disables Docker version-update PRs for the Node and Go toolchain images.

Docker-only toolchain bumps cannot satisfy the repository version contract: Node must also stay aligned with `.node-version` and `package.json`, while Go must stay aligned with `server/.go-version`. Those upgrades should therefore be coordinated maintainer PRs with the full CI suite.

This does not add an automatic merge path. Dependabot continues to surface the updates that fit the policy; CI, review and Tide remain the merge gates.

**Verification**

- parsed `.github/dependabot.yml` as YAML;
- `git diff --check` passes.

/kind cleanup