### PR TITLE
fix(metrics): align allocation capacity and coverage

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:metrics && pnpm run test:workload",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:metrics": "node --test projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs"
   },
   "dependencies": {

--- a/packages/web/projects/vgpu/components/previewBar.vue
+++ b/packages/web/projects/vgpu/components/previewBar.vue
@@ -57,6 +57,7 @@ import { getPreviewBarPie } from '~/vgpu/components/config';
 import { onMounted, ref, computed } from 'vue';
 import cardApi from '~/vgpu/api/card';
 import TabTop from '~/vgpu/components/TabTop.vue';
+import { buildGroupedResourceTopQueries } from '~/vgpu/metrics/query-contract.mjs';
 
 const props = defineProps({
   title: {
@@ -74,6 +75,9 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 const isNodeType = computed(() => props.type === 'node');
+const resourceTopQueries = computed(() =>
+  buildGroupedResourceTopQueries(props.type),
+);
 
 const nodeComputeTop5 = computed(() => ({
   title: t('dashboard.nodeComputeTop5'),
@@ -83,14 +87,14 @@ const nodeComputeTop5 = computed(() => ({
       key: 'alloc',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_container_vcore_allocated{}) by (${props.type}) / sum(hami_core_size{}) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.computeAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       nameKey: props.type,
       data: [],
-      query: `topk(5, avg(hami_core_util_avg) by (${props.type}))`,
+      query: resourceTopQueries.value.computeUsage,
     },
   ],
 }));
@@ -103,14 +107,14 @@ const nodeMemoryTop5 = computed(() => ({
       key: 'alloc',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_container_vmemory_allocated{}) by (${props.type}) / sum(hami_memory_size{}) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.memoryAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_memory_used) by (${props.type}) / sum(hami_memory_size) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.memoryUsage,
     },
   ],
 }));
@@ -123,14 +127,14 @@ const gpuComputeTop5 = computed(() => ({
       key: 'alloc',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_container_vcore_allocated{}) by (${props.type}) / sum(hami_core_size{}) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.computeAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       nameKey: props.type,
       data: [],
-      query: `topk(5, avg(hami_core_util_avg) by (${props.type}))`,
+      query: resourceTopQueries.value.computeUsage,
     },
   ],
 }));
@@ -143,14 +147,14 @@ const gpuMemoryTop5 = computed(() => ({
       key: 'alloc',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_container_vmemory_allocated{}) by (${props.type}) / sum(hami_memory_size{}) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.memoryAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       nameKey: props.type,
       data: [],
-      query: `topk(5, sum(hami_memory_used) by (${props.type}) / sum(hami_memory_size{}) by (${props.type}) * 100)`,
+      query: resourceTopQueries.value.memoryUsage,
     },
   ],
 }));

--- a/packages/web/projects/vgpu/hooks/instant-vector-state.mjs
+++ b/packages/web/projects/vgpu/hooks/instant-vector-state.mjs
@@ -21,6 +21,15 @@ export const readInstantValue = (response) => {
   return { status: METRIC_STATUS.READY, value };
 };
 
