### PR TITLE
fix(web): preserve allocation rate semantics

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:metrics",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs"
+    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.1.0",

--- a/packages/web/projects/vgpu/views/card/admin/allocation-percent.mjs
+++ b/packages/web/projects/vgpu/views/card/admin/allocation-percent.mjs
@@ -1,0 +1,18 @@
+export const getAllocationPercent = (used, total) => {
+  const usedValue = Number(used ?? 0);
+  const totalValue = Number(total);
+
+  if (
+    !Number.isFinite(usedValue) ||
+    !Number.isFinite(totalValue) ||
+    totalValue <= 0
+  ) {
+    return undefined;
+  }
+
+  const raw = Math.max(0, (usedValue / totalValue) * 100);
+  return {
+    raw,
+    progress: Math.min(100, raw),
+  };
+};

--- a/packages/web/projects/vgpu/views/card/admin/allocation-percent.test.mjs
+++ b/packages/web/projects/vgpu/views/card/admin/allocation-percent.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getAllocationPercent } from './allocation-percent.mjs';
+
+test('allocation text preserves overcommit while progress remains bounded', () => {
+  assert.deepEqual(getAllocationPercent(150, 100), {
+    raw: 150,
+    progress: 100,
+  });
+});
+
+test('allocation percentage rejects an unavailable capacity', () => {
+  assert.equal(getAllocationPercent(10, 0), undefined);
+  assert.equal(getAllocationPercent(10, undefined), undefined);
+});

--- a/packages/web/projects/vgpu/views/card/admin/index.vue
+++ b/packages/web/projects/vgpu/views/card/admin/index.vue
@@ -83,6 +83,7 @@ import { useI18n } from 'vue-i18n';
 import useTableColumnVisibility from '~/vgpu/hooks/useTableColumnVisibility';
 import useTableFilters from '~/vgpu/hooks/useTableFilters';
 import useLocalPagination from '~/vgpu/hooks/useLocalPagination';
+import { getAllocationPercent } from './allocation-percent.mjs';
 
 const props = defineProps(['hideTitle', 'filters']);
 
