### PR TITLE
fix: correct overview compute utilization

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -61,6 +61,8 @@ jobs:
         run: pnpm run build
       - name: Build web
         run: pnpm --filter hami-webui-web run build
+      - name: Test web
+        run: pnpm --filter hami-webui-web run test:metrics
       - name: Test BFF
         run: pnpm test
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,6 +16,7 @@
     "new": "plop",
     "svgo": "svgo -f src/icons/svg --config=src/icons/svgo.yml",
     "test:unit": "jest --clearCache && vue-cli-service test:unit",
+    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs",
     "test:ci": "npm run lint && npm run test:unit"
   },
   "dependencies": {

--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -175,6 +175,7 @@ import useFetchList from '@/hooks/useFetchList';
 import TabTop from '~/vgpu/components/TabTop.vue';
 import Gauge from '~/vgpu/components/gauge.vue';
 import { getRangeConfigInit } from './config';
+import { createComputeUsageGaugeConfig } from './metric-config.mjs';
 
 const router = useRouter();
 const { t, locale } = useI18n();
@@ -395,16 +396,7 @@ const _cardGaugeConfig = useInstantVector([
     used: 0,
     unit: 'GiB',
   },
-  {
-    title: 'computeUsageRate',
-    percent: 0,
-    query: `avg(avg(hami_core_util) by (node, device_uuid))`,
-    percentQuery: `avg(avg(hami_core_util_avg) by (node, device_uuid))`,
-    totalQuery: `avg(sum(hami_core_size) by (instance))`,
-    total: 100,
-    used: 0,
-    unit: ' ',
-  },
+  createComputeUsageGaugeConfig(),
   {
     title: 'memUsageRate',
     percent: 0,

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
@@ -1,0 +1,12 @@
+export const createComputeUsageGaugeConfig = () => ({
+  title: 'computeUsageRate',
+  percent: 0,
+  query: 'avg(avg(hami_core_util) by (node, device_uuid))',
+  percentQuery: 'avg(avg(hami_core_util_avg) by (node, device_uuid))',
+  // hami_core_util is already a percentage in the 0-100 range. Dividing it by
+  // cluster-wide hami_core_size would make the displayed value shrink as more
+  // devices are added to the cluster.
+  total: 100,
+  used: 0,
+  unit: ' ',
+});

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createComputeUsageGaugeConfig } from './metric-config.mjs';
+
+test('compute utilization is treated as an already-normalized percentage', () => {
+  const config = createComputeUsageGaugeConfig();
+
+  assert.equal(config.total, 100);
+  assert.equal(config.totalQuery, undefined);
+  assert.match(config.query, /hami_core_util/);
+  assert.equal((41 / config.total) * 100, 41);
+});


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The overview query already returns `hami_core_util` as a percentage in the
0-100 range. `useInstantVector` then replaced the configured total of 100 with
cluster-wide `hami_core_size`, so the displayed value was divided by the number
of devices in the cluster.

Keep 100 as the denominator and add a dependency-free regression test for this
metric contract. This does not redefine device busy-time relative to a
workload's requested core quota; that is a separate product-semantic question.

**Verification:**

- `pnpm --filter hami-webui-web run test:metrics`
- `pnpm --filter hami-webui-web run build`
- targeted ESLint for the changed frontend files
- Nest build and Jest suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected compute-usage monitoring so utilization percentages remain accurate as devices are added.
  * Updated metric queries to display values on a consistent 0–100% scale.

* **Tests**
  * Added automated coverage for compute-usage gauge configuration.
  * Web metric tests now run automatically as part of frontend pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->