### PR TITLE
feat: add reusable Go Web entry

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -3,6 +3,7 @@ CMD_PATH ?= ./cmd/
 BUILD_PATH ?= ./build/
 VERSION ?= $(shell git describe --tags --always)
 DIRS = $(shell ls $(CMD_PATH))
+WIRE_DIRS = $(patsubst $(CMD_PATH)%/wire.go,%,$(wildcard $(CMD_PATH)*/wire.go))
 TARGET_ARCH ?= amd64
 WIRE_VERSION ?= v0.7.0
 PROTOC_GEN_VALIDATE_VERSION ?= v1.0.4
@@ -33,7 +34,7 @@ generate-proto:
 
 .PHONY: generate-wire
 generate-wire:
-	@ for dir in $(DIRS); \
+	@ for dir in $(WIRE_DIRS); \
 	do \
 		cd ${CMD_PATH}$$dir/ && wire . && cd ../../; \
 	done

--- a/server/cmd/web-entry/main.go
+++ b/server/cmd/web-entry/main.go
@@ -1,0 +1,178 @@
+// Command web-entry serves the HAMi-WebUI SPA and same-origin API endpoint.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"vgpu/internal/webentry"
+)
+
+const (
+	defaultListenAddress  = ":3000"
+	defaultBackendURL     = "http://127.0.0.1:8000"
+	defaultStaticDir      = "/apps/public"
+	defaultProxyTimeout   = "65s"
+	defaultHealthcheckURL = "http://127.0.0.1:3000/health_check"
+	healthcheckTimeout    = 3 * time.Second
+	shutdownTimeout       = 10 * time.Second
+)
+
+type options struct {
+	listenAddress  string
+	backendURL     string
+	staticDir      string
+	proxyTimeout   string
+	healthcheck    bool
+	healthcheckURL string
+}
+
+func main() {
+	if err := run(os.Args[1:], os.LookupEnv); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, lookupEnv func(string) (string, bool)) error {
+	config, err := parseOptions(args, lookupEnv)
+	if err != nil {
+		return errors.New("invalid command-line options")
+	}
+	if config.healthcheck {
+		return performHealthcheck(config.healthcheckURL)
+	}
+
+	proxyTimeout, err := time.ParseDuration(config.proxyTimeout)
+	if err != nil || proxyTimeout <= 0 {
+		return errors.New("configuration error: proxy timeout must be a positive duration")
+	}
+	if config.listenAddress == "" {
+		return errors.New("configuration error: listen address must not be empty")
+	}
+	if config.staticDir == "" {
+		return errors.New("configuration error: static directory must not be empty")
+	}
+	staticInfo, err := os.Stat(config.staticDir)
+	if err != nil || !staticInfo.IsDir() {
+		return errors.New("configuration error: static directory is unavailable")
+	}
+
+	target, err := parseHTTPURL(config.backendURL)
+	if err != nil {
+		return errors.New("configuration error: backend URL must be an absolute HTTP URL without credentials")
+	}
+	logger := log.New(os.Stdout, "web-entry: ", log.LstdFlags|log.LUTC)
+	proxy, err := webentry.NewReverseProxy(webentry.ReverseProxyConfig{
+		Target:  target,
+		Timeout: proxyTimeout,
+		ReportError: func(failure webentry.ProxyFailure) {
+			logger.Printf("backend proxy failure status=%d class=%s error=%v", failure.Status, failure.Class, failure.Err)
+		},
+	})
+	if err != nil {
+		return errors.New("configuration error: backend proxy is invalid")
+	}
+	handler, err := webentry.NewHandler(webentry.HandlerConfig{
+		StaticFS:   os.DirFS(config.staticDir),
+		APIHandler: proxy,
+	})
+	if err != nil {
+		return errors.New("configuration error: static directory does not contain a usable SPA")
+	}
+
+	listener, err := net.Listen("tcp", config.listenAddress)
+	if err != nil {
+		return errors.New("cannot open Web-entry listener")
+	}
+	server, err := webentry.NewHTTPServer(webentry.HTTPServerConfig{
+		Address:      config.listenAddress,
+		Handler:      handler,
+		ProxyTimeout: proxyTimeout,
+	})
+	if err != nil {
+		_ = listener.Close()
+		return errors.New("configuration error: HTTP server settings are invalid")
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	logger.Printf("listening address=%s", listener.Addr())
+	if err := webentry.Serve(ctx, server, listener, shutdownTimeout); err != nil {
+		return fmt.Errorf("web entry stopped: %w", err)
+	}
+	return nil
+}
+
+func parseOptions(args []string, lookupEnv func(string) (string, bool)) (options, error) {
+	config := options{}
+	flags := flag.NewFlagSet("web-entry", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&config.listenAddress, "listen-address", envOrDefault(lookupEnv, "HAMI_WEBUI_LISTEN_ADDRESS", defaultListenAddress), "HTTP listen address")
+	flags.StringVar(&config.backendURL, "backend-url", envOrDefault(lookupEnv, "HAMI_WEBUI_BACKEND_URL", defaultBackendURL), "backend base URL")
+	flags.StringVar(&config.staticDir, "static-dir", envOrDefault(lookupEnv, "HAMI_WEBUI_STATIC_DIR", defaultStaticDir), "SPA static directory")
+	flags.StringVar(&config.proxyTimeout, "proxy-timeout", envOrDefault(lookupEnv, "HAMI_WEBUI_PROXY_TIMEOUT", defaultProxyTimeout), "backend request timeout")
+	flags.BoolVar(&config.healthcheck, "healthcheck", false, "check the running Web entry and exit")
+	flags.StringVar(&config.healthcheckURL, "healthcheck-url", envOrDefault(lookupEnv, "HAMI_WEBUI_HEALTHCHECK_URL", defaultHealthcheckURL), "health-check URL")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, errors.New("unexpected positional arguments")
+	}
+	return config, nil
+}
+
+func envOrDefault(lookupEnv func(string) (string, bool), key, fallback string) string {
+	if value, ok := lookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func parseHTTPURL(raw string) (*url.URL, error) {
+	target, err := url.Parse(raw)
+	if err != nil || target.Host == "" || (target.Scheme != "http" && target.Scheme != "https") || target.User != nil || target.Fragment != "" {
+		return nil, errors.New("invalid HTTP URL")
+	}
+	return target, nil
+}
+
+func performHealthcheck(rawURL string) error {
+	target, err := parseHTTPURL(rawURL)
+	if err != nil {
+		return errors.New("health check configuration is invalid")
+	}
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target.String(), nil)
+	if err != nil {
+		return errors.New("health check configuration is invalid")
+	}
+	client := &http.Client{
+		Timeout: healthcheckTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return errors.New("web-entry health check failed")
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4<<10))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return errors.New("web-entry health check returned a non-success status")
+	}
+	return nil
+}