@@ -261,22 +262,20 @@ const baseColumns = computed(() => [
     width: 180,
     render: ({ coreTotal, coreUsed, isExternal }) => {
       if (isExternal || !coreTotal) return <span>--</span>;
-      const percent = Math.max(
-        0,
-        Math.min(100, (Number(coreUsed || 0) / Number(coreTotal)) * 100),
-      );
-      const color = getResourceColor(percent);
+      const percent = getAllocationPercent(coreUsed, coreTotal);
+      if (!percent) return <span>--</span>;
+      const color = getResourceColor(percent.progress);
       return (
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
           <t-progress
             theme="circle"
             size={24}
             strokeWidth={3}
-            percentage={roundToDecimal(percent, 2)}
+            percentage={roundToDecimal(percent.progress, 2)}
             color={color}
             label={false}
           />
-          <span>{roundToDecimal(percent, 2)}%</span>
+          <span>{roundToDecimal(percent.raw, 2)}%</span>
         </span>
       );
     },
@@ -311,22 +310,20 @@ const baseColumns = computed(() => [
     width: 180,
     render: ({ memoryTotal, memoryUsed, isExternal }) => {
       if (isExternal || !memoryTotal) return <span>--</span>;
-      const percent = Math.max(
-        0,
-        Math.min(100, (Number(memoryUsed || 0) / Number(memoryTotal)) * 100),
-      );
-      const color = getResourceColor(percent);
+      const percent = getAllocationPercent(memoryUsed, memoryTotal);
+      if (!percent) return <span>--</span>;
+      const color = getResourceColor(percent.progress);
       return (
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
           <t-progress
             theme="circle"
             size={24}
             strokeWidth={3}
-            percentage={roundToDecimal(percent, 2)}
+            percentage={roundToDecimal(percent.progress, 2)}
             color={color}
             label={false}
           />
-          <span>{roundToDecimal(percent, 2)}%</span>
+          <span>{roundToDecimal(percent.raw, 2)}%</span>
         </span>
       );
     },

--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -175,7 +175,10 @@ import useFetchList from '@/hooks/useFetchList';
 import TabTop from '~/vgpu/components/TabTop.vue';
 import Gauge from '~/vgpu/components/gauge.vue';
 import { getRangeConfigInit } from './config';
-import { createComputeUsageGaugeConfig } from './metric-config.mjs';
+import {
+  createComputeUsageGaugeConfig,
+  createNodeAllocationTopQueries,
+} from './metric-config.mjs';
 
 const router = useRouter();
 const { t, locale } = useI18n();
@@ -535,8 +538,7 @@ const nodeComputeTop5 = computed(() => ({
       key: 'alloc',
       nameKey: 'node',
       data: [],
-      query:
-        'topk(5, avg(hami_container_vcore_allocated{}) by (node) / avg(hami_core_size{}) by (node) * 100)',
+      query: createNodeAllocationTopQueries().compute,
     },
     {
       tab: t('dashboard.usageRateLegend'),
@@ -557,8 +559,7 @@ const nodeMemoryTop5 = computed(() => ({
       key: 'alloc',
       nameKey: 'node',
       data: [],
-      query:
-        'topk(5, avg(hami_container_vmemory_allocated{}) by (node) / avg(hami_memory_size{}) by (node) * 100)',
+      query: createNodeAllocationTopQueries().memory,
     },
     {
       tab: t('dashboard.usageRateLegend'),

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
@@ -10,3 +10,24 @@ export const createComputeUsageGaugeConfig = () => ({
   used: 0,
   unit: ' ',
 });
+
+// Allocation series only exist for devices assigned to a workload. Sum all
+// devices within each scrape target first, then average equivalent exporter
+// replicas so idle devices remain in the capacity denominator. Capacity also
+// supplies an explicit zero when an entire node has no allocation series.
+const buildNodeAllocationTopQuery = (allocatedMetric, capacityMetric) => {
+  const allocated = `avg by (node) (sum by (node, instance) (${allocatedMetric}))`;
+  const capacity = `avg by (node) (sum by (node, instance) (${capacityMetric}))`;
+  return `topk(5, (${allocated} / ${capacity} * 100) or on (node) (${capacity} * 0))`;
+};
+
+export const createNodeAllocationTopQueries = () => ({
+  compute: buildNodeAllocationTopQuery(
+    'hami_container_vcore_allocated',
+    'hami_core_size',
+  ),
+  memory: buildNodeAllocationTopQuery(
+    'hami_container_vmemory_allocated',
+    'hami_memory_size',
+  ),
+});

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createComputeUsageGaugeConfig } from './metric-config.mjs';
+import {
+  createComputeUsageGaugeConfig,
+  createNodeAllocationTopQueries,
+} from './metric-config.mjs';
 
 test('compute utilization is treated as an already-normalized percentage', () => {
   const config = createComputeUsageGaugeConfig();
@@ -10,4 +13,17 @@ test('compute utilization is treated as an already-normalized percentage', () =>
   assert.equal(config.totalQuery, undefined);
   assert.match(config.query, /hami_core_util/);
   assert.equal((41 / config.total) * 100, 41);
+});
+
+test('node allocation rankings include every device and fully idle nodes', () => {
+  const queries = createNodeAllocationTopQueries();
+
+  assert.equal(
+    queries.compute,
+    'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vcore_allocated)) / avg by (node) (sum by (node, instance) (hami_core_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_core_size)) * 0))',
+  );
+  assert.equal(
+    queries.memory,
+    'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vmemory_allocated)) / avg by (node) (sum by (node, instance) (hami_memory_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_memory_size)) * 0))',
+  );
 });


### PR DESCRIPTION
## What

Correct two allocation-rate displays:

- aggregate every device per exporter before ranking node compute and memory allocation, and show fully idle nodes as 0%
- keep overcommit values such as 150% in card-list text while bounding only the progress ring at 100%

The previous Top5 queries averaged only devices with allocation series, which overstated nodes that still had idle cards. The card list then hid valid HAMi overcommit by clamping both the graphic and its label.

This changes no API, Helm, image, or release contract.

## Verification

- clean-home frozen pnpm install with Node 24.19 / pnpm 10.25
- Web tests and targeted metric/allocation tests
- root, Web, and changed-file ESLint
- Vite production build and environment-boundary verification
- both PromQL expressions parsed by the upstream Prometheus parser
- three independent source-level reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compute and memory allocation displays, showing accurate percentages while keeping progress indicators bounded.
  * Node allocation charts now include fully idle nodes and rank the top five nodes more reliably.

* **Bug Fixes**
  * Corrected handling of unavailable or invalid capacity data in allocation displays.
  * Preserved over-allocation percentages without allowing visual progress indicators to exceed 100%.

* **Tests**
  * Added coverage for allocation calculations and node allocation rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->