### PR TITLE
fix: restrict Vite build environment exposure

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -36,6 +36,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'scripts/verify-toolchain-versions.sh'
+              - 'scripts/verify-vite-env-boundary.mjs'
               - 'tsconfig*.json'
               - 'Makefile'
               - '.github/workflows/pr-frontend.yaml'

--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -59,8 +59,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build BFF
         run: pnpm run build
-      - name: Build web
-        run: pnpm --filter hami-webui-web run build
+      - name: Build web and verify environment boundary
+        run: pnpm run verify:vite-env
       - name: Test web
         run: pnpm --filter hami-webui-web run test:metrics
       - name: Test BFF

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -209,8 +209,8 @@ metricsExporter:
   timeout: "60s"
 
 # The frontend axios client timeout (default 60000ms) is compiled into the JS
-# bundle at image build time from the VUE_APP_REQUEST_TIMEOUT env var, as Vite
-# evaluates process.env at build, not at runtime. To change it for a deployed
-# cluster you need to rebuild packages/web with a different VUE_APP_REQUEST_TIMEOUT
-# (set in packages/web/.env.production or as a build-arg). It cannot be tuned
-# through this values.yaml.
+# bundle at image build time from the VITE_APP_REQUEST_TIMEOUT env var. To
+# change it for a deployed cluster you need to rebuild packages/web with a
+# different VITE_APP_REQUEST_TIMEOUT
+# (set in packages/web/.env.production before building the frontend image). It
+# cannot be tuned through this values.yaml.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "verify:vite-env": "node scripts/verify-vite-env-boundary.mjs"
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.1",

--- a/packages/web/.env.development
+++ b/packages/web/.env.development
@@ -2,8 +2,7 @@
 ENV = 'development'
 
 # base api
-VUE_APP_BASE_API = '/'
+VITE_APP_BASE_API = '/'
 
-# axios global timeout in ms; override via build env or chart values.frontend.requestTimeout
-VUE_APP_REQUEST_TIMEOUT = 60000
-
+# axios global timeout in ms; override via the image build environment
+VITE_APP_REQUEST_TIMEOUT = 60000

--- a/packages/web/.env.production
+++ b/packages/web/.env.production
@@ -2,7 +2,7 @@
 ENV = 'production'
 
 # base api
-VUE_APP_BASE_API = './'
+VITE_APP_BASE_API = './'
 
-# axios global timeout in ms; override via build env or chart values.frontend.requestTimeout
-VUE_APP_REQUEST_TIMEOUT = 60000
+# axios global timeout in ms; override via the image build environment
+VITE_APP_REQUEST_TIMEOUT = 60000