+export const readReadyMetricField = (metric, field) => {
+  if (metric?.status !== METRIC_STATUS.READY) {
+    return undefined;
+  }
+
+  const value = Number(metric?.[field]);
+  return Number.isFinite(value) ? value : undefined;
+};
+
 export const calculateMetricPercent = (used, total) => {
   const numericUsed = Number(used);
   const numericTotal = Number(total);

--- a/packages/web/projects/vgpu/hooks/instant-vector-state.test.mjs
+++ b/packages/web/projects/vgpu/hooks/instant-vector-state.test.mjs
@@ -5,6 +5,7 @@ import {
   calculateMetricPercent,
   METRIC_STATUS,
   readInstantValue,
+  readReadyMetricField,
   requiresMetricCapacity,
   resolveMetricStatus,
   setMetricErrorState,
@@ -28,6 +29,30 @@ test('protobuf JSON non-finite samples are marked invalid', () => {
       METRIC_STATUS.INVALID,
     );
   }
+});
+
+test('detail values only expose ready samples while preserving a real zero', () => {
+  assert.equal(
+    readReadyMetricField(
+      { status: METRIC_STATUS.READY, percent: 0 },
+      'percent',
+    ),
+    0,
+  );
+  assert.equal(
+    readReadyMetricField(
+      { status: METRIC_STATUS.MISSING, percent: 0 },
+      'percent',
+    ),
+    undefined,
+  );
+  assert.equal(
+    readReadyMetricField(
+      { status: METRIC_STATUS.ERROR, used: 0 },
+      'used',
+    ),
+    undefined,
+  );
 });
 
 test('percentages require a finite positive capacity', () => {

--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -1,0 +1,124 @@
+const METRICS = Object.freeze({
+  computeAllocated: 'hami_container_vcore_allocated',
+  computeCapacity: 'hami_core_size',
+  computeUsageAverage: 'hami_core_util_avg',
+  memoryAllocated: 'hami_container_vmemory_allocated',
+  memorySchedulableCapacity: 'hami_vmemory_size',
+  memoryPhysicalCapacity: 'hami_memory_size',
+  memoryUsed: 'hami_memory_used',
+});
+
+const PROMETHEUS_LABEL_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const REPORTING_DEVICE_MATCH = 'on (instance, node, provider, device_uuid)';
+
+const metricSeries = (metric, selector = '') =>
+  selector ? `${metric}{${selector}}` : metric;
+
+const validateGroupLabel = (groupLabel) => {
+  if (groupLabel && !PROMETHEUS_LABEL_NAME.test(groupLabel)) {
+    throw new TypeError(`Invalid Prometheus group label: ${groupLabel}`);
+  }
+};
+
+// Every WebUI backend replica exports the same cluster-wide device series.
+// Sum within one scrape target first, then average equivalent replicas.
+const aggregateAcrossExporterReplicas = (series, groupLabel = '') => {
+  validateGroupLabel(groupLabel);
+  const labels = groupLabel ? `${groupLabel}, instance` : 'instance';
+  const perReplica = `sum by (${labels}) (${series})`;
+  return groupLabel
+    ? `avg by (${groupLabel}) (${perReplica})`
+    : `avg(${perReplica})`;
+};
+
+const divideForDisplay = (expression, divisor) =>
+  divisor === 1 ? expression : `${expression} / ${divisor}`;
+
+const buildAllocationQueries = ({
+  allocatedMetric,
+  capacityMetric,
+  selector = '',
+  groupLabel = '',
+  displayDivisor = 1,
+}) => {
+  const allocated = aggregateAcrossExporterReplicas(
+    metricSeries(allocatedMetric, selector),
+    groupLabel,
+  );
+  const capacity = aggregateAcrossExporterReplicas(
+    metricSeries(capacityMetric, selector),
+    groupLabel,
+  );
+  const join = groupLabel ? ` or on (${groupLabel}) ` : ' or ';
+  const allocatedOrIdle = `(${allocated}${join}(${capacity} * 0))`;
+  const percent = `(${allocated} / ${capacity} * 100)${join}(${capacity} * 0)`;
+
+  return {
+    query: divideForDisplay(allocatedOrIdle, displayDivisor),
+    totalQuery: divideForDisplay(capacity, displayDivisor),
+    percentQuery: percent,
+  };
+};
+
+export const buildComputeAllocationQueries = (options = {}) =>
+  buildAllocationQueries({
+    allocatedMetric: METRICS.computeAllocated,
+    capacityMetric: METRICS.computeCapacity,
+    ...options,
+  });
+
+export const buildMemoryAllocationQueries = (options = {}) =>
+  buildAllocationQueries({
+    allocatedMetric: METRICS.memoryAllocated,
+    capacityMetric: METRICS.memorySchedulableCapacity,
+    displayDivisor: 1024,
+    ...options,
+  });
+
+export const buildMemoryUsageQueries = ({
+  selector = '',
+  groupLabel = '',
+  displayDivisor = 1024,
+} = {}) => {
+  const usedSeries = metricSeries(METRICS.memoryUsed, selector);
+  const capacitySeries = metricSeries(METRICS.memoryPhysicalCapacity, selector);
+  const reportingCapacitySeries = `${capacitySeries} and ${REPORTING_DEVICE_MATCH} ${usedSeries}`;
+  const used = aggregateAcrossExporterReplicas(usedSeries, groupLabel);
+  const capacity = aggregateAcrossExporterReplicas(
+    reportingCapacitySeries,
+    groupLabel,
+  );
+
+  return {
+    query: divideForDisplay(used, displayDivisor),
+    totalQuery: divideForDisplay(capacity, displayDivisor),
+    // Missing provider data must remain absent. Unlike allocation, usage has no
+    // capacity-derived zero fallback.
+    percentQuery: `${used} / ${capacity} * 100`,
+  };
+};
+
+export const buildGroupedResourceTopQueries = (groupLabel) => {
+  validateGroupLabel(groupLabel);
+  if (!groupLabel) {
+    throw new TypeError('A Prometheus group label is required');
+  }
+
+  const computeAllocation = buildComputeAllocationQueries({ groupLabel });
+  const memoryAllocation = buildMemoryAllocationQueries({ groupLabel });
+  const memoryUsage = buildMemoryUsageQueries({ groupLabel });
+
+  return {
+    computeAllocation: `topk(5, ${computeAllocation.percentQuery})`,
+    computeUsage: `topk(5, avg by (${groupLabel}) (${METRICS.computeUsageAverage}))`,
+    memoryAllocation: `topk(5, ${memoryAllocation.percentQuery})`,
+    memoryUsage: `topk(5, ${memoryUsage.percentQuery})`,
+  };
+};
+
+export const buildClusterTrendQueries = () => ({
+  computeAllocation: buildComputeAllocationQueries().percentQuery,
+  computeUsage: `avg(${METRICS.computeUsageAverage})`,
+  memoryAllocation: buildMemoryAllocationQueries().percentQuery,
+  memoryUsage: buildMemoryUsageQueries().percentQuery,
+});

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildClusterTrendQueries,
+  buildGroupedResourceTopQueries,
+  buildMemoryAllocationQueries,
+  buildMemoryUsageQueries,
+} from './query-contract.mjs';
+
+test('memory allocation uses schedulable capacity and fills idle allocation', () => {
+  const queries = buildMemoryAllocationQueries();
+
+  for (const query of Object.values(queries)) {
+    assert.match(query, /hami_vmemory_size/);
+    assert.doesNotMatch(query, /hami_memory_size/);
+  }
+  assert.match(queries.query, / or /);
+  assert.match(queries.percentQuery, /\* 0/);
+});
+
+test('scoped memory allocation keeps the same contract for node and card details', () => {
+  const node = buildMemoryAllocationQueries({
+    selector: 'node=~"$node"',
+  });
+  const card = buildMemoryAllocationQueries({
+    selector: 'device_uuid=~"$device_uuid"',
+  });
+
+  assert.match(node.totalQuery, /hami_vmemory_size\{node=~"\$node"\}/);
+  assert.match(
+    card.totalQuery,
+    /hami_vmemory_size\{device_uuid=~"\$device_uuid"\}/,
+  );
+  assert.match(node.percentQuery, / or /);
+  assert.match(card.percentQuery, / or /);
+});
+
+test('memory usage capacity only includes devices that report usage', () => {
+  const queries = buildMemoryUsageQueries();
+
+  assert.match(
+    queries.totalQuery,
+    /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
+  );
+  assert.doesNotMatch(queries.query, / or /);
+  assert.doesNotMatch(queries.totalQuery, / or /);
+  assert.doesNotMatch(queries.percentQuery, /\* 0/);
+});
+
+test('grouped rankings preserve idle allocation but not missing usage', () => {
+  for (const groupLabel of ['node', 'device_uuid']) {
+    const queries = buildGroupedResourceTopQueries(groupLabel);
+
+    assert.match(
+      queries.memoryAllocation,
+      new RegExp(`or on \\(${groupLabel}\\)`),
+    );
+    assert.match(queries.memoryAllocation, /hami_vmemory_size/);
+    assert.match(
+      queries.memoryUsage,
+      /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
+    );
+    assert.doesNotMatch(queries.memoryUsage, / or /);
+    assert.match(queries.memoryUsage, /sum by \([^)]*instance\)/);
+  }
+});
+
+test('cluster trends share the allocation and reporting-device contracts', () => {
+  const queries = buildClusterTrendQueries();
+
+  assert.match(queries.computeAllocation, / or /);
+  assert.match(queries.memoryAllocation, /hami_vmemory_size/);
+  assert.match(queries.memoryAllocation, / or /);
+  assert.match(
+    queries.memoryUsage,
+    /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
+  );
+  assert.doesNotMatch(queries.memoryUsage, / or /);
+});
+
+test('grouped query labels reject malformed PromQL input', () => {
+  assert.throws(
+    () => buildGroupedResourceTopQueries('node) or vector(1'),
+    /Invalid Prometheus group label/,
+  );
+  assert.throws(
+    () => buildGroupedResourceTopQueries(''),
+    /group label is required/,
+  );
+});

