### PR TITLE
fix(web): make overview metric semantics explicit

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:metrics && pnpm run test:workload",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:metrics": "node --test projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs"
   },
   "dependencies": {

--- a/packages/web/projects/vgpu/components/gauge.vue
+++ b/packages/web/projects/vgpu/components/gauge.vue
@@ -1,49 +1,123 @@
 <template>
   <div class="gauge-card">
-    <div class="gauge-card__title">{{ title }}</div>
+    <div class="gauge-card__title">
+      <span>{{ title }}</span>
+      <t-tooltip
+        v-if="description"
+        :content="description"
+        :visible="helpVisible"
+      >
+        <button
+          type="button"
+          class="gauge-card__help"
+          :aria-label="metricHelpLabel || title"
+          :aria-describedby="helpDescriptionId"
+          @mouseenter="helpHovered = true"
+          @mouseleave="helpHovered = false"
+          @focus="helpFocused = true"
+          @blur="helpFocused = false"
+        >
+          <help-circle-icon aria-hidden="true" />
+        </button>
+      </t-tooltip>
+      <span
+        v-if="description"
+        :id="helpDescriptionId"
+        class="gauge-card__sr-only"
+      >
+        {{ description }}
+      </span>
+    </div>
     <div class="gauge-card__value">
-      <span class="gauge-card__number">{{ percent.toFixed(1) }}</span>
-      <span class="gauge-card__unit">{{ gaugeUnit || '%' }}</span>
+      <template v-if="isReady">
+        <span class="gauge-card__number">{{ numericPercent.toFixed(1) }}</span>
+        <span class="gauge-card__unit">{{ gaugeUnit || '%' }}</span>
+      </template>
+      <span v-else class="gauge-card__number gauge-card__number--empty">—</span>
     </div>
     <t-progress
-      v-if="showProgress"
+      v-if="showProgress && isReady"
       theme="line"
-      :percentage="Math.min(100, Math.max(0, Number(percent)))"
+      :percentage="Math.min(100, Math.max(0, numericPercent))"
       :color="progressColor"
       :label="false"
       track-color="#e5e7eb"
       class="gauge-card__progress"
+      aria-hidden="true"
     />
     <div class="gauge-card__detail" v-if="!hideInfo">
-      <span>{{ title.includes('使用') || title.includes('Usage') ? $t('dashboard.usage') : $t('dashboard.allocation') }}</span>
-      <span v-if="unit && !title.includes('算力') && !title.includes('Compute')"> ({{ unit }})</span>
-      <span> : </span>
-      <b>{{ displayUsed.toFixed(1) }} / {{ displayTotal.toFixed() }}</b>
+      <template v-if="isReady">
+        <span>{{ detailLabel }}</span>
+        <span>: </span>
+        <b v-if="detailMode === 'value'">{{
+          displayUsed.toFixed(usedPrecision)
+        }}</b>
+        <b v-else>
+          {{ displayUsed.toFixed(usedPrecision) }} /
+          {{ displayTotal.toFixed(totalPrecision) }}
+        </b>
+        <span v-if="unit" class="gauge-card__detail-unit"
+          >&nbsp;{{ unit }}</span
+        >
+      </template>
+      <span v-else-if="status === 'error'">{{
+        $t('dashboard.metricQueryFailed')
+      }}</span>
+      <span v-else-if="status === 'loading'">{{ $t('common.loading') }}</span>
+      <span v-else-if="status === 'invalid'">{{
+        $t('dashboard.metricInvalid')
+      }}</span>
+      <span v-else-if="status === 'no-capacity'">{{
+        $t('dashboard.metricNoCapacity')
+      }}</span>
+      <span v-else>{{ $t('dashboard.metricNoData') }}</span>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, useId } from 'vue';
+import { HelpCircleIcon } from 'tdesign-icons-vue-next';
 
-const props = defineProps([
-  'title',
-  'total',
-  'used',
-  'unit',
-  'gaugeUnit',
-  'percent',
-  'hideInfo',
-  'showProgress',
-]);
+const props = defineProps({
+  title: { type: String, required: true },
+  description: { type: String, default: '' },
+  metricHelpLabel: { type: String, default: '' },
+  detailLabel: { type: String, default: '' },
+  detailMode: { type: String, default: 'ratio' },
+  kind: { type: String, default: 'allocation' },
+  displayDivisor: { type: Number, default: 1 },
+  usedPrecision: { type: Number, default: 1 },
+  totalPrecision: { type: Number, default: 0 },
+  status: { type: String, default: 'loading' },
+  total: { type: [Number, String], default: 0 },
+  used: { type: [Number, String], default: 0 },
+  unit: { type: String, default: '' },
+  gaugeUnit: { type: String, default: '%' },
+  percent: { type: [Number, String], default: 0 },
+  hideInfo: { type: Boolean, default: false },
+  showProgress: { type: Boolean, default: true },
+});
 
