### PR TITLE
fix(web): make container workload identity explicit

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,9 +9,10 @@
     "build": "vite build",
     "dev": "vite",
     "build:vite": "vite build",
-    "test": "pnpm run test:dev-proxy && pnpm run test:metrics",
+    "test": "pnpm run test:dev-proxy && pnpm run test:metrics && pnpm run test:workload",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs"
+    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.1.0",

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -1,7 +1,7 @@
 <template>
   <page-header
     :title="$t('task.workload')"
-    :name="detail.appName || detail.name"
+    :name="workloadDisplayName"
     :status="headerStatusDisplay.text"
     :status-icon="headerStatusDisplay.icon"
   >
@@ -80,6 +80,18 @@
             </div>
           </div>
           <div class="basic-info-summary">
+            <div class="summary-item">
+              <span class="summary-item-label">{{ $t('task.detail.podName') }}</span>
+              <span class="summary-item-value">
+                <ellipsis-text :text="detail.appName || '--'" mode="middle" tooltip="always" />
+              </span>
+            </div>
+            <div class="summary-item">
+              <span class="summary-item-label">{{ $t('task.detail.containerName') }}</span>
+              <span class="summary-item-value">
+                <ellipsis-text :text="detail.name || '--'" mode="middle" tooltip="always" />
+              </span>
+            </div>
             <div class="summary-item">
               <span class="summary-item-label">{{ $t('task.image') }}</span>
               <span class="summary-item-value">
@@ -189,12 +201,14 @@ import BlockBox from '@/components/BlockBox.vue';
 import { getLineOptions } from '~/vgpu/components/config';
 import VChart from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
+import { formatWorkloadName } from './workload-identity.mjs';
 
 const route = useRoute();
 const router = useRouter();
 const { t, locale } = useI18n();
 
 const detail = ref({});
+const workloadDisplayName = computed(() => formatWorkloadName(detail.value));
 const nodeUid = ref('');
 const cardTypeById = ref({});
 

--- a/packages/web/projects/vgpu/views/task/admin/index.vue
+++ b/packages/web/projects/vgpu/views/task/admin/index.vue
@@ -49,7 +49,7 @@
       </toolbar>
       <t-table
         :key="locale"
-        row-key="podUid"
+        row-key="workloadRowKey"
         class="workload-table vgpu-table-skin"
         :data="pagedTableData"
         :columns="visibleColumns"
@@ -93,6 +93,10 @@ import { useI18n } from 'vue-i18n';
 import useTableColumnVisibility from '~/vgpu/hooks/useTableColumnVisibility';
 import useTableFilters from '~/vgpu/hooks/useTableFilters';
 import useLocalPagination from '~/vgpu/hooks/useLocalPagination';
+import {
+  createWorkloadRowKey,
+  formatWorkloadName,
+} from './workload-identity.mjs';
 
 const props = defineProps(['hideTitle', 'filters', 'style']);
 const { t, locale } = useI18n();
@@ -162,9 +166,7 @@ const baseColumns = computed(() => [
     hideTooltip: true,
     render: ({ name, appName, podUid, namespace, namespaceName }) => {
       const to = `/admin/vgpu/task/admin/detail?name=${name}&podUid=${podUid}`;
-      const workloadName = [appName, name]
-        .filter((value, index, values) => value && values.indexOf(value) === index)
-        .join(' / ') || '--';
+      const workloadName = formatWorkloadName({ appName, name });
       const workloadNamespace = namespace || namespaceName || '--';
       return (
         <span style={{ display: 'inline-flex', alignItems: 'flex-start', gap: '10px' }}>
@@ -284,7 +286,10 @@ const fetchTableData = async () => {
       },
     };
     const { items = [] } = await taskApi.getTaskListReq(payload);
-    tableData.value = items;
+    tableData.value = items.map((item) => ({
+      ...item,
+      workloadRowKey: createWorkloadRowKey(item),
+    }));
     syncTotalAndClamp();
   } finally {
     tableLoading.value = false;

--- a/packages/web/projects/vgpu/views/task/admin/workload-identity.mjs
+++ b/packages/web/projects/vgpu/views/task/admin/workload-identity.mjs
@@ -1,0 +1,7 @@
+export const createWorkloadRowKey = ({ podUid, name } = {}) =>
+  [podUid, name].filter(Boolean).join('/');
+
+export const formatWorkloadName = ({ appName, name } = {}) =>
+  [appName, name]
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .join(' / ') || '--';

--- a/packages/web/projects/vgpu/views/task/admin/workload-identity.test.mjs
+++ b/packages/web/projects/vgpu/views/task/admin/workload-identity.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createWorkloadRowKey,
+  formatWorkloadName,
+} from './workload-identity.mjs';
+
+test('containers in the same Pod have distinct workload row keys', () => {
+  const worker = createWorkloadRowKey({ podUid: 'pod-uid', name: 'worker' });
+  const sidecar = createWorkloadRowKey({ podUid: 'pod-uid', name: 'sidecar' });
+
+  assert.equal(worker, 'pod-uid/worker');
+  assert.equal(sidecar, 'pod-uid/sidecar');
+  assert.notEqual(worker, sidecar);
+});
+
+test('workload name exposes both Pod and container identity', () => {
+  assert.equal(
+    formatWorkloadName({ appName: 'training-pod', name: 'worker' }),
+    'training-pod / worker',
+  );
+  assert.equal(
+    formatWorkloadName({ appName: 'worker', name: 'worker' }),
+    'worker',
+  );
+  assert.equal(formatWorkloadName(), '--');
+});

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -240,7 +240,7 @@ export default {
     description: 'Monitor workloads running on GPUs.',
     name: 'Name',
     workload: 'Workload',
-    searchWorkloadName: 'Search workload name',
+    searchWorkloadName: 'Search Pod or container name',
     status: 'Status',
     allStatus: 'All Status',
     node: 'Hosting Node',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -237,7 +237,7 @@ export default {
     description: '监控 GPU 上运行的工作负载状态与占用。',
     name: '任务名称',
     workload: '工作负载',
-    searchWorkloadName: '搜索工作负载名称',
+    searchWorkloadName: '搜索 Pod 或容器名称',
     status: '状态',
     allStatus: '全部状态',
     node: '所属节点',


### PR DESCRIPTION
## What

Make the current container-level workload identity explicit without changing the API or introducing a Job abstraction.

- give every Pod/container pair a unique table row key
- show `Pod / Container` consistently in list and detail headings
- expose both names in Basic Info
- state that search accepts either name
- cover two GPU containers in one Pod

The backend already returns and filters both names; this closes the remaining UI identity gap.

## Verification

- all 7 web tests
- targeted and root ESLint
- Vite production build
- headed Chromium smoke with two rows from one Pod and the detail view
- three independent read-only reviews

/kind bug