--- a/server/cmd/web-entry/main_test.go
+++ b/server/cmd/web-entry/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseOptionsFlagsOverrideEnvironment(t *testing.T) {
+	t.Parallel()
+
+	environment := map[string]string{
+		"HAMI_WEBUI_LISTEN_ADDRESS":  ":3100",
+		"HAMI_WEBUI_BACKEND_URL":     "http://backend-from-env:8000",
+		"HAMI_WEBUI_STATIC_DIR":      "/env/public",
+		"HAMI_WEBUI_PROXY_TIMEOUT":   "70s",
+		"HAMI_WEBUI_HEALTHCHECK_URL": "http://health-from-env/health_check",
+	}
+	lookup := func(key string) (string, bool) {
+		value, ok := environment[key]
+		return value, ok
+	}
+
+	config, err := parseOptions([]string{
+		"--listen-address=:3200",
+		"--backend-url=http://backend-from-flag:8000",
+		"--static-dir=/flag/public",
+		"--proxy-timeout=80s",
+		"--healthcheck-url=http://health-from-flag/health_check",
+	}, lookup)
+	if err != nil {
+		t.Fatalf("parseOptions: %v", err)
+	}
+
+	if config.listenAddress != ":3200" ||
+		config.backendURL != "http://backend-from-flag:8000" ||
+		config.staticDir != "/flag/public" ||
+		config.proxyTimeout != "80s" ||
+		config.healthcheckURL != "http://health-from-flag/health_check" {
+		t.Fatalf("flags did not override environment: %+v", config)
+	}
+}
+
+func TestParseOptionsUsesDocumentedDefaults(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseOptions(nil, func(string) (string, bool) { return "", false })
+	if err != nil {
+		t.Fatalf("parseOptions: %v", err)
+	}
+	if config.listenAddress != defaultListenAddress ||
+		config.backendURL != defaultBackendURL ||
+		config.staticDir != defaultStaticDir ||
+		config.proxyTimeout != defaultProxyTimeout ||
+		config.healthcheckURL != defaultHealthcheckURL {
+		t.Fatalf("defaults = %+v", config)
+	}
+}
+
+func TestPerformHealthcheckRequiresTwoHundredStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "success", status: http.StatusNoContent},
+		{name: "redirect", status: http.StatusFound, wantErr: true},
+		{name: "server error", status: http.StatusServiceUnavailable, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+			err := performHealthcheck(server.URL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("performHealthcheck error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHealthcheckModeDoesNotInitializeServeConfiguration(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	environment := map[string]string{
+		"HAMI_WEBUI_BACKEND_URL":     "://invalid",
+		"HAMI_WEBUI_STATIC_DIR":      "/does/not/exist",
+		"HAMI_WEBUI_PROXY_TIMEOUT":   "not-a-duration",
+		"HAMI_WEBUI_HEALTHCHECK_URL": server.URL,
+	}
+	lookup := func(key string) (string, bool) {
+		value, ok := environment[key]
+		return value, ok
+	}
+
+	if err := run([]string{"--healthcheck"}, lookup); err != nil {
+		t.Fatalf("healthcheck initialized unrelated serve configuration: %v", err)
+	}
+}
+
+func TestParseHTTPURLDoesNotExposeCredentials(t *testing.T) {
+	t.Parallel()
+
+	const secret = "do-not-print-this"
+	_, err := parseHTTPURL("http://user:" + secret + "@backend:8000")
+	if err == nil {
+		t.Fatal("parseHTTPURL accepted credentials")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("configuration error exposed URL credentials")
+	}
+}
+
+func TestRunDoesNotExposeBackendCredentials(t *testing.T) {
+	t.Parallel()
+
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<main></main>"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	const secret = "do-not-print-this"
+	environment := map[string]string{
+		"HAMI_WEBUI_BACKEND_URL": "http://user:" + secret + "@backend:8000",
+		"HAMI_WEBUI_STATIC_DIR":  staticDir,
+	}
+	lookup := func(key string) (string, bool) {
+		value, ok := environment[key]
+		return value, ok
+	}
+
+	err := run(nil, lookup)
+	if err == nil {
+		t.Fatal("run accepted backend credentials")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("startup error exposed URL credentials")
+	}
+}

--- a/server/internal/webentry/handler.go
+++ b/server/internal/webentry/handler.go
@@ -1,0 +1,299 @@
+// Package webentry provides the public HTTP entry point for HAMi-WebUI.
+//
+// It deliberately depends only on the Go standard library. The package owns
+// Web concerns (static files, SPA fallback and the same-origin API prefix), but
+// it does not initialize Kubernetes, Prometheus or the HAMi application.
+package webentry
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	apiPrefix       = "/api/vgpu"
+	indexFile       = "index.html"
+	noCache         = "no-cache"
+	immutableCache  = "public, max-age=31536000, immutable"
+	healthCheckBody = "OK\n"
+)
+
+var (
+	viteHashPattern    = regexp.MustCompile(`-[A-Za-z0-9_-]{8,}\.[^.]+$`)
+	webpackHashPattern = regexp.MustCompile(`\.[0-9a-fA-F]{8,}\.[^.]+$`)
+	backendOnlyPaths   = []string{"/metrics", "/readyz", "/q"}
+)
+
+// HandlerConfig contains the dependencies of the Web entry HTTP handler.
+// StaticFS must contain index.html at its root. APIHandler receives requests
+// after the /api/vgpu prefix has been removed.
+type HandlerConfig struct {
+	StaticFS   fs.FS
+	APIHandler http.Handler
+}
+
+// NewHandler constructs the Web entry handler and verifies that the SPA shell
+// exists. APIHandler may be nil; in that case API requests return 404 rather
+// than falling through to the SPA.
+func NewHandler(config HandlerConfig) (http.Handler, error) {
+	if config.StaticFS == nil {
+		return nil, errors.New("static filesystem is required")
+	}
+	info, err := fs.Stat(config.StaticFS, indexFile)
+	if err != nil {
+		return nil, fmt.Errorf("open SPA index: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("SPA index is not a regular file")
+	}
+
+	apiHandler := config.APIHandler
+	if apiHandler == nil {
+		apiHandler = http.HandlerFunc(writeNotFound)
+	}
+
+	return &entryHandler{
+		staticFS: config.StaticFS,
+		api:      http.StripPrefix(apiPrefix, apiHandler),
+	}, nil
+}
+
+type entryHandler struct {
+	staticFS fs.FS
+	api      http.Handler
+}
+
+func (h *entryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/health_check":
+		h.serveHealth(w, r)
+	case hasPathPrefix(r.URL.Path, "/health_check"):
+		writeNotFound(w, r)
+	case hasPathPrefix(r.URL.Path, apiPrefix):
+		if hasInvalidPathSegment(r.URL.Path) {
+			writeNotFound(w, r)
+			return
+		}
+		backendPath := path.Clean(strings.TrimPrefix(r.URL.Path, apiPrefix))
+		if !hasPathPrefix(backendPath, "/v1") {
+			writeNotFound(w, r)
+			return
+		}
+		h.api.ServeHTTP(w, r)
+	case r.URL.Path == "/api" || strings.HasPrefix(r.URL.Path, "/api/"):
+		writeNotFound(w, r)
+	case hasAnyPathPrefix(r.URL.Path, backendOnlyPaths):
+		writeNotFound(w, r)
+	default:
+		h.serveFrontend(w, r)
+	}
+}
+
+func (h *entryHandler) serveHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Length", strconv.Itoa(len(healthCheckBody)))
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodGet {
+		_, _ = io.WriteString(w, healthCheckBody)
+	}
+}
+
+func (h *entryHandler) serveFrontend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeNotFound(w, r)
+		return
+	}
+	if r.URL.Path != "/" && strings.HasSuffix(r.URL.Path, "/") {
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), "/")
+		if !fs.ValidPath(name) || h.isStaticRequest(name) {
+			writeNotFound(w, r)
+			return
+		}
+		h.serveFile(w, r, indexFile, true)
+		return
+	}
+
+	name, ok := requestFileName(r.URL.Path)
+	if !ok {
+		writeNotFound(w, r)
+		return
+	}
+	if name == "." {
+		h.serveFile(w, r, indexFile, true)
+		return
+	}
+
+	if info, err := fs.Stat(h.staticFS, name); err == nil {
+		if !info.Mode().IsRegular() {
+			writeNotFound(w, r)
+			return
+		}
+		h.serveFile(w, r, name, false)
+		return
+	}
+
+	if h.isStaticRequest(name) {
+		writeNotFound(w, r)
+		return
+	}
+	h.serveFile(w, r, indexFile, true)
+}
+
+func (h *entryHandler) serveFile(w http.ResponseWriter, r *http.Request, name string, index bool) {
+	servedName := name
+	if info, err := fs.Stat(h.staticFS, name+".gz"); err == nil && info.Mode().IsRegular() {
+		w.Header().Add("Vary", "Accept-Encoding")
+		if acceptsGzip(r.Header.Get("Accept-Encoding")) {
+			servedName = name + ".gz"
+			w.Header().Set("Content-Encoding", "gzip")
+		}
+	}
+
+	file, err := h.staticFS.Open(servedName)
+	if err != nil {
+		writeNotFound(w, r)
+		return
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		writeNotFound(w, r)
+		return
+	}
+
+	if index || !isHashedAsset(name) {
+		w.Header().Set("Cache-Control", noCache)
+	} else {
+		w.Header().Set("Cache-Control", immutableCache)
+	}
+	if contentType := mime.TypeByExtension(path.Ext(name)); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+
+	reader, err := seekableFile(file)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	http.ServeContent(w, r, name, info.ModTime(), reader)
+}
+
+func (h *entryHandler) isStaticRequest(name string) bool {
+	if !strings.Contains(name, "/") && path.Ext(name) != "" {
+		return true
+	}
+	first, _, _ := strings.Cut(name, "/")
+	info, err := fs.Stat(h.staticFS, first)
+	return err == nil && info.IsDir()
+}
+
+func requestFileName(urlPath string) (string, bool) {
+	if urlPath == "/" {
+		return ".", true
+	}
+	if !strings.HasPrefix(urlPath, "/") || strings.HasSuffix(urlPath, "/") {
+		return "", false
+	}
+	name := strings.TrimPrefix(urlPath, "/")
+	if !fs.ValidPath(name) {
+		return "", false
+	}
+	return name, true
+}
+
+func hasPathPrefix(requestPath, prefix string) bool {
+	return requestPath == prefix || strings.HasPrefix(requestPath, prefix+"/")
+}
+
+func writeNotFound(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	http.NotFound(w, r)
+}
+
+func hasAnyPathPrefix(requestPath string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if hasPathPrefix(requestPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasInvalidPathSegment(requestPath string) bool {
+	for _, segment := range strings.Split(requestPath, "/") {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func isHashedAsset(name string) bool {
+	base := path.Base(name)
+	return viteHashPattern.MatchString(base) || webpackHashPattern.MatchString(base)
+}
+
+func acceptsGzip(header string) bool {
+	gzipSpecified := false
+	gzipAccepted := false
+	wildcardAccepted := false
+	for _, value := range strings.Split(header, ",") {
+		parts := strings.Split(value, ";")
+		encoding := strings.TrimSpace(strings.ToLower(parts[0]))
+		if encoding != "gzip" && encoding != "*" {
+			continue
+		}
+		quality := 1.0
+		for _, parameter := range parts[1:] {
+			key, rawValue, found := strings.Cut(strings.TrimSpace(parameter), "=")
+			if !found || !strings.EqualFold(key, "q") {
+				continue
+			}
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(rawValue), 64)
+			if err != nil {
+				quality = 0
+			} else {
+				quality = parsed
+			}
+		}
+		accepted := quality > 0 && quality <= 1
+		if encoding == "gzip" {
+			gzipSpecified = true
+			gzipAccepted = accepted
+		} else {
+			wildcardAccepted = accepted
+		}
+	}
+	if gzipSpecified {
+		return gzipAccepted
+	}
+	return wildcardAccepted
+}
+
+func seekableFile(file fs.File) (io.ReadSeeker, error) {
+	if reader, ok := file.(io.ReadSeeker); ok {
+		return reader, nil
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(data), nil
+}

--- a/server/internal/webentry/handler_test.go
+++ b/server/internal/webentry/handler_test.go
@@ -1,0 +1,430 @@
+package webentry
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHandlerRoutes(t *testing.T) {
+	t.Parallel()
+
+	staticDir := newStaticDir(t)
+	var receivedPath string
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("X-Upstream", "preserved")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, `{"error":"upstream"}`)
+	})
+	handler := mustHandler(t, HandlerConfig{
+		StaticFS:   os.DirFS(staticDir),
+		APIHandler: api,
+	})
+
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		wantStatus  int
+		wantBody    string
+		wantAPIPath string
+	}{
+		{
+			name:       "root serves index",
+			method:     http.MethodGet,
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantBody:   "<main>HAMi WebUI</main>",
+		},
+		{
+			name:       "deep route serves index",
+			method:     http.MethodGet,
+			path:       "/admin/vgpu/monitor/overview",
+			wantStatus: http.StatusOK,
+			wantBody:   "<main>HAMi WebUI</main>",
+		},
+		{
+			name:       "deep route with trailing slash serves index",
+			method:     http.MethodGet,
+			path:       "/admin/vgpu/monitor/overview/",
+			wantStatus: http.StatusOK,
+			wantBody:   "<main>HAMi WebUI</main>",
+		},
+		{
+			name:       "deep route with dotted parameter serves index",
+			method:     http.MethodGet,
+			path:       "/redirect/example.com",
+			wantStatus: http.StatusOK,
+			wantBody:   "<main>HAMi WebUI</main>",
+		},
+		{
+			name:       "existing asset is served",
+			method:     http.MethodGet,
+			path:       "/static/app.js",
+			wantStatus: http.StatusOK,
+			wantBody:   "console.log('app')",
+		},
+		{
+			name:        "api prefix is stripped",
+			method:      http.MethodPost,
+			path:        "/api/vgpu/v1/nodes",
+			wantStatus:  http.StatusTeapot,
+			wantBody:    `{"error":"upstream"}`,
+			wantAPIPath: "/v1/nodes",
+		},
+		{
+			name:       "unknown api is not a frontend route",
+			method:     http.MethodGet,
+			path:       "/api/unknown",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "similar api prefix is not proxied",
+			method:     http.MethodGet,
+			path:       "/api/vgpu-extra/v1/nodes",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "api dot segments cannot reach backend-only paths",
+			method:     http.MethodGet,
+			path:       "/api/vgpu/../metrics",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "api prefix cannot expose backend metrics",
+			method:     http.MethodGet,
+			path:       "/api/vgpu/metrics",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "api prefix cannot expose backend readiness",
+			method:     http.MethodGet,
+			path:       "/api/vgpu/readyz",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "api prefix cannot expose backend documentation",
+			method:     http.MethodGet,
+			path:       "/api/vgpu/q/openapi.yaml",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "unsupported api version is not proxied",
+			method:     http.MethodGet,
+			path:       "/api/vgpu/v2/private",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "missing asset with extension is not index",
+			method:     http.MethodGet,
+			path:       "/static/missing.js",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "missing file below asset directory is not index",
+			method:     http.MethodGet,
+			path:       "/static/missing",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "asset directory is not index",
+			method:     http.MethodGet,
+			path:       "/static/",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+		{
+			name:       "post to frontend route is not index",
+			method:     http.MethodPost,
+			path:       "/admin/vgpu/monitor/overview",
+			wantStatus: http.StatusNotFound,
+			wantBody:   "404 page not found\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedPath = ""
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			response := recorder.Result()
+			defer closeResponseBody(t, response.Body)
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			if response.StatusCode != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", response.StatusCode, tt.wantStatus)
+			}
+			if string(body) != tt.wantBody {
+				t.Errorf("body = %q, want %q", body, tt.wantBody)
+			}
+			if receivedPath != tt.wantAPIPath {
+				t.Errorf("API path = %q, want %q", receivedPath, tt.wantAPIPath)
+			}
+			if tt.wantAPIPath != "" && response.Header.Get("X-Upstream") != "preserved" {
+				t.Errorf("upstream response header was not preserved")
+			}
+			if tt.wantStatus == http.StatusNotFound && response.Header.Get("Cache-Control") != "no-store" {
+				t.Errorf("generated 404 Cache-Control = %q, want no-store", response.Header.Get("Cache-Control"))
+			}
+		})
+	}
+}
+
+func TestHandlerDoesNotExposeBackendOnlyPaths(t *testing.T) {
+	t.Parallel()
+
+	handler := mustHandler(t, HandlerConfig{StaticFS: os.DirFS(newStaticDir(t))})
+	for _, requestPath := range []string{"/metrics", "/readyz", "/q", "/q/openapi.yaml"} {
+		t.Run(requestPath, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, requestPath, nil))
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+			}
+		})
+	}
+}
+
+func TestHandlerHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	handler := mustHandler(t, HandlerConfig{StaticFS: os.DirFS(newStaticDir(t))})
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(method, "/health_check", nil))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+			}
+			if method == http.MethodGet && recorder.Body.String() != "OK\n" {
+				t.Errorf("body = %q, want %q", recorder.Body.String(), "OK\\n")
+			}
+		})
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/health_check", nil))
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status = %d, want %d", recorder.Code, http.StatusMethodNotAllowed)
+	}
+
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/health_check/", nil))
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("trailing-slash status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandlerCachingAndPrecompressedAssets(t *testing.T) {
+	t.Parallel()
+
+	staticDir := newStaticDir(t)
+	writeFile(t, filepath.Join(staticDir, "static", "app-a1B2c3D4.js"), []byte("plain"))
+	writeFile(t, filepath.Join(staticDir, "static", "app-a1B2c3D4.js.gz"), []byte("compressed"))
+	handler := mustHandler(t, HandlerConfig{StaticFS: os.DirFS(staticDir)})
+
+	tests := []struct {
+		name             string
+		path             string
+		acceptEncoding   string
+		wantBody         string
+		wantCacheControl string
+		wantEncoding     string
+	}{
+		{
+			name:             "index is revalidated",
+			path:             "/",
+			wantBody:         "<main>HAMi WebUI</main>",
+			wantCacheControl: "no-cache",
+		},
+		{
+			name:             "hashed asset uses gzip and immutable cache",
+			path:             "/static/app-a1B2c3D4.js",
+			acceptEncoding:   "br, gzip",
+			wantBody:         "compressed",
+			wantCacheControl: "public, max-age=31536000, immutable",
+			wantEncoding:     "gzip",
+		},
+		{
+			name:             "gzip q zero serves the original",
+			path:             "/static/app-a1B2c3D4.js",
+			acceptEncoding:   "gzip;q=0, br",
+			wantBody:         "plain",
+			wantCacheControl: "public, max-age=31536000, immutable",
+		},
+		{
+			name:             "explicit gzip rejection overrides wildcard",
+			path:             "/static/app-a1B2c3D4.js",
+			acceptEncoding:   "*;q=1, gzip;q=0",
+			wantBody:         "plain",
+			wantCacheControl: "public, max-age=31536000, immutable",
+		},
+		{
+			name:             "unhashed asset is revalidated",
+			path:             "/static/app.js",
+			wantBody:         "console.log('app')",
+			wantCacheControl: "no-cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+			}
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+
+			response := recorder.Result()
+			defer closeResponseBody(t, response.Body)
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+			}
+			if string(body) != tt.wantBody {
+				t.Errorf("body = %q, want %q", body, tt.wantBody)
+			}
+			if got := response.Header.Get("Cache-Control"); got != tt.wantCacheControl {
+				t.Errorf("Cache-Control = %q, want %q", got, tt.wantCacheControl)
+			}
+			if got := response.Header.Get("Content-Encoding"); got != tt.wantEncoding {
+				t.Errorf("Content-Encoding = %q, want %q", got, tt.wantEncoding)
+			}
+			if tt.wantEncoding != "" && !strings.Contains(response.Header.Get("Vary"), "Accept-Encoding") {
+				t.Errorf("Vary = %q, want Accept-Encoding", response.Header.Get("Vary"))
+			}
+			if strings.HasSuffix(tt.path, ".js") && !strings.Contains(response.Header.Get("Content-Type"), "javascript") {
+				t.Errorf("Content-Type = %q, want JavaScript", response.Header.Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestHandlerHeadAssetHasHeadersAndNoBody(t *testing.T) {
+	t.Parallel()
+
+	staticDir := newStaticDir(t)
+	writeFile(t, filepath.Join(staticDir, "static", "app-a1B2c3D4.js"), []byte("plain"))
+	handler := mustHandler(t, HandlerConfig{StaticFS: os.DirFS(staticDir)})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodHead, "/static/app-a1B2c3D4.js", nil))
+
+	response := recorder.Result()
+	defer closeResponseBody(t, response.Body)
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if len(body) != 0 {
+		t.Errorf("HEAD body = %q, want empty", body)
+	}
+	if got := response.Header.Get("Cache-Control"); got != immutableCache {
+		t.Errorf("Cache-Control = %q, want %q", got, immutableCache)
+	}
+	if response.Header.Get("Content-Length") == "" {
+		t.Error("HEAD response is missing Content-Length")
+	}
+}
+
+func closeResponseBody(t *testing.T, body io.Closer) {
+	t.Helper()
+	if err := body.Close(); err != nil {
+		t.Errorf("close response body: %v", err)
+	}
+}
+
+func TestNewHandlerRequiresIndex(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewHandler(HandlerConfig{StaticFS: os.DirFS(t.TempDir())}); err == nil {
+		t.Fatal("NewHandler succeeded without index.html")
+	}
+}
+
+func TestHandlerForwardsRequestBodyAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	requestBody := []byte(`{"filters":{"name":"worker"}}`)
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read API body: %v", err)
+		}
+		if !bytes.Equal(body, requestBody) {
+			t.Errorf("body = %q, want %q", body, requestBody)
+		}
+		if got := r.Header.Get("X-Hami-Probe"); got != "preserved" {
+			t.Errorf("X-Hami-Probe = %q, want preserved", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := mustHandler(t, HandlerConfig{
+		StaticFS:   os.DirFS(newStaticDir(t)),
+		APIHandler: api,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/vgpu/v1/nodes?limit=10", bytes.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hami-Probe", "preserved")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func mustHandler(t *testing.T, config HandlerConfig) http.Handler {
+	t.Helper()
+	handler, err := NewHandler(config)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return handler
+}
+
+func newStaticDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "index.html"), []byte("<main>HAMi WebUI</main>"))
+	writeFile(t, filepath.Join(dir, "static", "app.js"), []byte("console.log('app')"))
+	return dir
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/server/internal/webentry/proxy.go
+++ b/server/internal/webentry/proxy.go
@@ -1,0 +1,127 @@
+package webentry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+// ReverseProxyConfig defines an internal backend proxy. ReportError is optional
+// and is called for transport failures without receiving the browser request,
+// preventing request URLs, queries and bodies from entering logs by accident.
+type ReverseProxyConfig struct {
+	Target      *url.URL
+	Timeout     time.Duration
+	ReportError func(ProxyFailure)
+}
+
+// ProxyFailure is the bounded diagnostic passed to ReportError.
+type ProxyFailure struct {
+	Status int
+	Class  string
+	Err    error
+}
+
+// NewReverseProxy creates a reverse proxy with a request-wide upstream
+// deadline. Upstream HTTP status codes and response bodies pass through
+// unchanged; transport failures are represented as 502 or 504 JSON responses.
+func NewReverseProxy(config ReverseProxyConfig) (http.Handler, error) {
+	target := config.Target
+	timeout := config.Timeout
+	if target == nil || target.Host == "" || (target.Scheme != "http" && target.Scheme != "https") {
+		return nil, errors.New("backend URL must be an absolute HTTP URL")
+	}
+	if target.User != nil {
+		return nil, errors.New("backend URL must not contain credentials")
+	}
+	if target.Fragment != "" {
+		return nil, errors.New("backend URL must not contain a fragment")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("proxy timeout must be positive")
+	}
+
+	target = cloneURL(target)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	director := proxy.Director
+	proxy.Director = func(request *http.Request) {
+		director(request)
+		request.Host = target.Host
+	}
+	proxy.ErrorLog = log.New(io.Discard, "", 0)
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		if isTimeoutError(err) {
+			reportProxyFailure(config.ReportError, http.StatusGatewayTimeout, "timeout", err)
+			writeProxyError(w, http.StatusGatewayTimeout, "GATEWAY_TIMEOUT", "backend request timed out")
+			return
+		}
+		reportProxyFailure(config.ReportError, http.StatusBadGateway, "transport", err)
+		writeProxyError(w, http.StatusBadGateway, "BAD_GATEWAY", "backend unavailable")
+	}
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = transport.Clone()
+		// The backend is an explicitly configured internal endpoint. Do not let
+		// ambient HTTP_PROXY settings reroute same-Pod API traffic.
+		transport.Proxy = nil
+		transport.DialContext = (&net.Dialer{
+			Timeout:   minDuration(timeout, 10*time.Second),
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+		transport.ResponseHeaderTimeout = timeout
+		transport.TLSHandshakeTimeout = minDuration(timeout, 10*time.Second)
+		transport.MaxIdleConnsPerHost = 32
+		proxy.Transport = transport
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		proxy.ServeHTTP(w, r.WithContext(ctx))
+	}), nil
+}
+
+func reportProxyFailure(report func(ProxyFailure), status int, class string, err error) {
+	if report != nil {
+		report(ProxyFailure{Status: status, Class: class, Err: err})
+	}
+}
+
+type proxyError struct {
+	Code    int    `json:"code"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+func writeProxyError(w http.ResponseWriter, status int, reason, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(proxyError{Code: status, Reason: reason, Message: message})
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netError net.Error
+	return errors.As(err, &netError) && netError.Timeout()
+}
+
+func cloneURL(target *url.URL) *url.URL {
+	clone := *target
+	return &clone
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/server/internal/webentry/proxy_test.go
+++ b/server/internal/webentry/proxy_test.go
@@ -1,0 +1,168 @@
+package webentry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReverseProxyPreservesUpstreamResponse(t *testing.T) {
+	t.Parallel()
+
+	var wantHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/nodes" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/v1/nodes")
+		}
+		if r.Host != wantHost {
+			t.Errorf("Host = %q, want %q", r.Host, wantHost)
+		}
+		w.Header().Set("X-Upstream", "preserved")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid request"}`)
+	}))
+	t.Cleanup(backend.Close)
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	wantHost = backendURL.Host
+
+	proxy := mustReverseProxy(t, backend.URL, time.Second, nil)
+	recorder := httptest.NewRecorder()
+	proxy.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/nodes", nil))
+
+	response := recorder.Result()
+	defer closeResponseBody(t, response.Body)
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", response.StatusCode, http.StatusBadRequest)
+	}
+	if response.Header.Get("X-Upstream") != "preserved" {
+		t.Errorf("upstream response header was not preserved")
+	}
+	if string(body) != `{"error":"invalid request"}` {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestReverseProxyMapsConnectionFailureToBadGateway(t *testing.T) {
+	t.Parallel()
+
+	// TCP port zero cannot have a listening service, making the connection
+	// failure deterministic without a close-and-rebind race in this test.
+	var failure ProxyFailure
+	proxy := mustReverseProxy(t, "http://127.0.0.1:0", time.Second, func(got ProxyFailure) {
+		failure = got
+	})
+	recorder := httptest.NewRecorder()
+	proxy.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/nodes", nil))
+
+	assertProxyError(t, recorder.Result(), http.StatusBadGateway, "BAD_GATEWAY")
+	if failure.Status != http.StatusBadGateway || failure.Class != "transport" || failure.Err == nil {
+		t.Errorf("reported failure = %+v", failure)
+	}
+}
+
+func TestReverseProxyMapsUpstreamTimeoutToGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	requestCancelled := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		close(requestCancelled)
+	}))
+	t.Cleanup(backend.Close)
+
+	var failure ProxyFailure
+	proxy := mustReverseProxy(t, backend.URL, 50*time.Millisecond, func(got ProxyFailure) {
+		failure = got
+	})
+	recorder := httptest.NewRecorder()
+	proxy.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/slow", nil))
+
+	assertProxyError(t, recorder.Result(), http.StatusGatewayTimeout, "GATEWAY_TIMEOUT")
+	if failure.Status != http.StatusGatewayTimeout || failure.Class != "timeout" || failure.Err == nil {
+		t.Errorf("reported failure = %+v", failure)
+	}
+	select {
+	case <-requestCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("upstream request context was not cancelled")
+	}
+}
+
+func TestNewReverseProxyRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		target  *url.URL
+		timeout time.Duration
+	}{
+		{name: "nil target", timeout: time.Second},
+		{name: "missing scheme", target: &url.URL{Host: "backend:8000"}, timeout: time.Second},
+		{name: "unsupported scheme", target: &url.URL{Scheme: "file", Path: "/tmp/backend"}, timeout: time.Second},
+		{name: "credentials", target: &url.URL{Scheme: "http", Host: "backend:8000", User: url.UserPassword("user", "secret")}, timeout: time.Second},
+		{name: "zero timeout", target: &url.URL{Scheme: "http", Host: "backend:8000"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewReverseProxy(ReverseProxyConfig{Target: tt.target, Timeout: tt.timeout}); err == nil {
+				t.Fatal("NewReverseProxy succeeded, want error")
+			}
+		})
+	}
+}
+
+func mustReverseProxy(t *testing.T, rawURL string, timeout time.Duration, report func(ProxyFailure)) http.Handler {
+	t.Helper()
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	proxy, err := NewReverseProxy(ReverseProxyConfig{
+		Target:      target,
+		Timeout:     timeout,
+		ReportError: report,
+	})
+	if err != nil {
+		t.Fatalf("NewReverseProxy: %v", err)
+	}
+	return proxy
+}
+
+func assertProxyError(t *testing.T, response *http.Response, wantStatus int, wantReason string) {
+	t.Helper()
+	defer closeResponseBody(t, response.Body)
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != wantStatus {
+		t.Errorf("status = %d, want %d", response.StatusCode, wantStatus)
+	}
+	if contentType := response.Header.Get("Content-Type"); !strings.Contains(contentType, "application/json") {
+		t.Errorf("Content-Type = %q, want JSON", contentType)
+	}
+	if !strings.Contains(string(body), `"reason":"`+wantReason+`"`) {
+		t.Errorf("body = %q, want reason %q", body, wantReason)
+	}
+}
+
+func TestTimeoutErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	if !isTimeoutError(context.DeadlineExceeded) {
+		t.Fatal("context deadline should be classified as a timeout")
+	}
+}

