### PR TITLE
feat: switch frontend runtime to Go Web entry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,8 @@ packages/*/node_modules
 # Build outputs
 dist
 packages/*/dist
+/public
+server/build
 coverage
 .nyc_output
 
@@ -50,22 +52,20 @@ jest.config.*
 .eslintrc.*
 .prettierrc.*
 
-# Server (backend is built separately)
-server
-
 # Charts
 charts
 
-# Scripts (not needed in production)
-scripts
+# Only the Web-asset build helper is part of the frontend image context.
+scripts/*
+!scripts/precompress-web-assets.mjs
 
 # Temporary files
 tmp
 *.tmp
 *.temp
 
-# Environment files (should be provided at runtime)
+# Ignore local environment files but keep the committed Vite production defaults.
 .env
 .env.*
 !.env.example
-
+!packages/web/.env.production

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,16 +47,93 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
+  frontend-runtime-smoke:
+    name: Smoke frontend image runtime (${{ matrix.arch }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+          - arch: arm64
+            platform: linux/arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build frontend image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: hami-webui-frontend:runtime-smoke-${{ matrix.arch }}
+          cache-from: type=gha,scope=frontend-runtime-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=frontend-runtime-${{ matrix.arch }}
+
+      - name: Verify non-root read-only runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          image=hami-webui-frontend:runtime-smoke-${{ matrix.arch }}
+          container=hami-webui-frontend-runtime-smoke-${{ matrix.arch }}
+          curl_local=(curl --noproxy '*')
+          trap 'docker rm --force "${container}" >/dev/null 2>&1 || true' EXIT
+
+          [[ "$(docker image inspect --format '{{.Config.User}}' "${image}")" == "65532:65532" ]]
+          docker run --detach \
+            --platform '${{ matrix.platform }}' \
+            --name "${container}" \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --publish 127.0.0.1::3000 \
+            "${image}"
+
+          port="$(docker port "${container}" 3000/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
+          for _ in {1..30}; do
+            if "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/health_check" >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/health_check" >/dev/null
+          "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/" | grep -Fq '<div id="app"></div>'
+          [[ "$("${curl_local[@]}" --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}/static/contract-missing.js")" == "404" ]]
+
+          docker stop --time 5 "${container}" >/dev/null
+          [[ "$(docker inspect --format '{{.State.ExitCode}}' "${container}")" == "0" ]]
+
   pr-images-required:
     name: pr-images-required
     if: github.event_name == 'pull_request' && always()
-    needs: validate-images
+    needs:
+      - validate-images
+      - frontend-runtime-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate image build results
         run: |
           if [[ "${{ needs.validate-images.result }}" != "success" ]]; then
             echo "Image builds did not complete successfully: ${{ needs.validate-images.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.frontend-runtime-smoke.result }}" != "success" ]]; then
+            echo "Frontend runtime smoke did not complete successfully: ${{ needs.frontend-runtime-smoke.result }}"
             exit 1
           fi
           echo "All image builds passed."

--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Only run the frontend jobs when frontend sources (the NestJS BFF in src/,
-  # the Vue app in packages/, the workspace manifests) or this workflow change.
+  # Run when the Vue app, legacy Nest code, Go Web entry, or their build and
+  # contract inputs change.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -31,10 +31,18 @@ jobs:
               - 'src/**'
               - 'packages/**'
               - 'package.json'
+              - '.browserslistrc'
+              - '.dockerignore'
               - '.node-version'
               - 'Dockerfile'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'server/.go-version'
+              - 'server/cmd/web-entry/**'
+              - 'server/go.mod'
+              - 'server/go.sum'
+              - 'server/internal/webentry/**'
+              - 'scripts/precompress-web-assets.mjs'
               - 'scripts/verify-toolchain-versions.sh'
               - 'scripts/verify-vite-env-boundary.mjs'
               - 'test/web-entry/**'
@@ -55,6 +63,10 @@ jobs:
         with:
           node-version-file: .node-version
           cache: pnpm
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: server/.go-version
+          cache-dependency-path: server/go.sum
       - name: Verify toolchain versions
         run: bash scripts/verify-toolchain-versions.sh
       - name: Install dependencies
@@ -63,6 +75,11 @@ jobs:
         run: pnpm run build
       - name: Build web and verify environment boundary
         run: pnpm run verify:vite-env
+      - name: Pre-compress Web assets
+        run: pnpm run precompress:web-assets
+      - name: Build Go Web entry
+        working-directory: server
+        run: mkdir -p build && GOTOOLCHAIN=local go build -mod=readonly -trimpath -o build/web-entry ./cmd/web-entry
       - name: Test Web-entry contract
         run: pnpm run test:web-entry-contract
       - name: Test web
@@ -89,7 +106,7 @@ jobs:
       # structured-clone polyfill that is not committed to the repo; run ESLint
       # directly in check mode (the supported Node runtime has structuredClone).
       - name: Lint BFF
-        run: pnpm exec eslint "{src,apps,libs,test}/**/*.ts" "test/web-entry/**/*.mjs"
+        run: pnpm exec eslint "{src,apps,libs,test}/**/*.ts" "test/web-entry/**/*.mjs" "scripts/precompress-web-assets.mjs"
       - name: Lint web
         run: pnpm --filter hami-webui-web run lint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,60 @@
-FROM --platform=$BUILDPLATFORM node:24.20.0-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2 AS builder
+FROM --platform=$BUILDPLATFORM node:24.20.0-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2 AS web-builder
 
 WORKDIR /src
 
 # Enable corepack to use pnpm version from package.json packageManager field
 RUN corepack enable
 
-# Copy dependency files for better layer caching
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Copy dependency manifests before application sources so source-only changes
+# can reuse the dependency layer.
+COPY .browserslistrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/web/package.json packages/web/
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --filter hami-webui-web...
 