--- a/packages/web/src/utils/error-log.js
+++ b/packages/web/src/utils/error-log.js
@@ -8,7 +8,7 @@ import settings from '@/settings'
 const { errorLog: needErrorLog } = settings
 
 function checkNeed() {
-  const env = process.env.NODE_ENV
+  const env = import.meta.env.MODE
   if (isString(needErrorLog)) {
     return env === needErrorLog
   }

--- a/packages/web/src/utils/request.js
+++ b/packages/web/src/utils/request.js
@@ -3,16 +3,16 @@ import axios from 'axios';
 import { ElMessage, ElMessageBox, ElNotification } from 'element-plus';
 import i18n from '@/locales';
 
-// Default request timeout in ms. Override at build time via VUE_APP_REQUEST_TIMEOUT
-// (injected through .env.* or chart values.frontend.requestTimeout). 60s is large
+// Default request timeout in ms. Override at build time via VITE_APP_REQUEST_TIMEOUT
+// (injected through .env.* or the image build environment). 60s is large
 // enough for the slowest known page-side API (/v1/nodes can take a few seconds
 // against a large VictoriaMetrics cluster) while still bounding hung requests.
 const DEFAULT_REQUEST_TIMEOUT = 60000;
 const requestTimeout =
-  Number.parseInt(process.env.VUE_APP_REQUEST_TIMEOUT, 10) || DEFAULT_REQUEST_TIMEOUT;
+  Number.parseInt(import.meta.env.VITE_APP_REQUEST_TIMEOUT, 10) || DEFAULT_REQUEST_TIMEOUT;
 
 const service = axios.create({
-  baseURL: process.env.VUE_APP_BASE_API, // url = base url + request url
+  baseURL: import.meta.env.VITE_APP_BASE_API, // url = base url + request url
   timeout: requestTimeout,
   validateStatus: function (status) {
     return (status >= 200 && status < 300) || status > 520;

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,14 +1,12 @@
 import { fileURLToPath, URL } from 'node:url'
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import { createSvgIconsPlugin } from 'vite-plugin-svg-icons'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import path from 'path'
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd())
-  
+export default defineConfig(() => {
   return {
     base: './', // 对应 publicPath: './'
     plugins: [
@@ -67,9 +65,5 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
-    define: {
-      // 注入 Webpack 环境变量
-      'process.env': { ...process.env, ...env }
-    }
   }
 })

--- a/scripts/verify-vite-env-boundary.mjs
+++ b/scripts/verify-vite-env-boundary.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process'
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+)
+const outputDirectory = path.join(repositoryRoot, 'public')
+
+const inheritedEnvironment = ['CI', 'HOME', 'PATH', 'PNPM_HOME', 'TMPDIR']
+const buildEnvironment = Object.fromEntries(
+  inheritedEnvironment
+    .filter((name) => process.env[name] !== undefined)
+    .map((name) => [name, process.env[name]])
+)
+Object.assign(buildEnvironment, {
+  HAMI_WEBUI_UNREFERENCED_CANARY: 'hami_webui_canary_should_not_ship',
+  VITE_APP_BASE_API: '/vite-env-contract/',
+  VITE_APP_REQUEST_TIMEOUT: '71234567'
+})
+
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const build = spawnSync(
+  pnpm,
+  ['--filter', 'hami-webui-web', 'run', 'build'],
+  {
+    cwd: repositoryRoot,
+    env: buildEnvironment,
+    stdio: 'inherit'
+  }
+)
+if (build.status !== 0) {
+  throw new Error(`Vite build failed with status ${build.status}`)
+}
+
+const listJavaScriptFiles = async(directory) => {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const entryPath = path.join(directory, entry.name)
+      return entry.isDirectory() ? listJavaScriptFiles(entryPath) : [entryPath]
+    })
+  )
+
+  return files.flat().filter((file) => file.endsWith('.js'))
+}
+
+const bundles = await Promise.all(
+  (await listJavaScriptFiles(outputDirectory)).map((file) =>
+    readFile(file, 'utf8')
+  )
+)
+const contains = (value) => bundles.some((bundle) => bundle.includes(value))
+
+const forbiddenValues = [
+  'HAMI_WEBUI_UNREFERENCED_CANARY',
+  'hami_webui_canary_should_not_ship'
+]
+const bundledForbiddenValue = forbiddenValues.find(contains)
+if (bundledForbiddenValue) {
+  throw new Error(
+    `unreferenced build environment value was bundled: ${bundledForbiddenValue}`
+  )
+}
+
+const requiredValues = ['/vite-env-contract/', '71234567']
+const missingRequiredValue = requiredValues.find((value) => !contains(value))
+if (missingRequiredValue) {
+  throw new Error(
+    `allowlisted Vite value was not bundled: ${missingRequiredValue}`
+  )
+}
+
+console.log('Vite build environment boundary verified.')


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The Vite config replaces `process.env` with the complete build environment.
With the repository's frozen dependencies, a production build includes both
the name and value of an otherwise unreferenced canary variable in the main JS
bundle. This makes bundle contents depend on the builder environment and on
tree-shaking behavior.

Remove that replacement and use Vite's explicit `VITE_*` contract for the two
frontend settings. CI now performs a sanitized production build and verifies
both sides of the boundary:

- an unprefixed canary name and value are absent;
- the allowlisted API base URL and request timeout are present.

The official image workflows do not pass registry or GitHub credentials into
the Docker build, so this PR does not claim that released images exposed those
secrets.

This supersedes #112 while preserving its intended Vite environment support.
Thanks to @ly5156 for identifying that migration gap.

**Verification:**

- `pnpm run verify:vite-env`
- `pnpm --filter hami-webui-web run test:metrics`
- frontend ESLint
- Nest build and Jest suite
- `scripts/verify-chart.sh`
