### PR TITLE
perf(web): remove duplicate Element Plus styles

### DIFF
--- a/packages/web/src/plugins/element.js
+++ b/packages/web/src/plugins/element.js
@@ -1,5 +1,4 @@
 import ElementPlus from 'element-plus'
-import 'element-plus/dist/index.css'
 import locale from 'element-plus/dist/locale/zh-cn.mjs'
 
 export default (app) => {


### PR DESCRIPTION
## What

Remove the prebuilt default Element Plus stylesheet because the app already loads the complete customized Theme Chalk entry.

The production CSS changes from 1,603,498 to 1,361,510 bytes: about 242 KB raw and 33 KB gzip less. Component code and the custom `#2563eb` primary theme are unchanged.

## Verification

- all 7 web tests and lint
- Vite production build
- workload list/detail browser smoke
- Element Plus date-range panel browser smoke, 0 console errors
- compiled DatePicker, MessageBox and Popover selectors remain present
- three independent read-only reviews

This does not claim a measured Core Web Vitals improvement; the current environment has no Chrome DevTools trace integration.

/kind cleanup