-# Copy source code
-COPY . .
+COPY packages/web/ packages/web/
+COPY scripts/precompress-web-assets.mjs scripts/precompress-web-assets.mjs
 
-# Build application
-RUN make build-bff build-web
+# Build the browser application. Node.js is a build-time dependency only; the
+# production image runs the Go Web entry below.
+RUN pnpm --filter hami-webui-web run build
 
-# Remove devDependencies to reduce image size (only keep production dependencies)
-RUN CI=true pnpm prune --prod
+# Pre-compress immutable browser assets once at build time. The Web entry serves
+# these siblings when the client advertises gzip support.
+RUN pnpm run precompress:web-assets
 
-# Clean pnpm store cache to reduce image size
-RUN pnpm store prune
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:e8c859f5632dcfde7b32d2012b4351728f6437930887c2f6a91ea242459e5514 AS web-entry-builder
 
-FROM node:24.20.0-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e
+WORKDIR /src/server
 
-# Set production environment
-ENV NODE_ENV=production
+ARG TARGETOS=linux
+ARG TARGETARCH
 
-# Create app directory and non-root user for security
+COPY server/go.mod server/go.sum ./
+COPY server/cmd/web-entry/ ./cmd/web-entry/
+COPY server/internal/webentry/ ./internal/webentry/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOTOOLCHAIN=local \
+    go build -mod=readonly -trimpath -o /out/web-entry ./cmd/web-entry
+
+FROM scratch
+
 WORKDIR /apps
-RUN groupadd -r appuser && useradd -r -g appuser appuser
 
-# Copy built artifacts from builder stage
-COPY --from=builder --chown=appuser:appuser /src/dist/ ./dist/
-COPY --from=builder --chown=appuser:appuser /src/node_modules/ ./node_modules/
-COPY --from=builder --chown=appuser:appuser /src/public/ ./public/
+# Keep HTTPS proxy targets and the existing TZ environment extension point
+# functional without carrying a production Linux package layer.
+COPY --from=web-entry-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=web-entry-builder /usr/share/zoneinfo/ /usr/share/zoneinfo/
+COPY --from=web-entry-builder --chown=65532:65532 /out/web-entry /apps/web-entry
+COPY --from=web-builder --chown=65532:65532 /src/public/ /apps/public/
 
-# Switch to non-root user
-USER appuser
+USER 65532:65532
 
-# Expose port
 EXPOSE 3000
 
-# Health check using the application's health_check endpoint
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/health_check', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
+  CMD ["/apps/web-entry", "--healthcheck"]
 
-# Start application
-CMD ["node", "dist/main"]
+ENTRYPOINT ["/apps/web-entry"]

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -55,6 +55,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | dcgm-exporter.serviceMonitor.interval | string | `"15s"`                                                                            |  |
 | externalPrometheus.address | string | `"http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"` |  |
 | externalPrometheus.enabled | bool | `false`                                                                            |  |
+| frontend.livenessProbe.enabled | bool | `true` | Enable the Web-entry liveness probe. |
+| frontend.livenessProbe.failureThreshold | int | `6` |  |
+| frontend.livenessProbe.initialDelaySeconds | int | `5` |  |
+| frontend.livenessProbe.periodSeconds | int | `10` |  |
+| frontend.livenessProbe.timeoutSeconds | int | `3` |  |
+| frontend.proxyTimeout | string | `"65s"` | End-to-end backend proxy timeout; keep this longer than `backend.http.timeout`. |
+| frontend.readinessProbe.enabled | bool | `true` | Enable the Web-entry readiness probe. |
+| frontend.readinessProbe.failureThreshold | int | `3` |  |
+| frontend.readinessProbe.initialDelaySeconds | int | `1` |  |
+| frontend.readinessProbe.periodSeconds | int | `5` |  |
+| frontend.readinessProbe.timeoutSeconds | int | `3` |  |
 | fullnameOverride | string | `""`                                                                               |  |
 | hamiServiceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
 | hamiServiceMonitor.enabled | bool | `true`                                                                             |  |