--- a/server/internal/webentry/server.go
+++ b/server/internal/webentry/server.go
@@ -1,0 +1,97 @@
+package webentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultReadHeaderTimeout = 5 * time.Second
+	defaultReadTimeout       = 30 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+	requestTimeoutMargin     = 5 * time.Second
+	defaultMaxHeaderBytes    = 1 << 20
+)
+
+// ErrShutdownTimeout indicates that in-flight requests did not finish within
+// the configured graceful-shutdown window and were forcefully disconnected.
+var ErrShutdownTimeout = errors.New("graceful shutdown timed out")
+
+// HTTPServerConfig defines the bounded public HTTP server. ProxyTimeout is used
+// to keep the outer HTTP deadline longer than the upstream proxy deadline.
+type HTTPServerConfig struct {
+	Address      string
+	Handler      http.Handler
+	ProxyTimeout time.Duration
+}
+
+// NewHTTPServer constructs an HTTP server with explicit slow-client and idle
+// connection bounds. It does not open a listener.
+func NewHTTPServer(config HTTPServerConfig) (*http.Server, error) {
+	if config.ProxyTimeout <= 0 {
+		return nil, errors.New("proxy timeout must be positive")
+	}
+	const maxDuration = time.Duration(1<<63 - 1)
+	if config.ProxyTimeout > maxDuration-defaultReadTimeout-requestTimeoutMargin {
+		return nil, errors.New("proxy timeout is too large")
+	}
+	handler := config.Handler
+	if handler == nil {
+		handler = http.NotFoundHandler()
+	}
+	writeTimeout := defaultReadTimeout + config.ProxyTimeout + requestTimeoutMargin
+	return &http.Server{
+		Addr:              config.Address,
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		ReadTimeout:       defaultReadTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       defaultIdleTimeout,
+		MaxHeaderBytes:    defaultMaxHeaderBytes,
+	}, nil
+}
+
+// Serve runs server on listener until the server exits or ctx is cancelled.
+// Cancellation performs graceful shutdown and force-closes connections after
+// shutdownTimeout, ensuring SIGTERM handling remains bounded.
+func Serve(ctx context.Context, server *http.Server, listener net.Listener, shutdownTimeout time.Duration) error {
+	if server == nil || listener == nil {
+		return errors.New("server and listener are required")
+	}
+	if shutdownTimeout <= 0 {
+		return errors.New("shutdown timeout must be positive")
+	}
+
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- server.Serve(listener)
+	}()
+
+	select {
+	case err := <-serveResult:
+		return normalizeServeError(err)
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
+			<-serveResult
+			if errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("%w after %s", ErrShutdownTimeout, shutdownTimeout)
+			}
+			return fmt.Errorf("shut down HTTP server: %w", err)
+		}
+		return normalizeServeError(<-serveResult)
+	}
+}
+
+func normalizeServeError(err error) error {
+	if err == nil || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return fmt.Errorf("serve HTTP: %w", err)
+}

