### PR TITLE
refactor(dev): proxy Vite directly to the backend

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -71,6 +71,8 @@ jobs:
         run: bash scripts/verify-toolchain-versions.sh
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Test Vite development proxy
+        run: pnpm --filter hami-webui-web run test:dev-proxy
       - name: Build BFF
         run: pnpm run build
       - name: Build web and verify environment boundary

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build-web:
 	pnpm --filter hami-webui-web run build
 
 .PHONY: start-dev
-start-dev: install-modules start-bff start-web
+start-dev: install-modules start-web
 
 
 .PHONY: start-bff

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -52,10 +52,19 @@ By default, you can access the web-ui-server-swagger at `http://localhost:8000/q
 
 ### Frontend
 
-For browser development, run `make start-dev` in the repository root. This
-starts the Vite development server and the legacy development proxy.
+Start the backend first, then run `make start-dev` in the repository root. This
+starts the Vite development server; NestJS is not part of the browser
+development path. Vite forwards browser requests below `/api/vgpu/v1/*`
+directly to the backend at `http://127.0.0.1:8000` and removes the
+`/api/vgpu` prefix.
 
 By default, you can access the web-ui at `http://localhost:3000/`.
+
+Set `HAMI_WEBUI_BACKEND_URL` when the backend uses a different origin:
+
+```bash
+HAMI_WEBUI_BACKEND_URL=http://127.0.0.1:18000 make start-dev
+```
 
 To exercise the production Web entry locally:
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,24 +1,29 @@
-# web
+# Web application
+
+The supported development server is Vite. Start the Go backend first; see the
+[developer guide](../../docs/contribute/developer-guide.md) for the complete
+workflow and backend URL override.
 
 ## Project setup
+
 ```
 pnpm install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 pnpm run start:dev
 ```
 
 ### Compiles and minifies for production
+
 ```
 pnpm run build
 ```
 
 ### Lints and fixes files
+
 ```
 pnpm run lint
 ```
-
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
     "start": "vite",
     "start:dev": "vite",
     "start:webpack": "export NODE_ENV=development && vue-cli-service serve",
-    "lint": "eslint --ext .js,.mjs,.vue src",
+    "lint": "eslint --ext .js,.mjs,.vue src test vite.config.js",
     "build": "vite build",
     "build:webpack": "vue-cli-service build",
     "build:stage": "vue-cli-service build --mode staging",
@@ -16,6 +16,7 @@
     "new": "plop",
     "svgo": "svgo -f src/icons/svg --config=src/icons/svgo.yml",
     "test:unit": "jest --clearCache && vue-cli-service test:unit",
+    "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
     "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs",
     "test:ci": "npm run lint && npm run test:unit"
   },

--- a/packages/web/test/vite-dev-proxy.contract.test.mjs
+++ b/packages/web/test/vite-dev-proxy.contract.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import {
+  createServer as createHTTPServer,
+  request as createHTTPRequest,
+} from 'node:http'
+import { test } from 'node:test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createServer as createViteServer, loadConfigFromFile } from 'vite'
+
+const webRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const configFile = path.join(webRoot, 'vite.config.js')
+
+const listen = async(server) => {
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const address = server.address()
+  assert.notEqual(address, null)
+  assert.equal(typeof address, 'object')
+  return `http://127.0.0.1:${address.port}`
+}
+
+const close = async(server) => {
+  if (!server.listening) return
+  server.close()
+  await once(server, 'close')
+}
+
+const getRawPath = async(origin, requestPath) => {
+  const url = new URL(origin)
+
+  return new Promise((resolve, reject) => {
+    const request = createHTTPRequest(
+      {
+        hostname: url.hostname,
+        method: 'GET',
+        path: requestPath,
+        port: url.port,
+      },
+      async(response) => {
+        const chunks = []
+        for await (const chunk of response) chunks.push(chunk)
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: response.headers,
+          status: response.statusCode,
+        })
+      }
+    )
+    request.on('error', reject)
+    request.end()
+  })
+}
+
+test('Vite serves the SPA and proxies the versioned Web API without NestJS', async() => {
+  const requests = []
+  const backend = createHTTPServer(async(request, response) => {
+    const chunks = []
+    for await (const chunk of request) chunks.push(chunk)
+
+    requests.push({
+      body: Buffer.concat(chunks).toString('utf8'),
+      headers: request.headers,
+      method: request.method,
+      url: request.url,
+    })
+
+    response.writeHead(422, {
+      'content-type': 'application/json',
+      'x-contract-response': 'preserved',
+    })
+    response.end(JSON.stringify({ code: 422, message: 'contract response' }))
+  })
+
+  const previousBackendURL = process.env.HAMI_WEBUI_BACKEND_URL
+  let frontend
+  let vite
+
+  try {
+    delete process.env.HAMI_WEBUI_BACKEND_URL
+    const loadedConfig = await loadConfigFromFile(
+      { command: 'serve', mode: 'development' },
+      configFile,
+      webRoot,
+      'silent'
+    )
+    assert.notEqual(loadedConfig, null)
+    assert.equal(
+      loadedConfig.config.server.proxy['^/api/vgpu/v1(?:/|[?]|$)'].target,
+      'http://127.0.0.1:8000'
+    )
+
+    const backendURL = await listen(backend)
+    process.env.HAMI_WEBUI_BACKEND_URL = backendURL
+
+    vite = await createViteServer({
+      configFile,
+      logLevel: 'silent',
+      optimizeDeps: {
+        include: [],
+        noDiscovery: true,
+      },
+      root: webRoot,
+      server: {
+        middlewareMode: true,
+      },
+    })
+
+    assert.equal(vite.config.server.port, 3000)
+    assert.equal(vite.config.server.strictPort, true)
+    assert.deepEqual(Object.keys(vite.config.server.proxy), [
+      '^/api/vgpu/v1(?:/|[?]|$)',
+    ])
+    assert.equal(
+      vite.config.server.proxy['^/api/vgpu/v1(?:/|[?]|$)'].target,
+      backendURL
+    )
+
+    frontend = createHTTPServer(vite.middlewares)
+    const frontendURL = await listen(frontend)
+
+    const apiResponse = await fetch(
+      `${frontendURL}/api/vgpu/v1/nodes?limit=10&name=contract%20probe`,
+      {
+        body: JSON.stringify({ node: 'worker-1' }),
+        headers: {
+          'content-type': 'application/json',
+          'x-contract-request': 'preserved',
+        },
+        method: 'POST',
+      }
+    )
+
+    assert.equal(apiResponse.status, 422)
+    assert.equal(apiResponse.headers.get('x-contract-response'), 'preserved')
+    assert.deepEqual(await apiResponse.json(), {
+      code: 422,
+      message: 'contract response',
+    })
+    assert.equal(requests.length, 1)
+    assert.equal(requests[0].method, 'POST')
+    assert.equal(
+      requests[0].url,
+      '/v1/nodes?limit=10&name=contract%20probe'
+    )
+    assert.equal(requests[0].body, JSON.stringify({ node: 'worker-1' }))
+    assert.equal(requests[0].headers['content-type'], 'application/json')
+    assert.equal(requests[0].headers['x-contract-request'], 'preserved')
+
+    const deepLinkResponse = await fetch(
+      `${frontendURL}/admin/vgpu/monitor/overview`,
+      { headers: { accept: 'text/html' } }
+    )
+    assert.equal(deepLinkResponse.status, 200)
+    assert.match(await deepLinkResponse.text(), /<div id="app"><\/div>/)
+
+    for (const blockedPath of [
+      '/api/unknown',
+      '/api/vgpu-extra/v1/nodes',
+      '/api/vgpu/metrics',
+      '/api/vgpu/readyz',
+      '/api/vgpu/q/openapi.yaml',
+      '/api/vgpu/v2/private',
+      '/api/vgpu/v1/../metrics',
+    ]) {
+      const blockedResponse = await getRawPath(frontendURL, blockedPath)
+      assert.equal(blockedResponse.status, 404, blockedPath)
+      assert.equal(
+        blockedResponse.headers['cache-control'],
+        'no-store',
+        blockedPath
+      )
+      assert.equal(blockedResponse.body, '404 page not found\n')
+      assert.equal(requests.length, 1, blockedPath)
+    }
+  } finally {
+    if (frontend) await close(frontend)
+    if (vite) await vite.close()
+    await close(backend)
+
+    if (previousBackendURL === undefined) {
+      delete process.env.HAMI_WEBUI_BACKEND_URL
+    } else {
+      process.env.HAMI_WEBUI_BACKEND_URL = previousBackendURL
+    }
+  }
+})

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -6,10 +6,41 @@ import { createSvgIconsPlugin } from 'vite-plugin-svg-icons'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import path from 'path'
 
+const versionedAPIPrefix = '/api/vgpu/v1'
+const apiProxyContext = '^/api/vgpu/v1(?:/|[?]|$)'
+
+const hasPathPrefix = (requestPath, prefix) =>
+  requestPath === prefix || requestPath.startsWith(`${prefix}/`)
+
 export default defineConfig(() => {
+  const backendURL =
+    process.env.HAMI_WEBUI_BACKEND_URL || 'http://127.0.0.1:8000'
+
   return {
     base: './', // 对应 publicPath: './'
     plugins: [
+      {
+        name: 'hami-webui-dev-api-boundary',
+        configureServer(server) {
+          server.middlewares.use((request, response, next) => {
+            const requestPath = new URL(
+              request.url || '/',
+              'http://vite.local'
+            ).pathname
+            const isAPIRequest = hasPathPrefix(requestPath, '/api')
+
+            if (isAPIRequest && !hasPathPrefix(requestPath, versionedAPIPrefix)) {
+              response.statusCode = 404
+              response.setHeader('Cache-Control', 'no-store')
+              response.setHeader('Content-Type', 'text/plain; charset=utf-8')
+              response.end('404 page not found\n')
+              return
+            }
+
+            next()
+          })
+        },
+      },
       vue(),
       vueJsx(),
       nodePolyfills({
@@ -40,17 +71,16 @@ export default defineConfig(() => {
       extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue']
     },
     server: {
-      port: 8080,
+      port: 3000,
+      strictPort: true,
       proxy: {
-        '/api': {
-          target: 'http://127.0.0.1:3000',
+        [apiProxyContext]: {
+          target: backendURL,
           changeOrigin: true,
+          rewrite: (requestPath) =>
+            requestPath.replace(/^\/api\/vgpu(?=\/|\?|$)/, ''),
         },
-        '/ws': {
-            target: 'ws://127.0.0.1:3000',
-            ws: true
-        }
-      }
+      },
     },
     build: {
       outDir: '../../public', // 输出到与 Webpack 相同的目录

--- a/scripts/verify-vite-env-boundary.mjs
+++ b/scripts/verify-vite-env-boundary.mjs
@@ -21,6 +21,7 @@ const buildEnvironment = Object.fromEntries(
     .map((name) => [name, process.env[name]])
 )
 Object.assign(buildEnvironment, {
+  HAMI_WEBUI_BACKEND_URL: 'http://private-backend-canary.invalid:8000',
   HAMI_WEBUI_UNREFERENCED_CANARY: 'hami_webui_canary_should_not_ship',
   VITE_APP_BASE_API: '/vite-env-contract/',
   VITE_APP_REQUEST_TIMEOUT: '71234567'
@@ -60,6 +61,7 @@ const bundles = await Promise.all(
 const contains = (value) => bundles.some((bundle) => bundle.includes(value))
 
 const forbiddenValues = [
+  'http://private-backend-canary.invalid:8000',
   'HAMI_WEBUI_UNREFERENCED_CANARY',
   'hami_webui_canary_should_not_ship',
   '/vite-env-contract/'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Makes Vite the complete local browser-development entry instead of routing API
requests through the legacy NestJS process.

- Vite listens on `3000` and proxies only `/api/vgpu/v1/*` directly to the Go
  backend on `8000`.
- Other `/api` paths return `404` before SPA fallback, matching the production
  Web-entry boundary.
- `make start-dev` no longer starts NestJS.
- `HAMI_WEBUI_BACKEND_URL` can override the local backend origin without being
  exposed to the browser bundle.

This is deliberately separate from deleting NestJS and the unused Webpack
fallback. It does not change the production image, Chart, or runtime topology.

**Verification**:

- Real Vite proxy contract test covers method, query, body, headers, upstream
  non-2xx status, SPA deep links, API allowlisting, and dot-segment rejection.
- `pnpm --filter hami-webui-web run test:dev-proxy`
- `pnpm --filter hami-webui-web run lint`
- `pnpm run verify:vite-env`
- Existing NestJS and metric tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vite development proxy support for versioned API requests.
  * Added configurable backend URL support through `HAMI_WEBUI_BACKEND_URL`.
  * Development server now runs on port 3000 and serves deep links correctly.

* **Bug Fixes**
  * Unversioned API paths are rejected with a 404 response.
  * Improved handling of blocked paths and proxy routing.

* **Documentation**
  * Updated frontend development instructions and setup examples.

* **Tests**
  * Added coverage for SPA serving, API proxying, routing boundaries, and environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->