+const helpDescriptionId = useId();
+const helpHovered = ref(false);
+const helpFocused = ref(false);
+const helpVisible = computed(() => helpHovered.value || helpFocused.value);
 const showProgress = computed(() => props.showProgress !== false);
-const isComputeTitle = computed(() => props.title?.includes('算力') || props.title?.includes('Compute'));
-const displayDivisor = computed(() => (isComputeTitle.value ? 100 : 1));
-const displayUsed = computed(() => Number(props.used || 0) / displayDivisor.value);
-const displayTotal = computed(() => Number(props.total || 0) / displayDivisor.value);
+const numericPercent = computed(() => Number(props.percent));
+const isReady = computed(
+  () => props.status === 'ready' && Number.isFinite(numericPercent.value),
+);
+const displayUsed = computed(
+  () => Number(props.used || 0) / props.displayDivisor,
+);
+const displayTotal = computed(
+  () => Number(props.total || 0) / props.displayDivisor,
+);
 
 const progressColor = computed(() => {
+  if (props.kind === 'utilization') return '#2563EB';
+
   const value = Number(props.percent);
   if (value < 50) return '#16A34A';
   if (value < 80) return '#2563EB';
@@ -62,10 +136,53 @@ const progressColor = computed(() => {
   border-radius: 8px;
 
   &__title {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 12px;
     color: #939ea9;
     margin-bottom: 8px;
     line-height: 20px;
+  }
+
+  &__help {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: 0;
+    color: #939ea9;
+    background: transparent;
+    cursor: help;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+
+    &:hover {
+      color: var(--el-color-primary);
+    }
+
+    &:focus-visible {
+      border-radius: 4px;
+      outline: 2px solid var(--el-color-primary);
+      outline-offset: 1px;
+    }
+  }
+
+  &__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   &__value {
@@ -77,6 +194,10 @@ const progressColor = computed(() => {
     font-weight: 600;
     color: #1d2b3a;
     line-height: 28px;
+  }
+
+  &__number--empty {
+    color: #939ea9;
   }
 
   &__unit {

--- a/packages/web/projects/vgpu/hooks/instant-vector-state.mjs
+++ b/packages/web/projects/vgpu/hooks/instant-vector-state.mjs
@@ -1,0 +1,80 @@
+export const METRIC_STATUS = Object.freeze({
+  LOADING: 'loading',
+  READY: 'ready',
+  MISSING: 'missing',
+  INVALID: 'invalid',
+  NO_CAPACITY: 'no-capacity',
+  ERROR: 'error',
+});
+
+export const readInstantValue = (response) => {
+  const rawValue = response?.data?.[0]?.value;
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return { status: METRIC_STATUS.MISSING, value: 0 };
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isFinite(value)) {
+    return { status: METRIC_STATUS.INVALID, value: 0 };
+  }
+
+  return { status: METRIC_STATUS.READY, value };
+};
+
+export const calculateMetricPercent = (used, total) => {
+  const numericUsed = Number(used);
+  const numericTotal = Number(total);
+  if (
+    !Number.isFinite(numericUsed) ||
+    !Number.isFinite(numericTotal) ||
+    numericTotal <= 0
+  ) {
+    return undefined;
+  }
+
+  return (numericUsed / numericTotal) * 100;
+};
+
+export const requiresMetricCapacity = (config) =>
+  Object.prototype.hasOwnProperty.call(config, 'percent');
+
+export const setMetricErrorState = (
+  metric,
+  { hasTotal = false, requiresCapacity = false } = {},
+) => {
+  metric.hasData = undefined;
+  metric.totalHasData = undefined;
+  metric.count = 0;
+  metric.used = 0;
+  if (hasTotal) {
+    metric.total = 0;
+  }
+  metric.status = METRIC_STATUS.ERROR;
+  if (requiresCapacity) {
+    metric.percent = 0;
+  } else {
+    delete metric.percent;
+  }
+  return metric;
+};
+
+export const resolveMetricStatus = ({
+  usedStatus,
+  totalStatus,
+  total,
+  requiresCapacity = false,
+}) => {
+  if (totalStatus && totalStatus !== METRIC_STATUS.READY) {
+    return totalStatus;
+  }
+  if (usedStatus !== METRIC_STATUS.READY) {
+    return usedStatus;
+  }
+  if (
+    requiresCapacity &&
+    (!Number.isFinite(Number(total)) || Number(total) <= 0)
+  ) {
+    return METRIC_STATUS.NO_CAPACITY;
+  }
+  return METRIC_STATUS.READY;
+};

--- a/packages/web/projects/vgpu/hooks/instant-vector-state.test.mjs
+++ b/packages/web/projects/vgpu/hooks/instant-vector-state.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  calculateMetricPercent,
+  METRIC_STATUS,
+  readInstantValue,
+  requiresMetricCapacity,
+  resolveMetricStatus,
+  setMetricErrorState,
+} from './instant-vector-state.mjs';
+
+test('an empty instant vector is distinct from a real zero sample', () => {
+  assert.deepEqual(readInstantValue({ data: [] }), {
+    status: METRIC_STATUS.MISSING,
+    value: 0,
+  });
+  assert.deepEqual(readInstantValue({ data: [{ value: 0 }] }), {
+    status: METRIC_STATUS.READY,
+    value: 0,
+  });
+});
+
+test('protobuf JSON non-finite samples are marked invalid', () => {
+  for (const value of ['NaN', 'Infinity', '-Infinity', Number.NaN]) {
+    assert.equal(
+      readInstantValue({ data: [{ value }] }).status,
+      METRIC_STATUS.INVALID,
+    );
+  }
+});
+
+test('percentages require a finite positive capacity', () => {
+  assert.equal(calculateMetricPercent(0, 800), 0);
+  assert.equal(calculateMetricPercent(1200, 800), 150);
+  assert.equal(calculateMetricPercent(0, 0), undefined);
+  assert.equal(calculateMetricPercent(10, undefined), undefined);
+});
+
+test('capacity semantics come from the original metric config', () => {
+  assert.equal(requiresMetricCapacity({ query: 'sum(metric)' }), false);
+  assert.equal(requiresMetricCapacity({ percent: 0 }), true);
+  assert.equal(
+    requiresMetricCapacity(Object.create({ percent: 0 })),
+    false,
+  );
+});
+
+test('query errors remain unknown instead of becoming missing data', () => {
+  const plainMetric = {
+    hasData: false,
+    count: 42,
+    used: 42,
+    percent: 99,
+  };
+  setMetricErrorState(plainMetric);
+  assert.equal(plainMetric.status, METRIC_STATUS.ERROR);
+  assert.equal(plainMetric.hasData, undefined);
+  assert.equal(Object.hasOwn(plainMetric, 'percent'), false);
+
+  const capacityMetric = { percent: 50, total: 100 };
+  setMetricErrorState(capacityMetric, {
+    hasTotal: true,
+    requiresCapacity: true,
+  });
+  assert.equal(capacityMetric.hasData, undefined);
+  assert.equal(capacityMetric.totalHasData, undefined);
+  assert.equal(capacityMetric.percent, 0);
+  assert.equal(capacityMetric.total, 0);
+});
+
+test('metric status keeps missing, invalid and zero-capacity states distinct', () => {
+  assert.equal(
+    resolveMetricStatus({
+      usedStatus: METRIC_STATUS.MISSING,
+      totalStatus: METRIC_STATUS.READY,
+      total: 800,
+      requiresCapacity: true,
+    }),
+    METRIC_STATUS.MISSING,
+  );
+  assert.equal(
+    resolveMetricStatus({
+      usedStatus: METRIC_STATUS.READY,
+      totalStatus: METRIC_STATUS.INVALID,
+      total: 0,
+      requiresCapacity: true,
+    }),
+    METRIC_STATUS.INVALID,
+  );
+  assert.equal(
+    resolveMetricStatus({
+      usedStatus: METRIC_STATUS.READY,
+      totalStatus: METRIC_STATUS.READY,
+      total: 0,
+      requiresCapacity: true,
+    }),
+    METRIC_STATUS.NO_CAPACITY,
+  );
+  assert.equal(
+    resolveMetricStatus({
+      usedStatus: METRIC_STATUS.READY,
+      totalStatus: METRIC_STATUS.READY,
+      total: 800,
+      requiresCapacity: true,
+    }),
+    METRIC_STATUS.READY,
+  );
+});

--- a/packages/web/projects/vgpu/hooks/useInstantVector.js
+++ b/packages/web/projects/vgpu/hooks/useInstantVector.js
@@ -1,9 +1,22 @@
 import cardApi from '~/vgpu/api/card';
-import { onMounted, ref, watch, watchEffect } from 'vue';
+import { ref, watch, watchEffect } from 'vue';
 import { timeParse, calculatePrometheusStep } from '@/utils';
+import {
+  calculateMetricPercent,
+  METRIC_STATUS,
+  readInstantValue,
+  requiresMetricCapacity,
+  resolveMetricStatus,
+  setMetricErrorState,
+} from './instant-vector-state.mjs';
 
 const useInstantVector = (configs, parseQuery = (query) => query, times) => {
-  const data = ref(configs);
+  const data = ref(
+    configs.map((config) => ({
+      ...config,
+      status: METRIC_STATUS.LOADING,
+    })),
+  );
 
   const safeParseQuery = (q) => {
     try {
@@ -16,56 +29,86 @@ const useInstantVector = (configs, parseQuery = (query) => query, times) => {
 
   const fetchInstantData = async () => {
     const reqs = configs.map(
-      async ({ query, totalQuery, percentQuery, cntQuery }, index) => {
+      async (config, index) => {
+        const { query, totalQuery, percentQuery } = config;
+        const metric = data.value[index];
+        const requiresCapacity = requiresMetricCapacity(config);
+        metric.status = METRIC_STATUS.LOADING;
         const parsedQuery = query ? safeParseQuery(query) : undefined;
         if (!parsedQuery || parsedQuery.includes('undefined')) {
           return;
         }
-        if (query) {
-          const usedData = await cardApi.getInstantVector({
-            query: parsedQuery,
+        try {
+          let usedStatus = METRIC_STATUS.MISSING;
+          let totalStatus;
+          if (query) {
+            const usedData = await cardApi.getInstantVector({
+              query: parsedQuery,
+            });
+            const usedSample = readInstantValue(usedData);
+
+            // Preserve whether Prometheus returned a real sample. A zero sample
+            // is valid; an empty vector means that the metric is unavailable.
+            metric.hasData = usedSample.status === METRIC_STATUS.READY;
+            metric.count = usedSample.value;
+            metric.used = usedSample.value;
+            usedStatus = usedSample.status;
+          }
+
+          if (totalQuery) {
+            const parsedTotalQuery = safeParseQuery(totalQuery);
+            if (!parsedTotalQuery || parsedTotalQuery.includes('undefined')) {
+              return;
+            }
+            const totalData = await cardApi.getInstantVector({
+              query: parsedTotalQuery,
+            });
+            const totalSample = readInstantValue(totalData);
+            totalStatus = totalSample.status;
+            metric.totalHasData = totalSample.status === METRIC_STATUS.READY;
+            metric.total = totalSample.value;
+          }
+
+          metric.status = resolveMetricStatus({
+            usedStatus,
+            totalStatus,
+            total: metric.total,
+            requiresCapacity,
           });
 
-          // Preserve whether Prometheus returned a series. Some consumers need
-          // to distinguish a real zero from an empty vector (for example, an
-          // existing container with no CPU or memory limit).
-          const hasData = usedData.data.length > 0;
-          const used = hasData ? usedData.data[0]?.value : 0;
-          data.value[index].hasData = hasData;
-          data.value[index].count = used;
-          data.value[index].used = used;
-        }
+          if (requiresCapacity) {
+            const percent = calculateMetricPercent(metric.used, metric.total);
+            metric.percent = percent ?? 0;
+          }
 
-        if (totalQuery) {
-          const parsedTotalQuery = safeParseQuery(totalQuery);
-          if (!parsedTotalQuery || parsedTotalQuery.includes('undefined')) {
-            return;
-          }
-          const totalData = await cardApi.getInstantVector({
-            query: parsedTotalQuery,
-          });
-          if (totalData.data[0]) {
-            data.value[index].total = totalData.data[0].value;
-          }
-        }
-        if (data.value[index].total !== 0) {
-            data.value[index].percent = data.value[index].used / data.value[index].total * 100;
-        }
-        if (percentQuery && times?.value?.[0] && times?.value?.[1]) {
-          const parsedPercentQuery = safeParseQuery(percentQuery);
-          if (!parsedPercentQuery || parsedPercentQuery.includes('undefined')) {
-            return;
-          }
-          const percentData = await cardApi.getRangeVector({
-            query: parsedPercentQuery,
-            range: {
-                start: timeParse(times.value[0]),
-                end: timeParse(times.value[1]),
-              step: calculatePrometheusStep(times.value[0], times.value[1]),
-            },
-          });
+          if (percentQuery && times?.value?.[0] && times?.value?.[1]) {
+            const parsedPercentQuery = safeParseQuery(percentQuery);
+            if (
+              !parsedPercentQuery ||
+              parsedPercentQuery.includes('undefined')
+            ) {
+              return;
+            }
+            try {
+              const percentData = await cardApi.getRangeVector({
+                query: parsedPercentQuery,
+                range: {
+                  start: timeParse(times.value[0]),
+                  end: timeParse(times.value[1]),
+                  step: calculatePrometheusStep(times.value[0], times.value[1]),
+                },
+              });
 
-          data.value[index].data = percentData.data[0]?.values || [];
+              metric.data = percentData.data[0]?.values || [];
+            } catch {
+              metric.data = [];
+            }
+          }
+        } catch {
+          setMetricErrorState(metric, {
+            hasTotal: Boolean(totalQuery),
+            requiresCapacity,
+          });
         }
       },
     );

--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -15,7 +15,7 @@
             </RouterLink>
           </template>
           <div class="card-overview">
-            <div v-for="item in cardGaugeConfig" :key="item.title">
+            <div v-for="item in cardGaugeConfig" :key="item.id">
               <Gauge v-bind="item" />
             </div>
           </div>
@@ -206,8 +206,8 @@ import TabTop from '~/vgpu/components/TabTop.vue';
 import Gauge from '~/vgpu/components/gauge.vue';
 import { getRangeConfigInit } from './config';
 import {
-  createComputeUsageGaugeConfig,
   createNodeAllocationTopQueries,
+  createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 
 const router = useRouter();
@@ -389,58 +389,7 @@ const fetchNodeWorkloadDistribution = () => {
     });
 };
 
-// Use a base config object for non-reactive parts or keep useInstantVector
-// But useInstantVector likely returns a ref. We need to update titles.
-// Since useInstantVector is a custom hook, let's see if we can wrap the titles in computed or update them.
-// For simplicity in this refactor without changing the hook, let's update the titles in a watcher or computed wrapper.
-// Actually, let's just redefine the config inside a computed that returns the full object if the hook allows,
-// OR better: let the hook run once, and we wrap the result to override titles.
-// However, useInstantVector likely executes queries.
-// Let's use the existing `cardGaugeConfig` but update its titles reactively.
-
-const _cardGaugeConfig = useInstantVector([
-  {
-    title: 'vgpuAllocRate', // Use keys here
-    percent: 0,
-    query: `avg(sum (hami_container_vgpu_allocated) by (instance))`,
-    totalQuery: `avg(sum (hami_vgpu_count) by (instance))`,
-    percentQuery: `avg(sum (hami_container_vgpu_allocated) by (instance))/avg(sum (hami_vgpu_count) by (instance)) *100`,
-    total: 0,
-    used: 0,
-    unit: t('common.unitCount'),
-  },
-  {
-    title: 'computeAllocRate',
-    percent: 0,
-    query: `avg(sum(hami_container_vcore_allocated) by (instance))`,
-    totalQuery: `avg(sum(hami_core_size) by (instance))`,
-    percentQuery: `avg(sum(hami_container_vcore_allocated) by (instance))/avg(sum(hami_core_size) by (instance)) *100`,
-    total: 0,
-    used: 0,
-    unit: ' ',
-  },
-  {
-    title: 'memAllocRate',
-    percent: 0,
-    query: `avg(sum(hami_container_vmemory_allocated) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size) by (instance)) / 1024`,
-    percentQuery: `(avg(sum(hami_container_vmemory_allocated) by (instance)) / 1024 )/(avg(sum(hami_memory_size) by (instance)) / 1024) *100 `,
-    total: 0,
-    used: 0,
-    unit: 'GiB',
-  },
-  createComputeUsageGaugeConfig(),
-  {
-    title: 'memUsageRate',
-    percent: 0,
-    query: `avg(sum(hami_memory_used) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size) by (instance))/1024`,
-    percentQuery: `(avg(sum(hami_memory_used) by (instance)) / 1024)/(avg(sum(hami_memory_size) by (instance))/1024)*100`,
-    total: 0,
-    used: 0,
-    unit: 'GiB',
-  },
-]);
+const _cardGaugeConfig = useInstantVector(createOverviewGaugeConfigs());
 
 const clusterResourceConfig = useInstantVector([
   {
@@ -456,9 +405,15 @@ const clusterResourceConfig = useInstantVector([
 ]);
 
 const cardGaugeConfig = computed(() => {
-  return _cardGaugeConfig.value.map(item => ({
+  return _cardGaugeConfig.value.map((item) => ({
     ...item,
-    title: t(`dashboard.${item.title}`)
+    title: t(item.titleKey),
+    description: t(item.descriptionKey),
+    detailLabel: t(item.detailLabelKey),
+    unit: item.unitKey ? t(item.unitKey) : item.unit,
+    metricHelpLabel: t('dashboard.metricHelpLabel', {
+      metric: t(item.titleKey),
+    }),
   }));
 });
 

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
@@ -1,15 +1,88 @@
 export const createComputeUsageGaugeConfig = () => ({
-  title: 'computeUsageRate',
+  id: 'compute-utilization',
+  kind: 'utilization',
+  titleKey: 'dashboard.computeUsageRate',
+  descriptionKey: 'dashboard.computeUsageRateDescription',
+  detailLabelKey: 'dashboard.deviceAverage',
+  detailMode: 'value',
   percent: 0,
   query: 'avg(avg(hami_core_util) by (node, device_uuid))',
-  percentQuery: 'avg(avg(hami_core_util_avg) by (node, device_uuid))',
   // hami_core_util is already a percentage in the 0-100 range. Dividing it by
   // cluster-wide hami_core_size would make the displayed value shrink as more
   // devices are added to the cluster.
   total: 100,
   used: 0,
-  unit: ' ',
+  unit: '%',
 });
+
+export const createOverviewGaugeConfigs = () => [
+  {
+    id: 'vgpu-allocation',
+    kind: 'allocation',
+    titleKey: 'dashboard.vgpuAllocRate',
+    descriptionKey: 'dashboard.vgpuAllocRateDescription',
+    detailLabelKey: 'dashboard.allocated',
+    detailMode: 'ratio',
+    usedPrecision: 0,
+    totalPrecision: 0,
+    percent: 0,
+    query:
+      'avg(sum(hami_container_vgpu_allocated) by (instance)) or (avg(sum(hami_vgpu_count) by (instance)) * 0)',
+    totalQuery: 'avg(sum(hami_vgpu_count) by (instance))',
+    total: 0,
+    used: 0,
+    unitKey: 'dashboard.vgpuSlotUnit',
+  },
+  {
+    id: 'compute-allocation',
+    kind: 'allocation',
+    titleKey: 'dashboard.computeAllocRate',
+    descriptionKey: 'dashboard.computeAllocRateDescription',
+    detailLabelKey: 'dashboard.allocated',
+    detailMode: 'ratio',
+    displayDivisor: 100,
+    percent: 0,
+    query:
+      'avg(sum(hami_container_vcore_allocated) by (instance)) or (avg(sum(hami_core_size) by (instance)) * 0)',
+    totalQuery: 'avg(sum(hami_core_size) by (instance))',
+    total: 0,
+    used: 0,
+    unitKey: 'dashboard.acceleratorEquivalentUnit',
+  },
+  {
+    id: 'memory-allocation',
+    kind: 'allocation',
+    titleKey: 'dashboard.memAllocRate',
+    descriptionKey: 'dashboard.memAllocRateDescription',
+    detailLabelKey: 'dashboard.allocated',
+    detailMode: 'ratio',
+    totalPrecision: 1,
+    percent: 0,
+    query:
+      '(avg(sum(hami_container_vmemory_allocated) by (instance)) or (avg(sum(hami_memory_size) by (instance)) * 0)) / 1024',
+    totalQuery: 'avg(sum(hami_memory_size) by (instance)) / 1024',
+    total: 0,
+    used: 0,
+    unit: 'GiB',
+  },
+  createComputeUsageGaugeConfig(),
+  {
+    id: 'memory-utilization',
+    kind: 'utilization',
+    titleKey: 'dashboard.memUsageRate',
+    descriptionKey: 'dashboard.memUsageRateDescription',
+    detailLabelKey: 'dashboard.used',
+    detailMode: 'ratio',
+    totalPrecision: 1,
+    percent: 0,
+    query: 'avg(sum(hami_memory_used) by (instance)) / 1024',
+    totalQuery:
+      'avg(sum by (instance) (hami_memory_size and on (instance, node, provider, device_uuid) hami_memory_used)) / 1024',
+    total: 0,
+    used: 0,
+    unit: 'GiB',
+  },
+];
 
 // Allocation series only exist for devices assigned to a workload. Sum all
 // devices within each scrape target first, then average equivalent exporter

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   createComputeUsageGaugeConfig,
   createNodeAllocationTopQueries,
+  createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 
 test('compute utilization is treated as an already-normalized percentage', () => {
@@ -13,6 +14,72 @@ test('compute utilization is treated as an already-normalized percentage', () =>
   assert.equal(config.totalQuery, undefined);
   assert.match(config.query, /hami_core_util/);
   assert.equal((41 / config.total) * 100, 41);
+});
+
+test('overview gauges declare display semantics independently of translated titles', () => {
+  const configs = createOverviewGaugeConfigs();
+
+  assert.deepEqual(
+    configs.map(({ titleKey, detailMode, displayDivisor = 1 }) => ({
+      titleKey,
+      detailMode,
+      displayDivisor,
+    })),
+    [
+      {
+        titleKey: 'dashboard.vgpuAllocRate',
+        detailMode: 'ratio',
+        displayDivisor: 1,
+      },
+      {
+        titleKey: 'dashboard.computeAllocRate',
+        detailMode: 'ratio',
+        displayDivisor: 100,
+      },
+      {
+        titleKey: 'dashboard.memAllocRate',
+        detailMode: 'ratio',
+        displayDivisor: 1,
+      },
+      {
+        titleKey: 'dashboard.computeUsageRate',
+        detailMode: 'value',
+        displayDivisor: 1,
+      },
+      {
+        titleKey: 'dashboard.memUsageRate',
+        detailMode: 'ratio',
+        displayDivisor: 1,
+      },
+    ],
+  );
+});
+
+test('allocation gauges preserve their current capacity contracts', () => {
+  const [vgpu, compute, memory] = createOverviewGaugeConfigs();
+
+  assert.match(vgpu.totalQuery, /hami_vgpu_count/);
+  assert.match(compute.totalQuery, /hami_core_size/);
+  assert.doesNotMatch(compute.totalQuery, /hami_vcore_size/);
+  assert.match(memory.totalQuery, /hami_memory_size/);
+  assert.doesNotMatch(memory.totalQuery, /hami_vmemory_size/);
+});
+
+test('an idle cluster reports zero allocation when capacity is present', () => {
+  const [vgpu, compute, memory] = createOverviewGaugeConfigs();
+
+  assert.match(vgpu.query, /or \(avg\(sum\(hami_vgpu_count\)/);
+  assert.match(compute.query, /or \(avg\(sum\(hami_core_size\)/);
+  assert.match(memory.query, /or \(avg\(sum\(hami_memory_size\)/);
+});
+
+test('memory utilization capacity only includes reporting devices', () => {
+  const memoryUtilization = createOverviewGaugeConfigs().at(-1);
+
+  assert.match(
+    memoryUtilization.totalQuery,
+    /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
+  );
 });
 
 test('node allocation rankings include every device and fully idle nodes', () => {

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -202,6 +202,7 @@ import { getLineOptions } from '~/vgpu/components/config';
 import VChart from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
 import { formatWorkloadName } from './workload-identity.mjs';
+import { METRIC_STATUS } from '~/vgpu/hooks/instant-vector-state.mjs';
 
 const route = useRoute();
 const router = useRouter();
@@ -355,7 +356,7 @@ const resourceOverviewTexts = computed(() => {
       const value = toNumOrUndefined(metric.count);
       return value === undefined ? '--' : formatter(value);
     }
-    if (metric?.hasData === false && hasContainerInfo) {
+    if (metric?.status === METRIC_STATUS.MISSING && hasContainerInfo) {
       return t('common.notLimited');
     }
     return '--';

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -68,11 +68,29 @@ export default {
     viewAllGpuResources: 'View all GPU resources',
     viewAllNodes: 'View all nodes',
     viewAllGpuTypes: 'View all GPU types',
-    vgpuAllocRate: 'vGPU Alloc',
-    computeAllocRate: 'Compute Alloc',
-    memAllocRate: 'Memory Alloc',
-    computeUsageRate: 'Compute Usage',
+    vgpuAllocRate: 'vGPU Allocation',
+    computeAllocRate: 'Compute Allocation',
+    memAllocRate: 'Memory Allocation',
+    computeUsageRate: 'Compute Utilization',
     memUsageRate: 'Memory Usage',
+    vgpuAllocRateDescription:
+      'Allocated vGPU slots divided by the schedulable slots registered by HAMi. Slot capacity comes from device splitting and is not the physical accelerator count.',
+    computeAllocRateDescription:
+      'Allocated vCore divided by the physical compute baseline (100 per accelerator). Values above 100% indicate compute overcommit.',
+    memAllocRateDescription:
+      'Accelerator memory allocated to workloads divided by the schedulable memory registered by HAMi. With memory overcommit, the denominator includes expanded virtual capacity.',
+    computeUsageRateDescription:
+      'Equal-weight average of provider-native, device-level compute utilization across reporting devices. Definitions may differ by provider; this is not compute allocation.',
+    memUsageRateDescription:
+      'Used memory divided by HAMi-registered memory capacity across devices reporting memory-use data. With memory overcommit, this is not physical memory occupancy.',
+    metricHelpLabel: 'View metric definition for {metric}',
+    metricNoData: 'No metric data',
+    metricInvalid: 'Invalid metric value',
+    metricNoCapacity: 'No available capacity',
+    metricQueryFailed: 'Query failed',
+    deviceAverage: 'Reporting-device average',
+    vgpuSlotUnit: 'slots',
+    acceleratorEquivalentUnit: 'card eq.',
     computePowerTotal: 'Compute Power Total',
     node: 'Node',
     nodeTotal: 'Total Nodes',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -71,8 +71,26 @@ export default {
     vgpuAllocRate: 'vGPU 分配率',
     computeAllocRate: '算力分配率',
     memAllocRate: '显存分配率',
-    computeUsageRate: '算力使用率',
+    computeUsageRate: '算力利用率',
     memUsageRate: '显存使用率',
+    vgpuAllocRateDescription:
+      '已分配 vGPU 槽位 ÷ HAMi 注册的可调度槽位。槽位容量来自设备拆分配置，不等于物理加速卡数量。',
+    computeAllocRateDescription:
+      '已分配给工作负载的 vCore ÷ 物理算力基准（每张加速卡按 100 计）。超过 100% 表示算力超配。',
+    memAllocRateDescription:
+      '已分配给工作负载的显存 ÷ HAMi 注册的可调度显存。启用显存超配时，分母包含扩展后的虚拟容量。',
+    computeUsageRateDescription:
+      '所有已上报设备的厂商原生设备级算力利用率等权平均。不同厂商口径可能不同；它不是算力分配率。',
+    memUsageRateDescription:
+      '已上报显存使用数据的设备，其已用显存 ÷ HAMi 注册容量。启用显存超配时，该值不等于物理显存占用率。',
+    metricHelpLabel: '查看{metric}指标说明',
+    metricNoData: '暂无指标数据',
+    metricInvalid: '指标值无效',
+    metricNoCapacity: '无可用容量',
+    metricQueryFailed: '查询失败',
+    deviceAverage: '上报设备平均',
+    vgpuSlotUnit: '槽位',
+    acceleratorEquivalentUnit: '卡等效',
     computePowerTotal: '算力总量',
     node: '节点',
     nodeTotal: '节点总数',


### PR DESCRIPTION
The overview gauges currently infer semantics from translated titles and can render missing data as 0%.

This PR:
- defines each gauge's query, unit, display mode, and description explicitly;
- distinguishes real zero, missing, invalid, no-capacity, loading, and query-error states;
- keeps query failures from being reported as an unlimited CPU or memory limit;
- preserves allocation values above 100% and limits memory usage capacity to devices that report usage;
- adds keyboard-focusable metric definition tooltips in Chinese and English.

It builds on #178, which preserves missing vendor samples in the exporter.

Verification:
- `pnpm test`
- ESLint on all changed frontend files
- `pnpm build`
- browser checks for 0%, 150% overcommit, missing/error/no-capacity states, tooltips, and language switching