--- a/server/internal/webentry/server_test.go
+++ b/server/internal/webentry/server_test.go
@@ -1,0 +1,152 @@
+package webentry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServerUsesBoundedTimeouts(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Address:      ":3000",
+		Handler:      http.NotFoundHandler(),
+		ProxyTimeout: 65 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+
+	if server.ReadHeaderTimeout <= 0 || server.ReadTimeout <= 0 || server.WriteTimeout <= 0 || server.IdleTimeout <= 0 {
+		t.Fatalf("server timeouts must be bounded: %+v", server)
+	}
+	if server.WriteTimeout <= 65*time.Second {
+		t.Errorf("WriteTimeout = %s, must exceed proxy timeout", server.WriteTimeout)
+	}
+	if server.MaxHeaderBytes <= 0 {
+		t.Errorf("MaxHeaderBytes = %d, want positive limit", server.MaxHeaderBytes)
+	}
+}
+
+func TestServeShutsDownGracefully(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		_, _ = io.WriteString(w, "done")
+	})
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Handler:      handler,
+		ProxyTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- Serve(ctx, server, listener, time.Second)
+	}()
+
+	responseResult := make(chan error, 1)
+	go func() {
+		response, err := http.Get("http://" + listener.Addr().String())
+		if err == nil {
+			defer closeResponseBody(t, response.Body)
+			_, err = io.ReadAll(response.Body)
+		}
+		responseResult <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach server")
+	}
+
+	cancel()
+	select {
+	case err := <-serveResult:
+		t.Fatalf("Serve returned before in-flight request completed: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(releaseRequest)
+
+	if err := <-responseResult; err != nil {
+		t.Fatalf("in-flight request failed: %v", err)
+	}
+	if err := <-serveResult; err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}
+
+func TestServeBoundsGracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	})
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Handler:      handler,
+		ProxyTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- Serve(ctx, server, listener, 30*time.Millisecond)
+	}()
+	clientResult := make(chan struct{})
+	go func() {
+		response, err := http.Get("http://" + listener.Addr().String())
+		if err == nil {
+			_ = response.Body.Close()
+		}
+		close(clientResult)
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach server")
+	}
+
+	cancel()
+	err = <-serveResult
+	if !errors.Is(err, ErrShutdownTimeout) {
+		t.Fatalf("Serve error = %v, want ErrShutdownTimeout", err)
+	}
+	close(releaseRequest)
+	select {
+	case <-clientResult:
+	case <-time.After(time.Second):
+		t.Fatal("client did not return after forced close")
+	}
+}
+
+func TestNewHTTPServerRejectsInvalidProxyTimeout(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewHTTPServer(HTTPServerConfig{}); err == nil {
+		t.Fatal("NewHTTPServer succeeded with zero proxy timeout")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Introduces the standard-library Go Web entry selected in #165, before changing the production frontend image or Helm deployment.

It provides:

- SPA and static-file delivery with explicit fallback, cache, and gzip behavior;
- an allowlisted `/api/vgpu/v1/*` reverse proxy that preserves HTTP semantics;
- bounded server and proxy timeouts, 502/504 responses, and graceful shutdown;
- a standalone health check with environment and flag configuration.

Backend-only `/metrics`, `/readyz`, and `/q` routes are not exposed through the public entry. This PR is intentionally additive: Docker and Chart defaults remain unchanged. A follow-up will switch the frontend runtime after this foundation is merged.

**Verification:**

- `go test ./...`
- `go test -race ./internal/webentry ./cmd/web-entry`
- `go vet ./...`
- static linux/amd64 and linux/arm64 builds and container contract smoke tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web entry service that serves the SPA and proxies same-origin API requests.
  * Added configurable listener, backend, static asset, timeout, and health-check settings.
  * Added SPA fallback routing, compressed asset support, caching headers, and health-check endpoints.
  * Added graceful shutdown with bounded timeouts and clear responses for upstream failures.

* **Bug Fixes**
  * Improved validation for URLs, paths, configuration, and unsupported requests.
  * Prevented credentials from appearing in configuration or startup errors.

* **Tests**
  * Added comprehensive coverage for routing, proxying, health checks, timeouts, shutdown, caching, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->