### PR TITLE
fix(metrics): preserve missing device usage samples

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -256,9 +256,11 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 		deviceMemUsed, err := s.deviceMemUsed(ctx, provider, device.Id)
 		if err == nil {
 			s.set(HamiMemoryUsed, float64(deviceMemUsed), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+			if device.Devmem > 0 {
+				s.set(HamiMemoryUtil, roundToOneDecimal(100*float64(deviceMemUsed/float32(device.Devmem))), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+			}
 		}
 		s.set(HamiMemorySize, float64(device.Devmem), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-		s.set(HamiMemoryUtil, roundToOneDecimal(100*float64(deviceMemUsed/float32(device.Devmem))), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		deviceMemSize, err := s.deviceMemTotal(ctx, provider, device.Id)
 		if err == nil && deviceMemSize > 0 {
 			s.set(HamiVMemoryScaling, roundToOneDecimal(float64(float32(device.Devmem)/deviceMemSize)), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
@@ -434,6 +436,17 @@ func (s *MetricsGenerator) queryInstantValWithPresence(ctx context.Context, quer
 	return 0, false, nil
 }
 
+func (s *MetricsGenerator) queryRequiredInstantVal(ctx context.Context, query string) (float32, error) {
+	val, present, err := s.queryInstantValWithPresence(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	if !present || math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
+		return 0, errNoMetricData
+	}
+	return val, nil
+}
+
 // 卡显存已使用量
 func (s *MetricsGenerator) deviceMemUsed(ctx context.Context, provider, deviceUUID string) (float32, error) {
 	query := ""
@@ -451,7 +464,7 @@ func (s *MetricsGenerator) deviceMemUsed(ctx context.Context, provider, deviceUU
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	val, err := s.queryInstantVal(ctx, query)
+	val, err := s.queryRequiredInstantVal(ctx, query)
 	if err != nil {
 		return val, err
 	}
@@ -513,7 +526,7 @@ func (s *MetricsGenerator) deviceCoreUtil(ctx context.Context, provider, deviceU
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	return s.queryInstantVal(ctx, query)
+	return s.queryRequiredInstantVal(ctx, query)
 }
 
 // 任务算力利用率

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -58,6 +58,54 @@ func TestTaskCoreUsedKeepsLegacyEmptyBehaviorForOtherProviders(t *testing.T) {
 	}
 }
 
+func TestDeviceUsageMetricsDistinguishMissingFromIdle(t *testing.T) {
+	tests := []struct {
+		name  string
+		query func(*MetricsGenerator) (float32, error)
+	}{
+		{
+			name: "memory",
+			query: func(generator *MetricsGenerator) (float32, error) {
+				return generator.deviceMemUsed(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+			},
+		},
+		{
+			name: "compute",
+			query: func(generator *MetricsGenerator) (float32, error) {
+				return generator.deviceCoreUtil(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" missing", func(t *testing.T) {
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}}
+			_, err := tt.query(generator)
+			if !errors.Is(err, errNoMetricData) {
+				t.Fatalf("expected errNoMetricData, got %v", err)
+			}
+		})
+
+		t.Run(tt.name+" idle", func(t *testing.T) {
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: 0}}}}}}
+			value, err := tt.query(generator)
+			if err != nil || value != 0 {
+				t.Fatalf("idle sample = (%v, %v), want (0, nil)", value, err)
+			}
+		})
+	}
+}
+
+func TestDeviceUsageMetricsRejectNonFiniteSamples(t *testing.T) {
+	for _, value := range []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
+		generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: value}}}}}}
+		_, err := generator.deviceCoreUtil(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+		if !errors.Is(err, errNoMetricData) {
+			t.Fatalf("expected errNoMetricData for %v, got %v", value, err)
+		}
+	}
+}
+
 func TestNvidiaContainerCoreMetrics(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Device-level memory and compute queries currently turn an empty Prometheus vector into a valid zero sample. The exporter then publishes that zero, so consumers cannot distinguish an idle accelerator from missing vendor metrics.

Preserve query presence for these usage paths: missing and non-finite samples are omitted, while a real zero is still exported. Memory utilization is now emitted only when the underlying used-memory sample and registered capacity are valid.

**Verification**:

- go test ./internal/exporter
- make generate-wire && go test ./...

Tests cover missing versus idle samples and NaN/Infinity rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device memory and compute utilization reporting when metrics are missing or invalid.
  * Preserved valid idle readings instead of treating them as unavailable.
  * Reported memory utilization only when valid usage data and device memory capacity are available.
* **Tests**
  * Added coverage for missing, idle, NaN, and infinite metric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->