--- a/charts/hami-webui/templates/deployment.yaml
+++ b/charts/hami-webui/templates/deployment.yaml
@@ -1,4 +1,11 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.podAnnotations) (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)) -}}
+{{- $frontendEnv := default (list) .Values.env.frontend -}}
+{{- $frontendProxyTimeoutOverridden := false -}}
+{{- range $frontendEnv -}}
+{{- if eq (get . "name") "HAMI_WEBUI_PROXY_TIMEOUT" -}}
+{{- $frontendProxyTimeoutOverridden = true -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,15 +38,43 @@ spec:
           image: {{ include "hami-webui.image" (dict "name" "frontend" "image" .Values.image.frontend "appVersion" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
           env:
-            {{- toYaml .Values.env.frontend | nindent 12 }}
+            {{- if not $frontendProxyTimeoutOverridden }}
+            - name: HAMI_WEBUI_PROXY_TIMEOUT
+              value: {{ default "65s" (get (default (dict) .Values.frontend) "proxyTimeout") | quote }}
+            {{- end }}
+            {{- with $frontendEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
-          command:
-            - "node"
-          args:
-            - "/apps/dist/main"
+          {{- with .Values.frontend }}
+          {{- with .livenessProbe }}
+          {{- if .enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health_check
+              port: http
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
+          {{- with .readinessProbe }}
+          {{- if .enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health_check
+              port: http
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources.frontend | nindent 12 }}
         - name: {{ .Chart.Name }}-be-oss

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -177,6 +177,28 @@ externalPrometheus:
   # Single PromQL upstream timeout (sent to Prometheus / VictoriaMetrics as the &timeout= parameter).
   timeout: "1m"
 
+# Web-entry runtime settings and health probes. The probes report the frontend
+# container's own health; backend readiness is gated separately below.
+frontend:
+  # Keep this longer than backend.http.timeout so the backend owns normal API
+  # deadline responses. The previous Node frontend safely ignores this value.
+  proxyTimeout: "65s"
+  # /health_check reports whether the Web entry itself can serve traffic. It is
+  # intentionally independent from backend readiness; the backend probe below
+  # still keeps the Pod out of Service endpoints until informer caches sync.
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 6
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
+
 # Kratos server timeouts. These bound the deadline placed on each incoming HTTP/gRPC
 # request context. They no longer affect /metrics generation (which runs in the background),
 # but they still gate the page-side APIs, some of which legitimately take a few seconds
@@ -188,8 +210,8 @@ backend:
     timeout: "60s"
   # Readiness probe on the backend's /readyz. The backend only starts listening
   # after its k8s informer caches have synced, so gating the pod on /readyz keeps
-  # it out of the Service until the backend can serve — this prevents the frontend
-  # BFF from hitting "connection refused" against the not-yet-listening backend
+  # it out of the Service until the backend can serve — this prevents the Web entry
+  # from hitting "connection refused" against the not-yet-listening backend
   # during startup. failureThreshold * periodSeconds should comfortably exceed the
   # worst-case informer sync time on a large cluster.
   readinessProbe:

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -7,8 +7,9 @@ This guide helps you get started developing HAMi-WebUI.
 Make sure you have the following dependencies installed before setting up your developer environment:
 
 - [Git](https://git-scm.com/)
-- [Go](https://golang.org/dl/) (see [go.mod](../../server/go.mod) for minimum required version)
-- [Node.js](https://nodejs.org/), [Vue.js](https://vuejs.org/), [Element-UI](https://element.eleme.cn/)
+- [Go](https://golang.org/dl/) (use the version in [`server/.go-version`](../../server/.go-version))
+- [Node.js](https://nodejs.org/) (use the version in [`.node-version`](../../.node-version))
+- [pnpm](https://pnpm.io/) (use the version in the root `package.json`)
 
 
 ### macOS
@@ -18,7 +19,8 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 ```
 brew install git
 brew install go
-brew install node@20
+brew install node@24
+corepack enable
 ```
 
 ## Download HAMi-WebUI
@@ -32,10 +34,15 @@ For alternative ways of cloning the HAMi-WebUI repository, refer to [GitHub's do
 
 ## Build HAMi-WebUI
 
-When building HAMi-WebUI, be aware that it consists of two components:
+The Chart 1.x deployment consists of two containers:
 
-- The _backend_.
-- The _frontend_.
+- the Go API and metrics backend; and
+- the Web entry, which serves the built Vue application and proxies
+  `/api/vgpu/v1/*` to the backend.
+
+Node.js is required to build the Vue application. The frontend image built from
+this revision uses Go at runtime; the previous official Node image remains
+supported for Chart 1.x rollback.
 
 ### Backend
 
@@ -45,25 +52,84 @@ By default, you can access the web-ui-server-swagger at `http://localhost:8000/q
 
 ### Frontend
 
-Build and run the frontend by running `make start-dev` in the `root` directory of the repository. This command installs the related dependencies and starts a bff server and a frontend server.
+For browser development, run `make start-dev` in the repository root. This
+starts the Vite development server and the legacy development proxy.
 
 By default, you can access the web-ui at `http://localhost:3000/`.
+
+To exercise the production Web entry locally:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter hami-webui-web run build
+pnpm run precompress:web-assets
+(cd server && mkdir -p build && go build -trimpath -o build/web-entry ./cmd/web-entry)
+server/build/web-entry --static-dir ./public
+```
+
+The backend must be available at `http://127.0.0.1:8000` for API requests.
+
+### Chart 1.x frontend image contract
+
+The frontend image owns its OCI entrypoint; the Chart does not inject a
+Node-specific command. A compatible custom image must:
+
+- listen on port `3000`;
+- return HTTP 200 from `/health_check` without depending on backend readiness;
+- serve the SPA and its static assets;
+- forward `/api/vgpu/v1/*` to the backend while preserving HTTP status codes;
+  and
+- terminate cleanly on `SIGTERM`.
+
+The new official Go image additionally runs as a numeric non-root user and is
+verified with a read-only root filesystem in CI. Those are official-image
+security gates, not new requirements retroactively imposed on the previous
+official image.
+
+The new official Go Web entry exposes only the versioned HAMi Web API through
+the same-origin entry. Backend-only `/metrics`, `/readyz`, and `/q` endpoints
+remain available only on the backend listener for internal diagnostics and
+scraping. Pinning the previous Node-based official image restores its legacy
+wildcard `/api/vgpu/*` proxy and HTTP 200 / `code: 599` proxy-error behavior;
+that rollback path does not provide the new routing or error guarantees. The
+legacy process may also require forced termination when the Pod's termination
+grace period expires.
+
+The official Go Web entry also accepts these optional environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HAMI_WEBUI_LISTEN_ADDRESS` | `:3000` | Standalone Web listener; Chart 1.x requires `:3000` |
+| `HAMI_WEBUI_BACKEND_URL` | `http://127.0.0.1:8000` | Backend origin |
+| `HAMI_WEBUI_STATIC_DIR` | `/apps/public` | Built Vue asset directory |
+| `HAMI_WEBUI_PROXY_TIMEOUT` | `65s` | End-to-end backend request timeout; keep it longer than `backend.http.timeout` |
+| `HAMI_WEBUI_HEALTHCHECK_URL` | `http://127.0.0.1:3000/health_check` | Target used only by `--healthcheck` |
+
+The public port, health endpoint, and versioned API prefix are compatibility
+contracts.
+Filesystem paths and executable names inside the image are not.
+
+Chart 1.x currently serves the WebUI at the site root. Runtime base-path and
+configurable iframe framing support are tracked as the next compatibility
+increment and are not part of this container revision.
 
 ## Build a Docker image
 
 To build a HAMi-WebUI Frontend Docker image, run:
 
 ```
-make build-image DOCKER_IMAGE=projecthami/hami-webui-fe VERSION=dev
+make build-image DOCKER_IMAGE=projecthami/hami-webui-fe-oss VERSION=dev
 ```
 
-The resulting image will be tagged as `projecthami/hami-webui-fe:dev`.
+The resulting image will be tagged as `projecthami/hami-webui-fe-oss:dev`. It
+contains the Go Web entry and built Vue assets, but no production Node.js
+runtime.
 
 
-To build a HAMi-WebUI Backend Docker image, run:
+To build a HAMi-WebUI Backend Docker image, run from the repository root:
 
 ```
-make build-image DOCKER_IMAGE=projecthami/hami-webui-be VERSION=dev
+make -C server build-image DOCKER_IMAGE=projecthami/hami-webui-be-oss VERSION=dev
 ```
 
-The resulting image will be tagged as `projecthami/hami-webui-be:dev`.
+The resulting image will be tagged as `projecthami/hami-webui-be-oss:dev`.

--- a/docs/proposals/web-entry-and-embedding.md
+++ b/docs/proposals/web-entry-and-embedding.md
@@ -129,8 +129,8 @@ verified.
 ### Chart 1.x Web Gateway
 
 Chart 1.x will continue to deploy separate frontend and backend containers.
-The frontend container will use a minimal Nginx, Caddy, or equivalent Gateway
-instead of a production NestJS runtime.
+The frontend container will use the standard-library Go Web entry selected by
+the checked-in spike instead of a production NestJS runtime.
 
 The following public contracts remain stable:
 
@@ -138,10 +138,15 @@ The following public contracts remain stable:
   `env.frontend` Helm values;
 - existing `service.*`, `ingress.*`, and security-context configuration;
 - the frontend container port `3000` and configurable Service port;
-- `/api/vgpu/*`;
+- the versioned HAMi Web API below `/api/vgpu/v1/*`;
 - `/health_check` as a frontend-container liveness endpoint;
 - existing SPA routes and Helm upgrade and rollback behavior; and
 - amd64 and arm64 images.
+
+For the new official Go Web entry, the prefix is an allowlisted application API
+contract, not a tunnel to every backend endpoint. Unsupported API versions and
+`/metrics`, `/readyz`, and `/q` remain backend-only even when requested through
+`/api/vgpu`; no browser-facing route exposes them.
 
 The Gateway implementation PR must publish a versioned frontend-container
 contract before changing the default image. At minimum, that contract defines
@@ -156,6 +161,12 @@ the previous official frontend image at the root base path and for custom
 images that implement the published container contract. Both pinning the
 previous official image digest in the new Chart and `helm rollback` to the
 previous Chart must be tested.
+
+The previous Node-based official image retains its legacy wildcard
+`/api/vgpu/*` proxy and HTTP 200 / `code: 599` proxy-error behavior when pinned
+for rollback. Image rollback restores the previous availability contract; it
+does not provide the new allowlist, status-code, caching, static-404, or
+graceful-shutdown guarantees.
 
 The current `/admin` SPA path segment is a legacy route name, not an
 authentication boundary. Canonical route cleanup is separate work and must use
@@ -184,12 +195,14 @@ can be disabled by security-sensitive deployments, and is removed only in Chart
 version 2.0.0. Distinct Service labels must ensure that each Ready backend Pod
 has one scrape target and is not discovered again through the primary Service.
 
-The Gateway implementation will be selected with a small checked-in spike. The
-choice must support a non-root, read-only container; amd64 and arm64; runtime
-base-path and framing configuration; deterministic proxy status codes; and a
-small, actively maintained runtime surface. Technology preference alone is not
-a selection criterion. Proxy timeouts must be explicit and must not be shorter
-than the configured Go HTTP timeout.
+The selected Web entry supports a non-root, read-only container; amd64 and
+arm64; deterministic proxy status codes; and a small standard-library runtime
+surface. The default proxy timeout is explicit and longer than the default
+backend HTTP timeout. Runtime base-path and framing configuration are the next
+increment. In Chart 1.x it uses a reverse-proxy API adapter; Chart 2.0 can reuse
+the same static, routing, cache, compression, and framing handler with the
+in-process API handler. This keeps the compatibility bridge from becoming
+throwaway infrastructure.
 
 NestJS source and dependencies will be deleted only after the minimal Gateway is
 the tested default and rollback through the previous frontend image has been
@@ -197,12 +210,17 @@ verified.
 
 ### Observable contract
 
+The target behavior below applies to the new official Go Web entry. The legacy
+frontend image is tested as a rollback path under its explicitly documented
+legacy semantics.
+
 | Scenario | Required result |
 | --- | --- |
 | `/` and an existing SPA deep link | Serve the SPA at the root or configured base path |
 | Missing static asset | Return HTTP 404; never return `index.html` |
-| Existing `/api/vgpu/*` request | Preserve method, body, relevant headers, response body, and upstream status |
-| Unknown `/api/vgpu/*` request | Preserve the backend's non-2xx JSON response |
+| Existing `/api/vgpu/v1/*` request | Preserve method, query, body, relevant headers, response body, and upstream status |
+| Unknown application request below `/api/vgpu/v1/*` | Preserve the backend's non-2xx JSON response |
+| Unsupported version or backend-only `/metrics`, `/readyz`, or `/q` path, directly or below `/api/vgpu` | Return HTTP 404 without proxying |
 | Backend connection refused / timed out | Return HTTP 502 / 504 with a non-success JSON response |
 | `/health_check` | Return HTTP 200 when the Gateway can serve, independent of backend readiness |
 | `index.html` / hashed asset | No long-lived cache / immutable cache with compression |
@@ -253,16 +271,17 @@ being silently ignored.
    current root SPA, deep-link refresh, API method/body/status forwarding,
    `/health_check`, and current iframe behavior. Do not lock known incorrect
    error or caching behavior into the baseline.
-2. Select and document the minimal Gateway implementation using the acceptance
-   criteria above.
-3. Introduce target-behavior tests together with the Gateway: static 404s,
-   `502`/`504`, caching, compression, root and sub-path deployment, framing
-   allow/deny, probes, security context, and both rollback paths.
-4. Verify Kubernetes install, upgrade, Helm rollback, image rollback, and
-   backend failure recovery in an integration environment.
-5. Delete the unused NestJS runtime and dependencies after parity is established.
-6. Add the internal backend Service and deprecated legacy-port switch with
+2. Introduce the selected Go Web entry at the root path with target-behavior
+   tests for static 404s, `502`/`504`, caching, compression, probes, non-root and
+   read-only execution, and previous-image compatibility.
+3. Add runtime base-path and framing allow/deny behavior as a separate
+   compatibility increment with browser-level embedding tests.
+4. Add the internal backend Service and deprecated legacy-port switch with
    explicit upgrade notes and per-Ready-Pod exactly-once ServiceMonitor tests.
+5. Verify Kubernetes install, upgrade, Helm rollback, image rollback, and
+   backend failure recovery in an integration environment.
+6. Delete the unused NestJS runtime and dependencies after parity and rollback
+   are established, then publish and observe the Chart 1.x transition release.
 7. Treat a single Go image as separate Chart version 2.0.0 work after the
    exploration gates are satisfied.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "NODE_OPTIONS=\"--require ./scripts/structured-clone-polyfill.js\" eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:web-entry-contract": "node --test --test-concurrency=1 test/web-entry/web-entry.contract.test.mjs",
+    "precompress:web-assets": "node scripts/precompress-web-assets.mjs",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/scripts/precompress-web-assets.mjs
+++ b/scripts/precompress-web-assets.mjs
@@ -1,0 +1,36 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { gzip } from 'node:zlib'
+import { promisify } from 'node:util'
+
+const gzipAsync = promisify(gzip)
+const repositoryRoot = path.resolve(import.meta.dirname, '..')
+const outputDirectory = path.join(repositoryRoot, 'public')
+const compressibleExtensions = new Set([
+  '.css',
+  '.html',
+  '.js',
+  '.json',
+  '.svg'
+])
+
+async function listFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(entries.map((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    return entry.isDirectory() ? listFiles(entryPath) : [entryPath]
+  }))
+  return nested.flat()
+}
+
+const files = (await listFiles(outputDirectory)).filter((file) =>
+  compressibleExtensions.has(path.extname(file))
+)
+
+await Promise.all(files.map(async(file) => {
+  const source = await readFile(file)
+  const compressed = await gzipAsync(source, { level: 9 })
+  await writeFile(`${file}.gz`, compressed)
+}))
+
+console.log(`Pre-compressed ${files.length} Web assets.`)

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -110,6 +110,50 @@ tag_render="$(helm template test "${work_dir}/hami-webui" \
   --set-string 'image.backend.digest=')"
 grep -Fq "image: \"projecthami/hami-webui-fe-oss:${expected_tag}\"" <<<"${tag_render}"
 grep -Fq "image: \"projecthami/hami-webui-be-oss:${expected_tag}\"" <<<"${tag_render}"
+frontend_container="$(awk '
+  /^        - name: .*fe-oss$/ { in_frontend = 1 }
+  in_frontend && /^        - name: .*be-oss$/ { exit }
+  in_frontend { print }
+' <<<"${tag_render}")"
+if [[ -z "${frontend_container}" ]] || grep -Eq '^[[:space:]]+(command|args):' <<<"${frontend_container}"; then
+  echo "Chart must leave the frontend image entrypoint and command untouched" >&2
+  exit 1
+fi
+if [[ "$(grep -c 'path: /health_check' <<<"${tag_render}")" -ne 2 ]]; then
+  echo "Frontend liveness and readiness probes were not both rendered" >&2
+  exit 1
+fi
+grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${tag_render}" | grep -Fq 'value: "65s"'
+
+proxy_timeout_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'frontend.proxyTimeout=125s')"
+grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_render}" | grep -Fq 'value: "125s"'
+
+proxy_timeout_env_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'env.frontend[0].name=HAMI_WEBUI_PROXY_TIMEOUT' \
+  --set-string 'env.frontend[0].value=75s')"
+if [[ "$(grep -c 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_env_render}")" -ne 1 ]]; then
+  echo "Explicit frontend proxy-timeout environment override was duplicated" >&2
+  exit 1
+fi
+grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_env_render}" | grep -Fq 'value: 75s'
+
+for empty_frontend_env in '[]' 'null'; do
+  empty_frontend_env_render="$(helm template test "${work_dir}/hami-webui" \
+    --set-json "env.frontend=${empty_frontend_env}")"
+  if [[ "$(grep -c 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${empty_frontend_env_render}")" -ne 1 ]]; then
+    echo "Empty frontend env value did not render exactly one proxy-timeout variable" >&2
+    exit 1
+  fi
+done
+
+probes_disabled_render="$(helm template test "${work_dir}/hami-webui" \
+  --set 'frontend.livenessProbe.enabled=false' \
+  --set 'frontend.readinessProbe.enabled=false')"
+if grep -Fq 'path: /health_check' <<<"${probes_disabled_render}"; then
+  echo "Disabled frontend probes were still rendered" >&2
+  exit 1
+fi
 
 fallback_render="$(helm template test "${work_dir}/hami-webui" \
   --set-string 'image.frontend.tag=' \
@@ -126,6 +170,24 @@ digest_render="$(helm template test "${work_dir}/hami-webui" \
   --set-string "image.backend.digest=${backend_digest}")"
 grep -Fq "image: \"projecthami/hami-webui-fe-oss@${frontend_digest}\"" <<<"${digest_render}"
 grep -Fq "image: \"projecthami/hami-webui-be-oss@${backend_digest}\"" <<<"${digest_render}"
+
+# Chart 1.x must continue to accept the last Node-based frontend image. That
+# image owns `node dist/main` through its OCI entrypoint and command, so the
+# Deployment must not inject process-specific command or args.
+legacy_frontend_digest='sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e'
+legacy_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string "image.frontend.digest=${legacy_frontend_digest}" \
+  --set-string 'image.backend.digest=')"
+grep -Fq "image: \"projecthami/hami-webui-fe-oss@${legacy_frontend_digest}\"" <<<"${legacy_render}"
+legacy_frontend_container="$(awk '
+  /^        - name: .*fe-oss$/ { in_frontend = 1 }
+  in_frontend && /^        - name: .*be-oss$/ { exit }
+  in_frontend { print }
+' <<<"${legacy_render}")"
+if [[ -z "${legacy_frontend_container}" ]] || grep -Eq '^[[:space:]]+(command|args):' <<<"${legacy_frontend_container}"; then
+  echo "Legacy frontend image compatibility was broken by a process override" >&2
+  exit 1
+fi
 
 if helm template test "${work_dir}/hami-webui" \
   --set-string 'image.frontend.digest=not-a-digest' >/dev/null 2>&1; then

--- a/scripts/verify-toolchain-versions.sh
+++ b/scripts/verify-toolchain-versions.sh
@@ -7,7 +7,7 @@ node_version="$(<"${repo_root}/.node-version")"
 go_version="$(<"${repo_root}/server/.go-version")"
 
 grep -Fq "node:${node_version}-bookworm@" "${repo_root}/Dockerfile"
-grep -Fq "node:${node_version}-bookworm-slim@" "${repo_root}/Dockerfile"
+grep -Fq "golang:${go_version}-bookworm@" "${repo_root}/Dockerfile"
 grep -Fq "golang:${go_version}-bookworm@" "${repo_root}/server/Dockerfile"
 
 echo "Toolchain versions match their pinned Docker images."

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -48,7 +48,7 @@ RUN go mod download
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    make generate verify-mod build-linux TARGET_ARCH=${TARGETARCH}
+    make generate verify-mod build-linux TARGET_ARCH=${TARGETARCH} DIRS=server
 
 FROM debian:bookworm-20260824-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 

--- a/test/web-entry/launch-web-entry.mjs
+++ b/test/web-entry/launch-web-entry.mjs
@@ -1,11 +1,24 @@
 import { spawn } from 'node:child_process'
+import path from 'node:path'
 
 // Keep the implementation-specific process command outside the HTTP contract.
 // A future Gateway changes this adapter without rewriting the assertions.
-export function launchWebEntry(cwd) {
-  return spawn(process.execPath, ['dist/main.js'], {
+export function launchWebEntry({
+  cwd,
+  listenAddress,
+  backendURL,
+  staticDir = path.join(cwd, 'public'),
+  proxyTimeout = '150ms',
+  binary = path.join(cwd, 'server', 'build', 'web-entry')
+}) {
+  return spawn(binary, [
+    `--listen-address=${listenAddress}`,
+    `--backend-url=${backendURL}`,
+    `--static-dir=${staticDir}`,
+    `--proxy-timeout=${proxyTimeout}`
+  ], {
     cwd,
-    env: { NODE_ENV: 'production', TZ: 'UTC' },
+    env: { TZ: 'UTC' },
     stdio: ['ignore', 'pipe', 'pipe']
   })
 }

--- a/test/web-entry/web-entry.contract.test.mjs
+++ b/test/web-entry/web-entry.contract.test.mjs
@@ -5,11 +5,12 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { launchWebEntry } from './launch-web-entry.mjs'
 
 const backendAddress = '127.0.0.1'
-const backendPort = 8000
-const frontendURL = 'http://127.0.0.1:3000'
 
 let backend
+let backendPort
 let frontend
+let frontendPort
+let frontendURL
 let frontendLogs = ''
 let lastBackendRequest
 
@@ -57,27 +58,22 @@ async function closeServer(server) {
   }
 }
 
-async function assertPortAvailable(port, host) {
+async function reservePort(host) {
   const probe = http.createServer()
-  try {
-    await listen(probe, port, host)
-  } catch (error) {
-    if (error.code === 'EADDRINUSE') {
-      throw new Error(
-        `Contract test requires ${host ?? 'all interfaces'}:${port} ` +
-        'to be unused; ' +
-        'refusing to test against an unrelated process'
-      )
-    }
-    throw error
-  }
+  await listen(probe, 0, host)
+  const address = probe.address()
+  assert.equal(typeof address, 'object')
   await closeServer(probe)
+  return address.port
 }
 
 async function stopProcess(child) {
-  if (!child || child.exitCode !== null) return
+  if (!child || child.exitCode !== null || child.signalCode !== null) return
 
-  const exited = new Promise((resolve) => child.once('exit', resolve))
+  const exited = new Promise((resolve) => child.once(
+    'exit',
+    (code, signal) => resolve({ code, signal })
+  ))
   child.kill('SIGTERM')
   try {
     await withTimeout(exited, 2_000, 'Web entry ignored SIGTERM')
@@ -97,9 +93,10 @@ function fetchFrontend(path, options = {}) {
 async function waitForFrontend() {
   const deadline = Date.now() + 15_000
   while (Date.now() < deadline) {
-    if (frontend.exitCode !== null) {
+    if (frontend.exitCode !== null || frontend.signalCode !== null) {
       throw new Error(
-        `Web entry exited with code ${frontend.exitCode}.\n${frontendLogs}`
+        `Web entry exited with code ${frontend.exitCode} and signal ` +
+        `${frontend.signalCode}.\n${frontendLogs}`
       )
     }
 
@@ -110,7 +107,7 @@ async function waitForFrontend() {
       await response.arrayBuffer()
       if (response.ok) {
         await delay(25)
-        if (frontend.exitCode === null) return
+        if (frontend.exitCode === null && frontend.signalCode === null) return
       }
     } catch {
       // The process may still be binding the port.
@@ -122,8 +119,11 @@ async function waitForFrontend() {
 }
 
 before(async() => {
-  await assertPortAvailable(3000)
-  await assertPortAvailable(backendPort, backendAddress)
+  frontendPort = await reservePort(backendAddress)
+  do {
+    backendPort = await reservePort(backendAddress)
+  } while (backendPort === frontendPort)
+  frontendURL = `http://${backendAddress}:${frontendPort}`
 
   backend = http.createServer(async(req, res) => {
     const chunks = []
@@ -137,7 +137,27 @@ before(async() => {
       body: Buffer.concat(chunks).toString('utf8')
     }
 
-    if (req.method !== 'POST' || req.url !== '/v1/nodes') {
+    if (
+      req.url === '/metrics' ||
+      req.url === '/readyz' ||
+      req.url === '/q/openapi.yaml' ||
+      req.url === '/v2/private'
+    ) {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('private backend response')
+      return
+    }
+
+    if (req.url === '/v1/contract-timeout') {
+      await delay(500)
+      if (!res.destroyed) {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ delayed: true }))
+      }
+      return
+    }
+
+    if (req.method !== 'POST' || req.url !== '/v1/nodes?limit=10') {
       res.writeHead(404, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ error: 'unexpected contract-test request' }))
       return
@@ -150,11 +170,14 @@ before(async() => {
     res.end(JSON.stringify({ error: 'contract-probe' }))
   })
 
-  frontend = launchWebEntry(process.cwd())
+  frontend = launchWebEntry({
+    cwd: process.cwd(),
+    listenAddress: `${backendAddress}:${frontendPort}`,
+    backendURL: `http://${backendAddress}:${backendPort}`
+  })
   captureFrontendLogs(frontend.stdout)
   captureFrontendLogs(frontend.stderr)
   await waitForFrontend()
-  await listen(backend, backendPort, backendAddress)
 }, { timeout: 20_000 })
 
 after(async() => {
@@ -179,6 +202,16 @@ test('serves the SPA shell at the root and an existing deep link', {
     /text\/html/
   )
   assert.equal(deepLinkBody, rootBody)
+
+  const trailingSlashResponse = await fetchFrontend(
+    '/admin/vgpu/monitor/overview/'
+  )
+  assert.equal(trailingSlashResponse.status, 200)
+  assert.equal(await trailingSlashResponse.text(), rootBody)
+
+  const dottedParameterResponse = await fetchFrontend('/redirect/example.com')
+  assert.equal(dottedParameterResponse.status, 200)
+  assert.equal(await dottedParameterResponse.text(), rootBody)
 })
 
 test('keeps the Chart 1.x unrestricted iframe baseline', {
@@ -204,13 +237,29 @@ test('reports Web-entry liveness without asserting backend readiness', {
   assert.match(body, /OK/)
 })
 
+test('reports an unavailable backend as HTTP 502 JSON', {
+  timeout: 10_000
+}, async() => {
+  const response = await fetchFrontend('/api/vgpu/v1/nodes', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}'
+  })
+
+  assert.equal(response.status, 502)
+  assert.match(response.headers.get('content-type') ?? '', /application\/json/)
+  assert.equal(typeof await response.json(), 'object')
+})
+
 test('preserves the supported API request and non-success response', {
   timeout: 10_000
 }, async() => {
+  await listen(backend, backendPort, backendAddress)
+
   const requestBody = JSON.stringify({
     filters: { name: 'contract-probe' }
   })
-  const response = await fetchFrontend('/api/vgpu/v1/nodes', {
+  const response = await fetchFrontend('/api/vgpu/v1/nodes?limit=10', {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -222,7 +271,7 @@ test('preserves the supported API request and non-success response', {
 
   assert.deepEqual(lastBackendRequest, {
     method: 'POST',
-    url: '/v1/nodes',
+    url: '/v1/nodes?limit=10',
     contentType: 'application/json',
     probeHeader: 'preserved',
     body: requestBody
@@ -230,4 +279,120 @@ test('preserves the supported API request and non-success response', {
   assert.equal(response.status, 400)
   assert.equal(response.headers.get('x-upstream-contract'), 'preserved')
   assert.equal(responseBody, JSON.stringify({ error: 'contract-probe' }))
+})
+
+test('reports an upstream timeout as HTTP 504 JSON', {
+  timeout: 10_000
+}, async() => {
+  const response = await fetchFrontend('/api/vgpu/v1/contract-timeout')
+
+  assert.equal(response.status, 504)
+  assert.match(response.headers.get('content-type') ?? '', /application\/json/)
+  assert.equal(typeof await response.json(), 'object')
+})
+
+test('preserves the backend JSON response for an unknown v1 API', {
+  timeout: 10_000
+}, async() => {
+  const response = await fetchFrontend('/api/vgpu/v1/contract-missing')
+
+  assert.equal(response.status, 404)
+  assert.match(response.headers.get('content-type') ?? '', /application\/json/)
+  assert.deepEqual(await response.json(), {
+    error: 'unexpected contract-test request'
+  })
+})
+
+test('returns 404 for missing static assets and private backend paths', {
+  timeout: 10_000
+}, async() => {
+  const rootBody = await (await fetchFrontend('/')).text()
+  for (const requestPath of [
+    '/static/contract-missing.js',
+    '/metrics',
+    '/readyz',
+    '/q/openapi.yaml',
+    '/api/vgpu/metrics',
+    '/api/vgpu/readyz',
+    '/api/vgpu/q/openapi.yaml',
+    '/api/vgpu/v2/private'
+  ]) {
+    const response = await fetchFrontend(requestPath)
+    const body = await response.text()
+    assert.equal(response.status, 404, requestPath)
+    assert.equal(response.headers.get('cache-control'), 'no-store', requestPath)
+    assert.notEqual(body, rootBody, requestPath)
+    assert.notEqual(body, 'private backend response', requestPath)
+  }
+})
+
+test('serves built assets with bounded caching, gzip and HEAD semantics', {
+  timeout: 10_000
+}, async() => {
+  const indexResponse = await fetchFrontend('/')
+  const indexBody = await indexResponse.text()
+  assert.match(indexResponse.headers.get('cache-control') ?? '', /no-cache/)
+  assert.doesNotMatch(
+    indexResponse.headers.get('cache-control') ?? '',
+    /immutable/
+  )
+
+  const references = [...indexBody.matchAll(
+    /(?:src|href)="([^"?#]+\.(?:js|css))"/g
+  )].map((match) => match[1])
+  const hashedReference = references.find((reference) =>
+    /[-.][A-Za-z0-9_-]{8,}\.(?:js|css)$/.test(reference)
+  )
+  assert.ok(hashedReference, 'built index did not reference a hashed asset')
+  const assetPath = new URL(hashedReference, `${frontendURL}/`).pathname
+
+  const identityResponse = await fetchFrontend(assetPath, {
+    headers: { 'accept-encoding': 'identity' }
+  })
+  const identityBody = Buffer.from(await identityResponse.arrayBuffer())
+  assert.equal(identityResponse.status, 200)
+  assert.match(
+    identityResponse.headers.get('cache-control') ?? '',
+    /max-age=31536000/
+  )
+  assert.match(identityResponse.headers.get('cache-control') ?? '', /immutable/)
+  assert.equal(identityResponse.headers.has('content-encoding'), false)
+
+  const gzipResponse = await fetchFrontend(assetPath, {
+    headers: { 'accept-encoding': 'gzip' }
+  })
+  const gzipBody = Buffer.from(await gzipResponse.arrayBuffer())
+  assert.equal(gzipResponse.status, 200)
+  assert.equal(gzipResponse.headers.get('content-encoding'), 'gzip')
+  assert.match(gzipResponse.headers.get('vary') ?? '', /Accept-Encoding/i)
+  assert.deepEqual(gzipBody, identityBody)
+
+  const headResponse = await fetchFrontend(assetPath, {
+    method: 'HEAD',
+    headers: { 'accept-encoding': 'gzip' }
+  })
+  assert.equal(headResponse.status, 200)
+  assert.equal(headResponse.headers.get('content-encoding'), 'gzip')
+  assert.equal(headResponse.headers.get('cache-control'), gzipResponse.headers.get('cache-control'))
+  assert.equal((await headResponse.arrayBuffer()).byteLength, 0)
+})
+
+test('exits cleanly on SIGTERM and releases its listener', {
+  timeout: 10_000
+}, async() => {
+  const exited = new Promise((resolve) => frontend.once(
+    'exit',
+    (code, signal) => resolve({ code, signal })
+  ))
+  assert.equal(frontend.kill('SIGTERM'), true)
+  const result = await withTimeout(
+    exited,
+    3_000,
+    'Web entry did not exit after SIGTERM'
+  )
+  assert.deepEqual(result, { code: 0, signal: null })
+
+  const probe = http.createServer()
+  await listen(probe, frontendPort, backendAddress)
+  await closeServer(probe)
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it:**

Completes the Chart 1.x runtime transition designed in #165 on top of #167. Vue is still built with Node.js, but the final scratch frontend image now runs only the Go Web entry.

The existing two-container deployment, `image.frontend` extension point, port 3000, `/health_check`, root SPA routes, and `/api/vgpu/v1/*` contract remain compatible. The Chart no longer forces a Node command, so the v1.3 frontend digest remains available as an emergency rollback.

The new image adds correct static 404s, 502/504 proxy errors, bounded timeouts, pre-compressed assets, cache policy, graceful shutdown, numeric non-root execution, and read-only-filesystem smoke tests. Unsupported API versions and backend-only endpoints below the accidental wildcard proxy now return 404; the supported v1 API is unchanged. The legacy rollback image retains its previous wildcard proxy, `code: 599`, and shutdown behavior, as documented.

**Verification:**

- frontend build, Vite environment check, Jest, Vue metrics test, ESLint, and 10 Web-entry black-box contracts
- `go test ./...`, race tests, and `go vet ./...`
- Helm 3.21.4 and 4.2.4 lint/template/rollback regressions, ShellCheck, and actionlint
- linux/amd64 and linux/arm64 image build and runtime smoke under non-root, read-only, no-capabilities, and no-new-privileges settings
- previous v1.3 frontend digest startup, health, root, and deep-link compatibility