--- a/packages/web/projects/vgpu/views/card/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/card/admin/Detail.vue
@@ -281,6 +281,7 @@ import BlockBox from '@/components/BlockBox.vue';
 import { onMounted, ref, watch, computed } from 'vue';
 import { HelpCircleIcon } from 'tdesign-icons-vue-next';
 import useInstantVector from '~/vgpu/hooks/useInstantVector';
+import { readReadyMetricField } from '~/vgpu/hooks/instant-vector-state.mjs';
 import VChart from 'vue-echarts';
 import cardApi from '~/vgpu/api/card';
 import nodeApi from '~/vgpu/api/node';
@@ -289,6 +290,11 @@ import { timeParse, calculatePrometheusStep, roundToDecimal, getResourceColor } 
 import { getLineOptions as getLineOptions2 } from '~/vgpu/components/config';
 import { getRangeOptions } from '../../monitor/overview/getOptions';
 import { useI18n } from 'vue-i18n';
+import {
+  buildComputeAllocationQueries,
+  buildMemoryAllocationQueries,
+  buildMemoryUsageQueries,
+} from '~/vgpu/metrics/query-contract.mjs';
 
 const route = useRoute();
 const router = useRouter();
@@ -333,6 +339,16 @@ const start = new Date();
 start.setTime(start.getTime() - 3600 * 1000);
 
 const times = ref([start, end]);
+const cardMetricSelector = 'device_uuid=~"$device_uuid"';
+const computeAllocationQueries = buildComputeAllocationQueries({
+  selector: cardMetricSelector,
+});
+const memoryAllocationQueries = buildMemoryAllocationQueries({
+  selector: cardMetricSelector,
+});
+const memoryUsageQueries = buildMemoryUsageQueries({
+  selector: cardMetricSelector,
+});
 
 const basicPowerText = computed(() => {
   const v = lineTools.value[1]?.percent;
@@ -351,9 +367,9 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.computeAllocRate',
     percent: 0,
-    query: `avg(sum(hami_container_vcore_allocated{device_uuid=~"$device_uuid"}) by (instance))`,
-    totalQuery: `avg(sum(hami_core_size{device_uuid=~"$device_uuid"}) by (instance))`,
-    percentQuery: `avg(sum(hami_container_vcore_allocated{device_uuid=~"$device_uuid"}) by (instance))/avg(sum(hami_core_size{device_uuid=~"$device_uuid"}) by (instance)) *100`,
+    query: computeAllocationQueries.query,
+    totalQuery: computeAllocationQueries.totalQuery,
+    percentQuery: computeAllocationQueries.percentQuery,
     total: 0,
     used: 0,
     unit: ' ',
@@ -361,9 +377,9 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.memAllocRate',
     percent: 0,
-    query: `avg(sum(hami_container_vmemory_allocated{device_uuid=~"$device_uuid"}) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size{device_uuid=~"$device_uuid"}) by (instance)) / 1024`,
-    percentQuery: `(avg(sum(hami_container_vmemory_allocated{device_uuid=~"$device_uuid"}) by (instance)) / 1024 )/(avg(sum(hami_memory_size{device_uuid=~"$device_uuid"}) by (instance)) / 1024) *100 `,
+    query: memoryAllocationQueries.query,
+    totalQuery: memoryAllocationQueries.totalQuery,
+    percentQuery: memoryAllocationQueries.percentQuery,
     total: 0,
     used: 0,
     unit: 'GiB',
@@ -380,9 +396,9 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.memUsageRate',
     percent: 0,
-    query: `avg(sum(hami_memory_used{device_uuid=~"$device_uuid"}) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size{device_uuid=~"$device_uuid"}) by (instance))/1024`,
-    percentQuery: `(avg(sum(hami_memory_used{device_uuid=~"$device_uuid"}) by (instance)) / 1024)/(avg(sum(hami_memory_size{device_uuid=~"$device_uuid"}) by (instance))/1024)*100`,
+    query: memoryUsageQueries.query,
+    totalQuery: memoryUsageQueries.totalQuery,
+    percentQuery: memoryUsageQueries.percentQuery,
     total: 0,
     used: 0,
     unit: 'GiB',
@@ -402,14 +418,17 @@ const gaugeConfig = computed(() =>
   })),
 );
 
