### PR TITLE
feat(chart): add an internal backend Service

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -116,6 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | resources.frontend.requests.cpu | string | `"200m"`                                                                           |  |
 | resources.frontend.requests.memory | string | `"500Mi"`                                                                          |  |
 | securityContext | object | `{}`                                                                               |  |
+| service.legacyBackendPort | bool | `true`                                                                        | Deprecated Chart 1.x compatibility port for direct access to the raw backend on the primary Service. Set to `false` to expose only the supported Web entry; removed in Chart 2.0.0. |
 | service.port | int | `3000`                                                                             |  |
 | service.type | string | `"ClusterIP"`                                                                      |  |
 | serviceAccount.annotations | object | `{}`                                                                               |  |

--- a/charts/hami-webui/templates/NOTES.txt
+++ b/charts/hami-webui/templates/NOTES.txt
@@ -1,3 +1,9 @@
+{{- $legacyBackendPort := eq (include "hami-webui.legacyBackendPortEnabled" .) "true" -}}
+{{- if and $legacyBackendPort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
+WARNING: The primary Service exposes the deprecated raw backend port 8000 because
+service.legacyBackendPort is true. Set it to false unless an existing integration
+still connects directly to the backend.
+{{ end }}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -44,6 +44,15 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Name the internal backend Service without allowing a 63-character fullname to
+drop the distinguishing suffix.
+*/}}
+{{- define "hami-webui.backendServiceName" -}}
+{{- $baseName := include "hami-webui.fullname" . | trunc 55 | trimSuffix "-" -}}
+{{- printf "%s-backend" $baseName -}}
+{{- end -}}
+
+{{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
 {{- define "hami-webui.namespace" -}}
@@ -95,6 +104,23 @@ Selector labels
 app.kubernetes.io/name: {{ include "hami-webui.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Keep the Chart 1.x backend port when the value is absent from reused values.
+Do not use Helm's default function here: an explicit false is considered empty.
+*/}}
+{{- define "hami-webui.legacyBackendPortEnabled" -}}
+{{- $serviceSettings := default (dict) .Values.service -}}
+{{- $legacyBackendPort := true -}}
+{{- if hasKey $serviceSettings "legacyBackendPort" -}}
+{{- $configuredLegacyBackendPort := get $serviceSettings "legacyBackendPort" -}}
+{{- if not (kindIs "bool" $configuredLegacyBackendPort) -}}
+{{- fail "service.legacyBackendPort must be a boolean" -}}
+{{- end -}}
+{{- $legacyBackendPort = $configuredLegacyBackendPort -}}
+{{- end -}}
+{{- $legacyBackendPort -}}
+{{- end -}}
 
 {{/*
 Create the name of the service account to use

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -45,11 +45,17 @@ If release name contains chart name it will be used as a full name.
 
 {{/*
 Name the internal backend Service without allowing a 63-character fullname to
-drop the distinguishing suffix.
+drop the distinguishing suffix. Hash long names so distinct releases with the
+same prefix cannot collide after truncation.
 */}}
 {{- define "hami-webui.backendServiceName" -}}
-{{- $baseName := include "hami-webui.fullname" . | trunc 55 | trimSuffix "-" -}}
-{{- printf "%s-backend" $baseName -}}
+{{- $fullName := include "hami-webui.fullname" . -}}
+{{- if le (len $fullName) 55 -}}
+{{- printf "%s-backend" $fullName -}}
+{{- else -}}
+{{- $prefix := $fullName | trunc 46 | trimSuffix "-" -}}
+{{- printf "%s-%s-backend" $prefix ($fullName | sha256sum | trunc 8) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/hami-webui/templates/backend-service.yaml
+++ b/charts/hami-webui/templates/backend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hami-webui.backendServiceName" . }}
+  namespace: {{ include "hami-webui.namespace" . }}
+  labels:
+    {{- include "hami-webui.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "backend"
+    monitoring.hami.io/job: {{ include "hami-webui.fullname" . | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: metrics
+      protocol: TCP
+      name: backend-http
+  selector:
+    {{- include "hami-webui.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "hami-webui"

--- a/charts/hami-webui/templates/service.yaml
+++ b/charts/hami-webui/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- $legacyBackendPort := eq (include "hami-webui.legacyBackendPortEnabled" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,10 +14,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if $legacyBackendPort }}
     - port: 8000
       targetPort: metrics
       protocol: TCP
       name: metrics
+    {{- end }}
   selector:
     {{- include "hami-webui.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "hami-webui"

--- a/charts/hami-webui/templates/servicemonitor.yaml
+++ b/charts/hami-webui/templates/servicemonitor.yaml
@@ -25,15 +25,16 @@ metadata:
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
+  jobLabel: monitoring.hami.io/job
   selector:
     matchLabels:
       {{- include "hami-webui.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "hami-webui"
+      app.kubernetes.io/component: "backend"
   namespaceSelector:
     matchNames:
     - "{{ include "hami-webui.namespace" . }}"
   endpoints:
-  - port: "metrics"
+  - port: "backend-http"
     path: "/metrics"
     interval: "{{ .Values.serviceMonitor.interval }}"
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -56,6 +56,11 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 3000
+  # Chart 1.x compatibility only. Port 8000 exposes the raw backend API,
+  # readiness, metrics, and Swagger endpoints through the primary Service.
+  # Disable it when only the supported Web entry should be reachable.
+  # This option is deprecated and will be removed in Chart 2.0.0.
+  legacyBackendPort: true
 
 ingress:
   enabled: false

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -116,6 +116,22 @@ emit a validated CSP `frame-ancestors` policy. These settings are runtime
 configuration, not Vite build variables. The unprefixed `/health_check`
 endpoint remains stable for Chart probes.
 
+### Chart 1.x Service topology
+
+The primary Service routes browser traffic to the Web entry on port `3000`.
+An independently labelled `*-backend` ClusterIP Service routes port `8000` to
+the backend container and is the only Service selected by the included
+ServiceMonitor. The Deployment keeps `component: hami-webui` because both
+containers share one Pod; the backend component label belongs to the Service
+used for discovery, not to a separate backend workload.
+
+The primary Service retains a deprecated port `8000` only when
+`service.legacyBackendPort` is enabled for Chart 1.x compatibility. Do not
+widen the ServiceMonitor selector to include both Services: that would create
+duplicate scrape targets. The ClusterIP split also does not create an
+authorization boundary; cluster-internal access policy remains a deployment
+concern.
+
 ## Build a Docker image
 
 To build a HAMi-WebUI Frontend Docker image, run:

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -86,6 +86,49 @@ If the same Prometheus selects both this chart's ServiceMonitor and HAMi's
 built-in device-plugin ServiceMonitor (`prometheus.enabled` in the HAMi chart),
 the endpoint is scraped twice. Configure that Prometheus to select only one.
 
+### Backend service boundary
+
+HAMi-WebUI exposes the supported browser API through the same-origin Web entry
+on the primary Service. The backend listener on port `8000` also serves raw API,
+`/readyz`, `/metrics`, and Swagger endpoints, so the chart creates a separate
+ClusterIP Service with a generated `*-backend` name (for example,
+`my-hami-webui-backend`) for backend discovery and Prometheus scraping.
+
+For Chart 1.x upgrade compatibility, the primary Service still includes port
+`8000` by default. The port is deprecated and can be removed from the primary
+Service without affecting WebUI traffic or the included ServiceMonitor:
+
+```yaml
+service:
+  legacyBackendPort: false
+```
+
+Set this to `false` for `NodePort` and `LoadBalancer` Services unless an existing
+integration still connects directly to the raw backend. Move in-cluster clients
+to the generated backend Service on port `8000`. For local diagnostics, forward
+that Service instead of changing the primary Service type:
+
+```bash
+kubectl port-forward service/my-hami-webui-backend 8000:8000 --namespace=kube-system
+```
+
+Use NetworkPolicy or an equivalent cluster policy when backend access must also
+be restricted inside the cluster; a ClusterIP Service is a discovery boundary,
+not an authorization boundary.
+
+The included ServiceMonitor now selects only the backend Service, so retaining
+the compatibility port does not double-scrape Pods. It preserves the existing
+Prometheus `job` label through an explicit Service label; the generated `service`
+target label changes to the generated backend Service name. Update custom rules
+that match `service` before upgrading.
+
+Custom ServiceMonitors that still select the primary Service—whether by
+`component: hami-webui` or only the common name and instance labels—and port
+`metrics` must move to `component: backend` and port `backend-http`. Otherwise
+they can duplicate the included ServiceMonitor while the compatibility port is
+enabled, and stop finding a target when it is disabled. The compatibility port
+will be removed from the primary Service in Chart 2.0.0.
+
 ### Access HAMi-WebUI
 
 1. Configure ~/.kube/config in your localhost to be able to connect your cluster.

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -17,6 +17,121 @@ cp -R "${repo_root}/charts/hami-webui" "${work_dir}/hami-webui"
 helm dependency build --skip-refresh "${work_dir}/hami-webui"
 helm lint "${work_dir}/hami-webui"
 
+render_template() {
+  local template="$1"
+  shift
+
+  helm template test "${work_dir}/hami-webui" \
+    --namespace hami-webui-test \
+    "$@" \
+    --show-only "${template}"
+}
+
+service_port_names() {
+  awk '
+    /^  ports:$/ { in_ports = 1; next }
+    /^  selector:$/ { in_ports = 0 }
+    in_ports && /^      name:/ { print $2 }
+  '
+}
+
+web_service_render="$(render_template templates/service.yaml)"
+backend_service_render="$(render_template templates/backend-service.yaml)"
+service_monitor_render="$(render_template templates/servicemonitor.yaml)"
+
+if [[ "$(service_port_names <<<"${web_service_render}")" != $'http\nmetrics' ]]; then
+  echo "Primary Service must preserve the Chart 1.x backend compatibility port by default" >&2
+  exit 1
+fi
+if [[ "$(service_port_names <<<"${backend_service_render}")" != "backend-http" ]] ||
+  ! grep -Fq 'name: test-hami-webui-backend' <<<"${backend_service_render}" ||
+  ! grep -Fq 'type: ClusterIP' <<<"${backend_service_render}" ||
+  ! grep -Fq 'monitoring.hami.io/job: "test-hami-webui"' <<<"${backend_service_render}" ||
+  ! grep -Fq 'targetPort: metrics' <<<"${backend_service_render}"; then
+  echo "Internal backend Service contract was not rendered" >&2
+  exit 1
+fi
+
+long_fullname="$(printf '%063d' 0 | tr '0' 'a')"
+long_name_web_service="$(render_template templates/service.yaml \
+  --set-string "fullnameOverride=${long_fullname}")"
+long_name_backend_service="$(render_template templates/backend-service.yaml \
+  --set-string "fullnameOverride=${long_fullname}")"
+rendered_web_service_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${long_name_web_service}")"
+rendered_backend_service_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${long_name_backend_service}")"
+if [[ ${#rendered_backend_service_name} -gt 63 ]] ||
+  [[ "${rendered_backend_service_name}" != *-backend ]] ||
+  [[ "${rendered_backend_service_name}" == "${rendered_web_service_name}" ]]; then
+  echo "Internal backend Service name is not distinct and DNS-label safe" >&2
+  exit 1
+fi
+
+service_monitor_spec="$(sed -n '/^spec:/,$p' <<<"${service_monitor_render}")"
+if ! grep -Fq 'app.kubernetes.io/component: "backend"' <<<"${service_monitor_spec}" ||
+  grep -Fq 'app.kubernetes.io/component: "hami-webui"' <<<"${service_monitor_spec}" ||
+  ! grep -Fq 'jobLabel: monitoring.hami.io/job' <<<"${service_monitor_spec}" ||
+  ! grep -Fq 'port: "backend-http"' <<<"${service_monitor_spec}"; then
+  echo "ServiceMonitor must select only the internal backend Service" >&2
+  exit 1
+fi
+
+web_only_service_render="$(render_template templates/service.yaml \
+  --set 'service.legacyBackendPort=false')"
+if [[ "$(service_port_names <<<"${web_only_service_render}")" != "http" ]] ||
+  grep -Fq 'targetPort: metrics' <<<"${web_only_service_render}"; then
+  echo "Disabling service.legacyBackendPort did not remove the raw backend port" >&2
+  exit 1
+fi
+
+for invalid_legacy_backend_port in \
+  --set-string=service.legacyBackendPort=false \
+  --set-json=service.legacyBackendPort=1; do
+  if helm template test "${work_dir}/hami-webui" \
+    "${invalid_legacy_backend_port}" >/dev/null 2>&1; then
+    echo "Invalid service.legacyBackendPort value was accepted: ${invalid_legacy_backend_port}" >&2
+    exit 1
+  fi
+done
+
+load_balancer_web_service="$(render_template templates/service.yaml \
+  --set 'service.type=LoadBalancer')"
+load_balancer_backend_service="$(render_template templates/backend-service.yaml \
+  --set 'service.type=LoadBalancer')"
+if ! grep -Fq 'type: LoadBalancer' <<<"${load_balancer_web_service}" ||
+  ! grep -Fq 'type: ClusterIP' <<<"${load_balancer_backend_service}" ||
+  grep -Fq 'type: LoadBalancer' <<<"${load_balancer_backend_service}"; then
+  echo "Internal backend Service must not inherit the public Service type" >&2
+  exit 1
+fi
+
+legacy_values_chart="${work_dir}/hami-webui-legacy-values"
+cp -R "${work_dir}/hami-webui" "${legacy_values_chart}"
+awk '$1 != "legacyBackendPort:" { print }' \
+  "${legacy_values_chart}/values.yaml" >"${legacy_values_chart}/values.yaml.next"
+mv "${legacy_values_chart}/values.yaml.next" "${legacy_values_chart}/values.yaml"
+legacy_values_service_render="$(helm template test "${legacy_values_chart}" \
+  --show-only templates/service.yaml)"
+if [[ "$(service_port_names <<<"${legacy_values_service_render}")" != $'http\nmetrics' ]]; then
+  echo "Missing service.legacyBackendPort did not preserve the Chart 1.x upgrade contract" >&2
+  exit 1
+fi
+
+null_legacy_backend_port_render="$(render_template templates/service.yaml \
+  --set-json 'service.legacyBackendPort=null')"
+if [[ "$(service_port_names <<<"${null_legacy_backend_port_render}")" != $'http\nmetrics' ]]; then
+  echo "A null service.legacyBackendPort did not preserve the compatibility port" >&2
+  exit 1
+fi
+
+monitor_disabled_render="$(helm template test "${work_dir}/hami-webui" \
+  --set 'serviceMonitor.enabled=false' \
+  --set 'hamiServiceMonitor.enabled=false')"
+if grep -Fq 'name: test-hami-webui-svc-monitor' <<<"${monitor_disabled_render}" ||
+  ! grep -Fq 'name: test-hami-webui-backend' <<<"${monitor_disabled_render}"; then
+  echo "Disabling ServiceMonitors must not remove the internal backend Service" >&2
+  exit 1
+fi
+
 assert_internal_prometheus_address() {
   local release_name="$1"
   local release_namespace="$2"

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -53,15 +53,20 @@ if [[ "$(service_port_names <<<"${backend_service_render}")" != "backend-http" ]
 fi
 
 long_fullname="$(printf '%063d' 0 | tr '0' 'a')"
+other_long_fullname="${long_fullname:0:55}bbbbbbbb"
 long_name_web_service="$(render_template templates/service.yaml \
   --set-string "fullnameOverride=${long_fullname}")"
 long_name_backend_service="$(render_template templates/backend-service.yaml \
   --set-string "fullnameOverride=${long_fullname}")"
+other_long_name_backend_service="$(render_template templates/backend-service.yaml \
+  --set-string "fullnameOverride=${other_long_fullname}")"
 rendered_web_service_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${long_name_web_service}")"
 rendered_backend_service_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${long_name_backend_service}")"
+other_rendered_backend_service_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${other_long_name_backend_service}")"
 if [[ ${#rendered_backend_service_name} -gt 63 ]] ||
   [[ "${rendered_backend_service_name}" != *-backend ]] ||
-  [[ "${rendered_backend_service_name}" == "${rendered_web_service_name}" ]]; then
+  [[ "${rendered_backend_service_name}" == "${rendered_web_service_name}" ]] ||
+  [[ "${rendered_backend_service_name}" == "${other_rendered_backend_service_name}" ]]; then
   echo "Internal backend Service name is not distinct and DNS-label safe" >&2
   exit 1
 fi


### PR DESCRIPTION
## What

- Add a dedicated `ClusterIP` Service for backend port 8000.
- Make the included ServiceMonitor select only that Service and preserve the existing Prometheus `job` label.
- Add deprecated `service.legacyBackendPort`; only explicit `false` removes port 8000 from the primary Service during Chart 1.x.
- Document direct-client and custom-ServiceMonitor migration, target-label changes, and the ClusterIP security boundary.

## Why

Port 8000 serves the raw API, readiness, metrics, and Swagger endpoints. Keeping it on the primary Service also exposes it when users select `NodePort` or `LoadBalancer`, while coupling Prometheus discovery to the browser entry. At the same time, #5, #73, and #108 show real direct-backend and metrics usage, so silently removing it in Chart 1.x would be a breaking change. The compatibility port is deprecated for removal in Chart 2.0.0.

## Verification

- Helm 3.21.4 and 4.2.4 chart verification passed.
- A kind upgrade from the previous chart with `--reuse-values` preserved the old primary ports and added the internal Service.
- Two Ready backend Pods produced two selected endpoints, not four; disabling the compatibility port did not change them.
- Long release names, invalid value types, `LoadBalancer` isolation, missing/null legacy values, and Kubernetes API validation are covered.
- `shellcheck` and `git diff --check` passed.

This does not add a PodMonitor, NetworkPolicy, or application listener change; those are separate concerns.