### PR TITLE
fix: bound GitHub Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,27 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    open-pull-requests-limit: 2
     labels:
       - dependencies
       - kind/cleanup
     groups:
-      github-actions:
+      github-actions-routine:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
           - minor
           - patch
+      github-actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
 
   - package-ecosystem: docker
     directory: "/"


### PR DESCRIPTION
The minor/patch-only group added in #156 left major GitHub Actions updates ungrouped, so Dependabot opened #157-#161 individually immediately after the configuration changed.

Split Actions updates into two bounded weekly groups:

- one routine PR for minor and patch updates;
- one major PR for updates that require migration review.

The ecosystem is capped at two open version-update PRs. Routine releases wait seven days and major releases wait thirty days before becoming eligible. This keeps major risk separate without allowing one PR per action.

Docker toolchain policy from #156 is unchanged.

**Verification**

- parsed `.github/dependabot.yml` as YAML;
- `git diff --check` passes.

/kind cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the timing of automated GitHub Actions dependency update proposals.
  * Routine updates are grouped separately from major-version updates for clearer maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->