+const readGaugeField = (index, field) =>
+  readReadyMetricField(gaugeConfig.value?.[index], field);
+
 const computeTotalText = computed(() => {
-  const total = Number(gaugeConfig.value?.[0]?.total);
-  return Number.isFinite(total) ? `${roundToDecimal(total / 100, 1)}` : '--';
+  const total = readGaugeField(0, 'total');
+  return total === undefined ? '--' : `${roundToDecimal(total / 100, 1)}`;
 });
 
 const memoryTotalText = computed(() => {
-  const total = Number(gaugeConfig.value?.[1]?.total);
-  return Number.isFinite(total) ? `${roundToDecimal(total, 1)} GiB` : '--';
+  const total = readGaugeField(1, 'total');
+  return total === undefined ? '--' : `${roundToDecimal(total, 1)} GiB`;
 });
 
 const formatUsedValue = (v, unit, divisor = 1) => {
@@ -420,29 +439,44 @@ const formatUsedValue = (v, unit, divisor = 1) => {
   return unit && String(unit).trim() ? `${text} ${unit}` : text;
 };
 
-const computeAllocUsedText = computed(() => (detail.value?.isExternal ? '--' : formatUsedValue(gaugeConfig.value?.[0]?.used, gaugeConfig.value?.[0]?.unit, 100)));
-const computeUsageUsedText = computed(() => formatUsedValue(gaugeConfig.value?.[2]?.used, gaugeConfig.value?.[2]?.unit, 100));
-const memoryAllocUsedText = computed(() => (detail.value?.isExternal ? '--' : formatUsedValue(gaugeConfig.value?.[1]?.used, gaugeConfig.value?.[1]?.unit)));
-const memoryUsageUsedText = computed(() => formatUsedValue(gaugeConfig.value?.[3]?.used, gaugeConfig.value?.[3]?.unit));
+const computeAllocUsedText = computed(() =>
+  detail.value?.isExternal
+    ? '--'
+    : formatUsedValue(
+        readGaugeField(0, 'used'),
+        gaugeConfig.value?.[0]?.unit,
+        100,
+      ),
+);
+const computeUsageUsedText = computed(() =>
+  formatUsedValue(
+    readGaugeField(2, 'used'),
+    gaugeConfig.value?.[2]?.unit,
+    100,
+  ),
+);
+const memoryAllocUsedText = computed(() =>
+  detail.value?.isExternal
+    ? '--'
+    : formatUsedValue(
+        readGaugeField(1, 'used'),
+        gaugeConfig.value?.[1]?.unit,
+      ),
+);
+const memoryUsageUsedText = computed(() =>
+  formatUsedValue(readGaugeField(3, 'used'), gaugeConfig.value?.[3]?.unit),
+);
 
 const computeAllocPercentRaw = computed(() => {
   if (detail.value?.isExternal) return undefined;
-  const p = Number(gaugeConfig.value?.[0]?.percent);
-  return Number.isFinite(p) ? p : undefined;
+  return readGaugeField(0, 'percent');
 });
 const memoryAllocPercentRaw = computed(() => {
   if (detail.value?.isExternal) return undefined;
-  const p = Number(gaugeConfig.value?.[1]?.percent);
-  return Number.isFinite(p) ? p : undefined;
+  return readGaugeField(1, 'percent');
 });
-const computeUsagePercentRaw = computed(() => {
-  const p = Number(gaugeConfig.value?.[2]?.percent);
-  return Number.isFinite(p) ? p : undefined;
-});
-const memoryUsagePercentRaw = computed(() => {
-  const p = Number(gaugeConfig.value?.[3]?.percent);
-  return Number.isFinite(p) ? p : undefined;
-});
+const computeUsagePercentRaw = computed(() => readGaugeField(2, 'percent'));
+const memoryUsagePercentRaw = computed(() => readGaugeField(3, 'percent'));
 
 const clampPercent = (v) => Math.max(0, Math.min(100, v));
 const roundPercentForProgress = (p) => (p === undefined ? undefined : roundToDecimal(p, 2));

--- a/packages/web/projects/vgpu/views/monitor/overview/config.js
+++ b/packages/web/projects/vgpu/views/monitor/overview/config.js
@@ -1,57 +1,63 @@
-export const getRangeConfigInit = (t) => [
-  {
-    title: t('dashboard.gpuComputeAllocUsageTrend'),
-    dataSource: [
-      {
-        name: t('dashboard.allocRateLegend'),
-        query: `sum(hami_container_vcore_allocated) / sum(hami_core_size) * 100`,
-        data: [],
-        type: 'line',
-        itemStyle: {
-          borderColor: 'rgb(84, 112, 198)',
+import { buildClusterTrendQueries } from '../../../metrics/query-contract.mjs';
+
+export const getRangeConfigInit = (t) => {
+  const queries = buildClusterTrendQueries();
+
+  return [
+    {
+      title: t('dashboard.gpuComputeAllocUsageTrend'),
+      dataSource: [
+        {
+          name: t('dashboard.allocRateLegend'),
+          query: queries.computeAllocation,
+          data: [],
+          type: 'line',
+          itemStyle: {
+            borderColor: 'rgb(84, 112, 198)',
+          },
+          lineStyle: {
+            color: 'rgb(84, 112, 198)',
+          },
         },
-        lineStyle: {
-          color: 'rgb(84, 112, 198)',
+        {
+          name: t('dashboard.usageRateLegend'),
+          query: queries.computeUsage,
+          data: [],
+          itemStyle: {
+            borderColor: 'rgb(145, 204, 117)',
+          },
+          lineStyle: {
+            color: 'rgb(145, 204, 117)',
+          },
         },
-      },
-      {
-        name: t('dashboard.usageRateLegend'),
-        query: `avg(hami_core_util_avg)`,
-        data: [],
-        itemStyle: {
-          borderColor: 'rgb(145, 204, 117)',
+      ],
+    },
+    {
+      title: t('dashboard.gpuMemAllocUsageTrend'),
+      dataSource: [
+        {
+          name: t('dashboard.allocRateLegend'),
+          query: queries.memoryAllocation,
+          data: [],
+          itemStyle: {
+            borderColor: 'rgb(84, 112, 198)',
+          },
+          lineStyle: {
+            color: 'rgb(84, 112, 198)',
+          },
         },
-        lineStyle: {
-          color: 'rgb(145, 204, 117)',
+        {
+          name: t('dashboard.usageRateLegend'),
+          query: queries.memoryUsage,
+          data: [],
+          itemStyle: {
+            borderColor: 'rgb(145, 204, 117)',
+          },
+          lineStyle: {
+            color: 'rgb(145, 204, 117)',
+          },
         },
-      },
-    ],
-  },
-  {
-    title: t('dashboard.gpuMemAllocUsageTrend'),
-    dataSource: [
-      {
-        name: t('dashboard.allocRateLegend'),
-        query: `sum(hami_container_vmemory_allocated) / sum(hami_memory_size) * 100`,
-        data: [],
-        itemStyle: {
-          borderColor: 'rgb(84, 112, 198)',
-        },
-        lineStyle: {
-          color: 'rgb(84, 112, 198)',
-        },
-      },
-      {
-        name: t('dashboard.usageRateLegend'),
-        query: `sum(hami_memory_used) / sum(hami_memory_size) * 100`,
-        data: [],
-        itemStyle: {
-          borderColor: 'rgb(145, 204, 117)',
-        },
-        lineStyle: {
-          color: 'rgb(145, 204, 117)',
-        },
-      },
-    ],
-  },
-];
+      ],
+    },
+  ];
+};

--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -206,7 +206,7 @@ import TabTop from '~/vgpu/components/TabTop.vue';
 import Gauge from '~/vgpu/components/gauge.vue';
 import { getRangeConfigInit } from './config';
 import {
-  createNodeAllocationTopQueries,
+  createNodeTopQueries,
   createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 
@@ -514,6 +514,8 @@ const nodes = computed(() => [
   },
 ]);
 
+const nodeTopQueries = createNodeTopQueries();
+
 const nodeComputeTop5 = computed(() => ({
   title: t('dashboard.nodeComputeTop5'),
   key: 'compute',
@@ -523,14 +525,14 @@ const nodeComputeTop5 = computed(() => ({
       key: 'alloc',
       nameKey: 'node',
       data: [],
-      query: createNodeAllocationTopQueries().compute,
+      query: nodeTopQueries.computeAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       data: [],
       nameKey: 'node',
-      query: 'topk(5, avg(hami_core_util_avg) by (node))',
+      query: nodeTopQueries.computeUsage,
     },
   ],
 }));
@@ -544,14 +546,14 @@ const nodeMemoryTop5 = computed(() => ({
       key: 'alloc',
       nameKey: 'node',
       data: [],
-      query: createNodeAllocationTopQueries().memory,
+      query: nodeTopQueries.memoryAllocation,
     },
     {
       tab: t('dashboard.usageRateLegend'),
       key: 'usage',
       nameKey: 'node',
       data: [],
-      query: 'topk(5, avg(hami_memory_used) by (node) / avg(hami_memory_size) by (node) * 100)',
+      query: nodeTopQueries.memoryUsage,
     },
   ],
 }));

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
@@ -1,3 +1,10 @@
+import {
+  buildComputeAllocationQueries,
+  buildGroupedResourceTopQueries,
+  buildMemoryAllocationQueries,
+  buildMemoryUsageQueries,
+} from '../../../metrics/query-contract.mjs';
+
 export const createComputeUsageGaugeConfig = () => ({
   id: 'compute-utilization',
   kind: 'utilization',
@@ -15,92 +22,77 @@ export const createComputeUsageGaugeConfig = () => ({
   unit: '%',
 });
 
-export const createOverviewGaugeConfigs = () => [
-  {
-    id: 'vgpu-allocation',
-    kind: 'allocation',
-    titleKey: 'dashboard.vgpuAllocRate',
-    descriptionKey: 'dashboard.vgpuAllocRateDescription',
-    detailLabelKey: 'dashboard.allocated',
-    detailMode: 'ratio',
-    usedPrecision: 0,
-    totalPrecision: 0,
-    percent: 0,
-    query:
-      'avg(sum(hami_container_vgpu_allocated) by (instance)) or (avg(sum(hami_vgpu_count) by (instance)) * 0)',
-    totalQuery: 'avg(sum(hami_vgpu_count) by (instance))',
-    total: 0,
-    used: 0,
-    unitKey: 'dashboard.vgpuSlotUnit',
-  },
-  {
-    id: 'compute-allocation',
-    kind: 'allocation',
-    titleKey: 'dashboard.computeAllocRate',
-    descriptionKey: 'dashboard.computeAllocRateDescription',
-    detailLabelKey: 'dashboard.allocated',
-    detailMode: 'ratio',
-    displayDivisor: 100,
-    percent: 0,
-    query:
-      'avg(sum(hami_container_vcore_allocated) by (instance)) or (avg(sum(hami_core_size) by (instance)) * 0)',
-    totalQuery: 'avg(sum(hami_core_size) by (instance))',
-    total: 0,
-    used: 0,
-    unitKey: 'dashboard.acceleratorEquivalentUnit',
-  },
-  {
-    id: 'memory-allocation',
-    kind: 'allocation',
-    titleKey: 'dashboard.memAllocRate',
-    descriptionKey: 'dashboard.memAllocRateDescription',
-    detailLabelKey: 'dashboard.allocated',
-    detailMode: 'ratio',
-    totalPrecision: 1,
-    percent: 0,
-    query:
-      '(avg(sum(hami_container_vmemory_allocated) by (instance)) or (avg(sum(hami_memory_size) by (instance)) * 0)) / 1024',
-    totalQuery: 'avg(sum(hami_memory_size) by (instance)) / 1024',
-    total: 0,
-    used: 0,
-    unit: 'GiB',
-  },
-  createComputeUsageGaugeConfig(),
-  {
-    id: 'memory-utilization',
-    kind: 'utilization',
-    titleKey: 'dashboard.memUsageRate',
-    descriptionKey: 'dashboard.memUsageRateDescription',
-    detailLabelKey: 'dashboard.used',
-    detailMode: 'ratio',
-    totalPrecision: 1,
-    percent: 0,
-    query: 'avg(sum(hami_memory_used) by (instance)) / 1024',
-    totalQuery:
-      'avg(sum by (instance) (hami_memory_size and on (instance, node, provider, device_uuid) hami_memory_used)) / 1024',
-    total: 0,
-    used: 0,
-    unit: 'GiB',
-  },
-];
+export const createOverviewGaugeConfigs = () => {
+  const computeAllocation = buildComputeAllocationQueries();
+  const memoryAllocation = buildMemoryAllocationQueries();
+  const memoryUsage = buildMemoryUsageQueries();
 
-// Allocation series only exist for devices assigned to a workload. Sum all
-// devices within each scrape target first, then average equivalent exporter
-// replicas so idle devices remain in the capacity denominator. Capacity also
-// supplies an explicit zero when an entire node has no allocation series.
-const buildNodeAllocationTopQuery = (allocatedMetric, capacityMetric) => {
-  const allocated = `avg by (node) (sum by (node, instance) (${allocatedMetric}))`;
-  const capacity = `avg by (node) (sum by (node, instance) (${capacityMetric}))`;
-  return `topk(5, (${allocated} / ${capacity} * 100) or on (node) (${capacity} * 0))`;
+  return [
+    {
+      id: 'vgpu-allocation',
+      kind: 'allocation',
+      titleKey: 'dashboard.vgpuAllocRate',
+      descriptionKey: 'dashboard.vgpuAllocRateDescription',
+      detailLabelKey: 'dashboard.allocated',
+      detailMode: 'ratio',
+      usedPrecision: 0,
+      totalPrecision: 0,
+      percent: 0,
+      query:
+        'avg(sum(hami_container_vgpu_allocated) by (instance)) or (avg(sum(hami_vgpu_count) by (instance)) * 0)',
+      totalQuery: 'avg(sum(hami_vgpu_count) by (instance))',
+      total: 0,
+      used: 0,
+      unitKey: 'dashboard.vgpuSlotUnit',
+    },
+    {
+      id: 'compute-allocation',
+      kind: 'allocation',
+      titleKey: 'dashboard.computeAllocRate',
+      descriptionKey: 'dashboard.computeAllocRateDescription',
+      detailLabelKey: 'dashboard.allocated',
+      detailMode: 'ratio',
+      displayDivisor: 100,
+      percent: 0,
+      query: computeAllocation.query,
+      totalQuery: computeAllocation.totalQuery,
+      total: 0,
+      used: 0,
+      unitKey: 'dashboard.acceleratorEquivalentUnit',
+    },
+    {
+      id: 'memory-allocation',
+      kind: 'allocation',
+      titleKey: 'dashboard.memAllocRate',
+      descriptionKey: 'dashboard.memAllocRateDescription',
+      detailLabelKey: 'dashboard.allocated',
+      detailMode: 'ratio',
+      totalPrecision: 1,
+      percent: 0,
+      query: memoryAllocation.query,
+      totalQuery: memoryAllocation.totalQuery,
+      total: 0,
+      used: 0,
+      unit: 'GiB',
+    },
+    createComputeUsageGaugeConfig(),
+    {
+      id: 'memory-utilization',
+      kind: 'utilization',
+      titleKey: 'dashboard.memUsageRate',
+      descriptionKey: 'dashboard.memUsageRateDescription',
+      detailLabelKey: 'dashboard.used',
+      detailMode: 'ratio',
+      totalPrecision: 1,
+      percent: 0,
+      query: memoryUsage.query,
+      totalQuery: memoryUsage.totalQuery,
+      total: 0,
+      used: 0,
+      unit: 'GiB',
+    },
+  ];
 };
 
-export const createNodeAllocationTopQueries = () => ({
-  compute: buildNodeAllocationTopQuery(
-    'hami_container_vcore_allocated',
-    'hami_core_size',
-  ),
-  memory: buildNodeAllocationTopQuery(
-    'hami_container_vmemory_allocated',
-    'hami_memory_size',
-  ),
-});
+export const createNodeTopQueries = () =>
+  buildGroupedResourceTopQueries('node');

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import {
   createComputeUsageGaugeConfig,
-  createNodeAllocationTopQueries,
+  createNodeTopQueries,
   createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 
@@ -55,22 +55,28 @@ test('overview gauges declare display semantics independently of translated titl
   );
 });
 
-test('allocation gauges preserve their current capacity contracts', () => {
+test('allocation gauges use their defined capacity contracts', () => {
   const [vgpu, compute, memory] = createOverviewGaugeConfigs();
 
   assert.match(vgpu.totalQuery, /hami_vgpu_count/);
   assert.match(compute.totalQuery, /hami_core_size/);
   assert.doesNotMatch(compute.totalQuery, /hami_vcore_size/);
-  assert.match(memory.totalQuery, /hami_memory_size/);
-  assert.doesNotMatch(memory.totalQuery, /hami_vmemory_size/);
+  assert.match(memory.totalQuery, /hami_vmemory_size/);
+  assert.doesNotMatch(memory.totalQuery, /hami_memory_size/);
 });
 
 test('an idle cluster reports zero allocation when capacity is present', () => {
   const [vgpu, compute, memory] = createOverviewGaugeConfigs();
 
   assert.match(vgpu.query, /or \(avg\(sum\(hami_vgpu_count\)/);
-  assert.match(compute.query, /or \(avg\(sum\(hami_core_size\)/);
-  assert.match(memory.query, /or \(avg\(sum\(hami_memory_size\)/);
+  assert.match(
+    compute.query,
+    /or \(avg\(sum by \(instance\) \(hami_core_size\)\)/,
+  );
+  assert.match(
+    memory.query,
+    /or \(avg\(sum by \(instance\) \(hami_vmemory_size\)\)/,
+  );
 });
 
 test('memory utilization capacity only includes reporting devices', () => {
@@ -83,14 +89,19 @@ test('memory utilization capacity only includes reporting devices', () => {
 });
 
 test('node allocation rankings include every device and fully idle nodes', () => {
-  const queries = createNodeAllocationTopQueries();
+  const queries = createNodeTopQueries();
 
   assert.equal(
-    queries.compute,
+    queries.computeAllocation,
     'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vcore_allocated)) / avg by (node) (sum by (node, instance) (hami_core_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_core_size)) * 0))',
   );
   assert.equal(
-    queries.memory,
-    'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vmemory_allocated)) / avg by (node) (sum by (node, instance) (hami_memory_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_memory_size)) * 0))',
+    queries.memoryAllocation,
+    'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vmemory_allocated)) / avg by (node) (sum by (node, instance) (hami_vmemory_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_vmemory_size)) * 0))',
   );
+  assert.match(
+    queries.memoryUsage,
+    /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
+  );
+  assert.doesNotMatch(queries.memoryUsage, / or /);
 });

--- a/packages/web/projects/vgpu/views/node/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/node/admin/Detail.vue
@@ -188,11 +188,17 @@ import { useRoute } from 'vue-router';
 import BlockBox from '@/components/BlockBox.vue';
 import { computed, onMounted, ref } from 'vue';
 import useInstantVector from '~/vgpu/hooks/useInstantVector';
+import { readReadyMetricField } from '~/vgpu/hooks/instant-vector-state.mjs';
 import VChart from 'vue-echarts';
 import nodeApi from '~/vgpu/api/node';
 import { getRangeOptions } from './getOptions';
 import { useI18n } from 'vue-i18n';
 import { getResourceColor, roundToDecimal } from '@/utils';
+import {
+  buildComputeAllocationQueries,
+  buildMemoryAllocationQueries,
+  buildMemoryUsageQueries,
+} from '~/vgpu/metrics/query-contract.mjs';
 
 const route = useRoute();
 const { t, locale } = useI18n();
@@ -204,14 +210,24 @@ const start = new Date();
 start.setTime(start.getTime() - 3600 * 1000);
 
 const times = ref([start, end]);
+const nodeMetricSelector = 'node=~"$node"';
+const computeAllocationQueries = buildComputeAllocationQueries({
+  selector: nodeMetricSelector,
+});
+const memoryAllocationQueries = buildMemoryAllocationQueries({
+  selector: nodeMetricSelector,
+});
+const memoryUsageQueries = buildMemoryUsageQueries({
+  selector: nodeMetricSelector,
+});
 
 const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.computeAllocRate',
     percent: 0,
-    query: `avg(sum(hami_container_vcore_allocated{node=~"$node"}) by (instance))`,
-    totalQuery: `avg(sum(hami_core_size{node=~"$node"}) by (instance))`,
-    percentQuery: `avg(sum(hami_container_vcore_allocated{node=~"$node"}) by (instance)) / avg(sum(hami_core_size{node=~"$node"}) by (instance)) *100`,
+    query: computeAllocationQueries.query,
+    totalQuery: computeAllocationQueries.totalQuery,
+    percentQuery: computeAllocationQueries.percentQuery,
     total: 0,
     used: 0,
     unit: ' ',
@@ -219,9 +235,9 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.memAllocRate',
     percent: 0,
-    query: `avg(sum(hami_container_vmemory_allocated{node=~"$node"}) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size{node=~"$node"}) by (instance)) / 1024`,
-    percentQuery: `(avg(sum(hami_container_vmemory_allocated{node=~"$node"}) by (instance)) / 1024) /(avg(sum(hami_memory_size{node=~"$node"}) by (instance)) / 1024) *100`,
+    query: memoryAllocationQueries.query,
+    totalQuery: memoryAllocationQueries.totalQuery,
+    percentQuery: memoryAllocationQueries.percentQuery,
     total: 0,
     used: 0,
     unit: 'GiB',
@@ -239,9 +255,9 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.memUsageRate',
     percent: 0,
-    query: `avg(sum(hami_memory_used{node=~"$node"}) by (instance)) / 1024`,
-    totalQuery: `avg(sum(hami_memory_size{node=~"$node"}) by (instance))/1024`,
-    percentQuery: `(avg(sum(hami_memory_used{node=~"$node"}) by (instance)) / 1024)/(avg(sum(hami_memory_size{node=~"$node"}) by (instance))/1024)*100`,
+    query: memoryUsageQueries.query,
+    totalQuery: memoryUsageQueries.totalQuery,
+    percentQuery: memoryUsageQueries.percentQuery,
     total: 0,
     used: 0,
     unit: 'GiB',
@@ -261,37 +277,32 @@ const gaugeConfig = computed(() =>
   })),
 );
 
+const readGaugeField = (index, field) =>
+  readReadyMetricField(gaugeConfig.value?.[index], field);
+
 const computePowerTotal = computed(() => {
-  const total = Number(gaugeConfig.value?.[0]?.total);
-  return Number.isFinite(total) ? roundToDecimal(total, 1) : undefined;
+  const total = readGaugeField(0, 'total');
+  return total === undefined ? undefined : roundToDecimal(total, 1);
 });
 
 const gpuMemoryTotal = computed(() => {
-  const total = Number(gaugeConfig.value?.[1]?.total);
-  return Number.isFinite(total) ? roundToDecimal(total, 1) : undefined;
+  const total = readGaugeField(1, 'total');
+  return total === undefined ? undefined : roundToDecimal(total, 1);
 });
 
 const computeAllocPercentRaw = computed(() => {
   if (detail.value?.isExternal) return undefined;
-  const percent = Number(gaugeConfig.value?.[0]?.percent);
-  return Number.isFinite(percent) ? percent : undefined;
+  return readGaugeField(0, 'percent');
 });
 
-const computeUsagePercentRaw = computed(() => {
-  const percent = Number(gaugeConfig.value?.[2]?.percent);
-  return Number.isFinite(percent) ? percent : undefined;
-});
+const computeUsagePercentRaw = computed(() => readGaugeField(2, 'percent'));
 
 const memoryAllocPercentRaw = computed(() => {
   if (detail.value?.isExternal) return undefined;
-  const percent = Number(gaugeConfig.value?.[1]?.percent);
-  return Number.isFinite(percent) ? percent : undefined;
+  return readGaugeField(1, 'percent');
 });
 
-const memoryUsagePercentRaw = computed(() => {
-  const percent = Number(gaugeConfig.value?.[3]?.percent);
-  return Number.isFinite(percent) ? percent : undefined;
-});
+const memoryUsagePercentRaw = computed(() => readGaugeField(3, 'percent'));
 
 const clampPercent = (v) => Math.max(0, Math.min(100, v));
 const roundPercentForProgress = (p) => (p === undefined ? undefined : roundToDecimal(p, 2));

--- a/server/internal/service/allocation_capacity_test.go
+++ b/server/internal/service/allocation_capacity_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kratos/kratos/v2/log"
+	pb "vgpu/api/v1"
+	"vgpu/internal/biz"
+	"vgpu/internal/data/prom"
+)
+
+func TestAllocationListsKeepRegisteredMemoryCapacity(t *testing.T) {
+	const registeredMemory = int32(65536)
+
+	var (
+		queriesMu sync.Mutex
+		queries   []string
+	)
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.FormValue("query")
+		queriesMu.Lock()
+		queries = append(queries, query)
+		queriesMu.Unlock()
+
+		label, value := "device_uuid", "100"
+		if strings.Contains(query, "by (node)") {
+			label = "node"
+		}
+		if strings.Contains(query, "hami_memory_size") {
+			// A physical-memory metric deliberately differs from the registered
+			// schedulable capacity. Allocation APIs must never use this value.
+			value = "32768"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"%s":"%s"},"value":[1788050000,"%s"]}]}}`, label, map[string]string{"node": "node-a", "device_uuid": "GPU-1"}[label], value)
+	}))
+	defer prometheus.Close()
+
+	device := &biz.DeviceInfo{
+		Id:       "GPU-1",
+		AliasId:  "GPU-1",
+		Count:    1,
+		Devmem:   registeredMemory,
+		Devcore:  200,
+		NodeName: "node-a",
+		NodeUid:  "node-uid-a",
+	}
+	nodeRepo := &capacityTestNodeRepo{
+		nodes:   []*biz.Node{{Name: "node-a", Uid: "node-uid-a", Devices: []*biz.DeviceInfo{device}}},
+		devices: []*biz.DeviceInfo{device},
+	}
+	podRepo := &capacityTestPodRepo{}
+	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
+	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	monitor := NewMonitorService(promClient, nodeUsecase, podUsecase)
+
+	nodes, err := NewNodeService(nodeUsecase, podUsecase, nil, monitor).GetAllNodes(
+		context.Background(),
+		&pb.GetAllNodesReq{Filters: &pb.GetAllNodesReq_Filters{}},
+	)
+	if err != nil {
+		t.Fatalf("GetAllNodes: %v", err)
+	}
+	if got := nodes.List[0].MemoryTotal; got != registeredMemory {
+		t.Fatalf("node memory_total = %d, want registered capacity %d", got, registeredMemory)
+	}
+	if got := nodes.List[0].CoreTotal; got != 100 {
+		t.Fatalf("node core_total = %d, want physical baseline 100", got)
+	}
+
+	cards, err := NewCardService(nodeUsecase, podUsecase, monitor).GetAllGPUs(
+		context.Background(),
+		&pb.GetAllGpusReq{Filters: &pb.GetAllGpusReq_Filters{}},
+	)
+	if err != nil {
+		t.Fatalf("GetAllGPUs: %v", err)
+	}
+	if got := cards.List[0].MemoryTotal; got != registeredMemory {
+		t.Fatalf("card memory_total = %d, want registered capacity %d", got, registeredMemory)
+	}
+	if got := cards.List[0].CoreTotal; got != 100 {
+		t.Fatalf("card core_total = %d, want physical baseline 100", got)
+	}
+
+	queriesMu.Lock()
+	defer queriesMu.Unlock()
+	if len(queries) != 2 {
+		t.Fatalf("Prometheus queries = %v, want one core query per list API", queries)
+	}
+	for _, query := range queries {
+		if !strings.Contains(query, "hami_core_size") || strings.Contains(query, "memory_size") {
+			t.Fatalf("unexpected allocation-list query %q", query)
+		}
+	}
+}
+
+type capacityTestNodeRepo struct {
+	nodes   []*biz.Node
+	devices []*biz.DeviceInfo
+}
+
+func (r *capacityTestNodeRepo) ListAll(context.Context) ([]*biz.Node, error) {
+	return r.nodes, nil
+}
+
+func (r *capacityTestNodeRepo) GetNode(context.Context, string) (*biz.Node, error) {
+	return r.nodes[0], nil
+}
+
+func (r *capacityTestNodeRepo) ListAllDevices(context.Context) ([]*biz.DeviceInfo, error) {
+	return r.devices, nil
+}
+
+func (r *capacityTestNodeRepo) FindDeviceByAliasId(aliasID string) (*biz.DeviceInfo, error) {
+	for _, device := range r.devices {
+		if device.AliasId == aliasID {
+			return device, nil
+		}
+	}
+	return nil, nil
+}
+
+type capacityTestPodRepo struct{}
+
+func (*capacityTestPodRepo) ListAll(context.Context) ([]*biz.Container, error) {
+	return nil, nil
+}
+
+func (*capacityTestPodRepo) FindOne(context.Context, string, string) (*biz.Container, error) {
+	return nil, nil
+}

--- a/server/internal/service/card.go
+++ b/server/internal/service/card.go
@@ -35,12 +35,11 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		return nil, err
 	}
 
-	// Pull hami_core_size / hami_memory_size for ALL devices in two queries keyed
-	// by device_uuid, instead of two PromQL per device. The old per-device fanout
-	// meant ~2*N serial instant queries against Prometheus / VictoriaMetrics
-	// (300+ at large scale), which made the card list spin for several seconds.
+	// Pull the normalized compute baseline for all devices in one query keyed by
+	// device_uuid. Memory capacity already comes from DeviceInfo.Devmem, HAMi's
+	// registered schedulable value, so querying the exporter's delayed copy would
+	// be redundant.
 	coreSizeByUUID := s.queryGaugeByLabel(ctx, "avg(hami_core_size) by (device_uuid)", "device_uuid")
-	memSizeByUUID := s.queryGaugeByLabel(ctx, "avg(hami_memory_size) by (device_uuid)", "device_uuid")
 
 	var res = &pb.GPUsReply{List: []*pb.GPUReply{}}
 	for _, device := range deviceInfos {
@@ -74,9 +73,6 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 
 		if v, ok := coreSizeByUUID[device.Id]; ok {
 			gpu.CoreTotal = v
-		}
-		if v, ok := memSizeByUUID[device.Id]; ok {
-			gpu.MemoryTotal = v
 		}
 		res.List = append(res.List, gpu)
 	}

--- a/server/internal/service/node.go
+++ b/server/internal/service/node.go
@@ -42,15 +42,14 @@ func (s *NodeService) GetAllNodes(ctx context.Context, req *pb.GetAllNodesReq) (
 	}
 
 	// Fetch containers once (StatisticsByDeviceId used to re-list per device) and
-	// pull the per-node core/memory totals in two queries keyed by node, instead
-	// of two PromQL per node. This is what made /v1/nodes take 3-4s — and it is
-	// also called for the workload page's node filter dropdown.
+	// pull the per-node normalized compute baseline in one query keyed by node.
+	// Memory capacity already comes from DeviceInfo.Devmem, HAMi's registered
+	// schedulable value, so querying the exporter's delayed copy would be redundant.
 	containers, err := s.pod.ListAllContainers(ctx)
 	if err != nil {
 		return nil, err
 	}
 	coreByNode := s.queryNodeGauge(ctx, "avg(sum(hami_core_size) by (node, instance)) by (node)")
-	memByNode := s.queryNodeGauge(ctx, "avg(sum(hami_memory_size) by (node, instance)) by (node)")
 
 	var res = &pb.NodesReply{List: []*pb.NodeReply{}}
 	for _, node := range nodes {
@@ -59,10 +58,6 @@ func (s *NodeService) GetAllNodes(ctx context.Context, req *pb.GetAllNodesReq) (
 		if v, ok := coreByNode[node.Name]; ok {
 			nodeReply.CoreTotal = v
 		}
-		if v, ok := memByNode[node.Name]; ok {
-			nodeReply.MemoryTotal = v
-		}
-
 		if filters.Ip != "" && filters.Ip != nodeReply.Ip {
 			continue
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Aligns the resource contract across Overview, Node, Card, Top 5, preview, and trends:

- allocation uses the HAMi-registered schedulable capacity and reports a real zero when capacity exists but no workload is allocated;
- memory usage divides only by devices that also report used memory, without a query-level zero fallback;
- Node/Card list APIs retain DeviceInfo.Devmem and remove the redundant Prometheus memory-capacity query;
- Node/Card details render missing or failed samples as -- while preserving a real zero.

This does not change exporter metric values. The physical-capacity producer contract and range-query gap handling remain follow-ups in #28.

**Verification**:

- pnpm test
- ESLint on all changed frontend files
- pnpm verify:vite-env
- go test ./...
- Prometheus 2.55 and 3.14 parsers accepted all generated query shapes

**Which issue(s) this PR fixes**:

Advances #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vGPU compute and memory capacity reporting across node, GPU, card, and overview views.
  - Preserved registered memory capacity while ensuring compute capacity reflects current monitoring data.
  - Improved handling of unavailable or error-state metric values.
  - Updated memory utilization calculations and reporting-device filtering for more accurate results.

- **Tests**
  - Added coverage for allocation, utilization, rankings, trends, capacity handling, and metric readiness scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->