### PR TITLE
fix(metrics): preserve missing range samples

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:metrics && pnpm run test:workload",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:metrics": "node --test projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs"
   },
   "dependencies": {

--- a/packages/web/projects/vgpu/api/card.js
+++ b/packages/web/projects/vgpu/api/card.js
@@ -1,12 +1,12 @@
 import request from '@/utils/request';
+import { normalizeRangeVectorResponse } from '../metrics/range-vector-state.mjs';
 
 const apiPrefix = '/api/vgpu';
-
 
 class cardApi {
   getCardList(data = { filters: {} }) {
     return {
-      url: apiPrefix +  '/v1/gpus',
+      url: apiPrefix + '/v1/gpus',
       method: 'POST',
       data,
     };
@@ -14,7 +14,7 @@ class cardApi {
 
   getCardType(data = { filters: {} }) {
     return {
-      url: apiPrefix +  '/v1/gpu-types',
+      url: apiPrefix + '/v1/gpu-types',
       method: 'POST',
       data,
     };
@@ -26,7 +26,7 @@ class cardApi {
 
   getCardDetail(params) {
     return request({
-      url: apiPrefix +  '/v1/gpu',
+      url: apiPrefix + '/v1/gpu',
       method: 'get',
       params,
     });
@@ -34,15 +34,15 @@ class cardApi {
 
   getRangeVector(data) {
     return request({
-      url: apiPrefix +  '/v1/monitor/query/range-vector',
+      url: apiPrefix + '/v1/monitor/query/range-vector',
       method: 'post',
       data,
-    });
+    }).then(normalizeRangeVectorResponse);
   }
 
   getInstantVector(data) {
     return request({
-      url: apiPrefix +  '/v1/monitor/query/instant-vector',
+      url: apiPrefix + '/v1/monitor/query/instant-vector',
       method: 'post',
       data,
     });

--- a/packages/web/projects/vgpu/components/config.js
+++ b/packages/web/projects/vgpu/components/config.js
@@ -1,5 +1,10 @@
 import { timeParse } from '@/utils';
 import i18n from '@/locales';
+import {
+  buildRangeLineSeries,
+  formatRangeTooltipValue,
+  normalizeRangeValues,
+} from '../metrics/range-vector-state.mjs';
 
 export default ({ percent, title, unit = '%' }) => {
   const value = percent.toFixed(1);
@@ -219,7 +224,14 @@ export const getTopOptions = ({ core, memory }) => {
   };
 };
 
-export const getLineOptions = ({ data = [], unit = '%', seriesName, animation = true }) => {
+export const getLineOptions = ({
+  data = [],
+  unit = '%',
+  seriesName,
+  animation = true,
+}) => {
+  const normalizedData = normalizeRangeValues(data);
+
   return {
     animation,
     tooltip: {
@@ -234,15 +246,24 @@ export const getLineOptions = ({ data = [], unit = '%', seriesName, animation = 
       formatter: function (params) {
         if (!Array.isArray(params) || params.length === 0) return '';
 
-        let result = `<div style="margin-bottom:5px;">${params[0]?.name ?? ''}</div>`;
+        let result = `<div style="margin-bottom:5px;">${
+          params[0]?.name ?? ''
+        }</div>`;
         for (let i = 0; i < params.length; i++) {
           const item = params[i];
-          const raw = Array.isArray(item?.value) ? item.value[item.value.length - 1] : item?.value;
-          const num = Number(raw);
-          const value = Number.isFinite(num) ? `${num.toFixed(1)} ${unit}` : '-';
+          const raw = Array.isArray(item?.value)
+            ? item.value[item.value.length - 1]
+            : item?.value;
+          const value = formatRangeTooltipValue(raw, {
+            digits: 1,
+            unit,
+            separator: ' ',
+          });
           result += `
             <div style="display:flex;align-items:center;font-size:14px;line-height:22px;">
-              <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${item?.color || '#5B8FF9'};margin-right:5px;"></span>
+              <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${
+                item?.color || '#5B8FF9'
+              };margin-right:5px;"></span>
               <span>${item?.seriesName || '-'}:&nbsp;</span>
               <span style="font-weight:bold;">${value}</span>
             </div>
@@ -266,7 +287,7 @@ export const getLineOptions = ({ data = [], unit = '%', seriesName, animation = 
     ],
     xAxis: {
       type: 'category',
-      data: data.map((item) => timeParse(+item.timestamp)),
+      data: normalizedData.map((item) => timeParse(item.timestamp)),
       axisLabel: {
         formatter: function (value) {
           return timeParse(value, 'HH:mm');
@@ -277,21 +298,21 @@ export const getLineOptions = ({ data = [], unit = '%', seriesName, animation = 
       type: 'value',
     },
     series: [
-      {
-        name: seriesName || '',
-        data: data.map((item) => {
-          return item.value.toFixed(1);
-        }),
-        type: 'line',
-        lineStyle: {
-          width: 3,
-          color: '#5B8FF9',
+      buildRangeLineSeries(
+        {
+          name: seriesName || '',
+          data: normalizedData,
+          lineStyle: {
+            width: 3,
+            color: '#5B8FF9',
+          },
+          itemStyle: {
+            color: '#5B8FF9',
+            borderColor: '#5B8FF9',
+          },
         },
-        itemStyle: {
-          color: '#5B8FF9',
-          borderColor: '#5B8FF9',
-        },
-      },
+        { digits: 1 },
+      ),
     ],
   };
 };

--- a/packages/web/projects/vgpu/metrics/range-vector-state.mjs
+++ b/packages/web/projects/vgpu/metrics/range-vector-state.mjs
@@ -1,0 +1,68 @@
+export function toFiniteRangeValue(rawValue) {
+  if (
+    (typeof rawValue !== 'number' && typeof rawValue !== 'string') ||
+    (typeof rawValue === 'string' && rawValue.trim() === '')
+  ) {
+    return null;
+  }
+
+  const value = Number(rawValue);
+  return Number.isFinite(value) ? value : null;
+}
+
+export function normalizeRangePoint(point) {
+  const isLegacyPair = Array.isArray(point);
+  const rawTimestamp = isLegacyPair ? point[0] : point?.timestamp;
+  const rawValue = isLegacyPair ? point[1] : point?.value;
+  const timestamp = toFiniteRangeValue(rawTimestamp);
+  const value =
+    !isLegacyPair && point?.missing === true
+      ? null
+      : toFiniteRangeValue(rawValue);
+
+  if (point && typeof point === 'object' && !isLegacyPair) {
+    return { ...point, timestamp, value };
+  }
+
+  return { timestamp, value };
+}
+
+export function normalizeRangeValues(values) {
+  return Array.isArray(values) ? values.map(normalizeRangePoint) : [];
+}
+
+export function normalizeRangeVectorResponse(response) {
+  if (!response || !Array.isArray(response.data)) return response;
+
+  return {
+    ...response,
+    data: response.data.map((stream) => ({
+      ...stream,
+      values: normalizeRangeValues(stream?.values),
+    })),
+  };
+}
+
+export function buildRangeLineData(values, { digits } = {}) {
+  return normalizeRangeValues(values).map(({ value }) => {
+    if (value === null) return null;
+    return digits === undefined ? value : Number(value.toFixed(digits));
+  });
+}
+
+export function buildRangeLineSeries(series, presentation) {
+  return {
+    ...series,
+    data: buildRangeLineData(series?.data, presentation),
+    type: 'line',
+    connectNulls: false,
+  };
+}
+
+export function formatRangeTooltipValue(
+  rawValue,
+  { digits = 1, unit = '', separator = '' } = {},
+) {
+  const value = toFiniteRangeValue(rawValue);
+  return value === null ? '-' : `${value.toFixed(digits)}${separator}${unit}`;
+}

--- a/packages/web/projects/vgpu/metrics/range-vector-state.test.mjs
+++ b/packages/web/projects/vgpu/metrics/range-vector-state.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildRangeLineSeries,
+  formatRangeTooltipValue,
+  normalizeRangeValues,
+  normalizeRangeVectorResponse,
+  toFiniteRangeValue,
+} from './range-vector-state.mjs';
+
+test('range normalization preserves slots while separating zero from missing data', () => {
+  const values = normalizeRangeValues([
+    { timestamp: '1000', value: 0 },
+    { timestamp: '2000', value: 0, missing: true },
+    { timestamp: '3000', value: 'NaN' },
+    { timestamp: '4000', value: 'Infinity' },
+    { timestamp: '5000', value: '-Infinity' },
+    { timestamp: '6000', value: '12.5' },
+    ['7000', 0],
+  ]);
+
+  assert.equal(values.length, 7);
+  assert.deepEqual(
+    values.map(({ timestamp, value }) => ({ timestamp, value })),
+    [
+      { timestamp: 1000, value: 0 },
+      { timestamp: 2000, value: null },
+      { timestamp: 3000, value: null },
+      { timestamp: 4000, value: null },
+      { timestamp: 5000, value: null },
+      { timestamp: 6000, value: 12.5 },
+      { timestamp: 7000, value: 0 },
+    ],
+  );
+  assert.equal(values[1].missing, true);
+});
+
+test('non-numeric range values do not become synthetic zeroes', () => {
+  assert.equal(toFiniteRangeValue(null), null);
+  assert.equal(toFiniteRangeValue(undefined), null);
+  assert.equal(toFiniteRangeValue(''), null);
+  assert.equal(toFiniteRangeValue(false), null);
+  assert.equal(toFiniteRangeValue('0'), 0);
+  assert.equal(toFiniteRangeValue(0), 0);
+});
+
+test('range response normalization is pure and retains every stream slot', () => {
+  const response = {
+    code: 0,
+    data: [
+      {
+        metric: { device_uuid: 'GPU-1' },
+        values: [
+          { timestamp: '1000', value: 0 },
+          { timestamp: '2000', missing: true },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeRangeVectorResponse(response);
+
+  assert.notEqual(normalized, response);
+  assert.notEqual(normalized.data, response.data);
+  assert.equal(normalized.data[0].values.length, 2);
+  assert.deepEqual(
+    normalized.data[0].values.map(({ timestamp, value }) => ({
+      timestamp,
+      value,
+    })),
+    [
+      { timestamp: 1000, value: 0 },
+      { timestamp: 2000, value: null },
+    ],
+  );
+  assert.equal(response.data[0].values[1].value, undefined);
+});
+
+test('live range chart series retain gaps and never reconnect missing slots', () => {
+  const points = [
+    { timestamp: 1000, value: 0 },
+    { timestamp: 2000, missing: true },
+    { timestamp: 3000, value: 2048 },
+  ];
+  const cases = [
+    { name: 'overview', presentation: undefined, expected: [0, null, 2048] },
+    { name: 'node detail', presentation: undefined, expected: [0, null, 2048] },
+    {
+      name: 'card common line',
+      presentation: { digits: 1 },
+      expected: [0, null, 2048],
+    },
+    {
+      name: 'task common line',
+      presentation: { digits: 1 },
+      expected: [0, null, 2048],
+    },
+  ];
+
+  for (const { name, presentation, expected } of cases) {
+    const series = buildRangeLineSeries({ name, data: points }, presentation);
+    assert.deepEqual(series.data, expected, name);
+    assert.equal(series.connectNulls, false, name);
+  }
+});
+
+test('range tooltips render missing values as a dash without hiding real zero', () => {
+  assert.equal(formatRangeTooltipValue(null, { digits: 1, unit: '%' }), '-');
+  assert.equal(formatRangeTooltipValue('NaN', { digits: 1, unit: '%' }), '-');
+  assert.equal(formatRangeTooltipValue(0, { digits: 1, unit: '%' }), '0.0%');
+});

--- a/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
+++ b/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
@@ -1,5 +1,10 @@
 import { timeParse } from '@/utils';
 import { cloneDeep } from 'lodash';
+import {
+  buildRangeLineSeries,
+  formatRangeTooltipValue,
+  normalizeRangeValues,
+} from '../../../metrics/range-vector-state.mjs';
 import nodeApi from '~/vgpu/api/node';
 import { MessagePlugin } from 'tdesign-vue-next';
 import i18n from '@/locales';
@@ -285,7 +290,14 @@ export const handleChartClick = async (params, router) => {
   }
 };
 
-const CARD_PIE_COLORS = ['#76B900', '#9FCB98', '#F59E0B', '#4F8F87', '#14B8A6', '#6B7280'];
+const CARD_PIE_COLORS = [
+  '#76B900',
+  '#9FCB98',
+  '#F59E0B',
+  '#4F8F87',
+  '#14B8A6',
+  '#6B7280',
+];
 
 export const getCardOptions = (list, chartWidth) => {
   const data = list.reduce((all, current) => {
@@ -525,6 +537,11 @@ export const getRangeOptions = (data) => {
     };
   }
 
+  const normalizedData = data.map((item) => ({
+    ...item,
+    data: normalizeRangeValues(item.data),
+  }));
+
   return {
     animation: true,
     legend: {
@@ -540,15 +557,23 @@ export const getRangeOptions = (data) => {
       formatter: function (params) {
         if (!Array.isArray(params) || params.length === 0) return '';
 
-        let result = `<div style="margin-bottom:5px;">${params[0]?.name ?? ''}</div>`;
+        let result = `<div style="margin-bottom:5px;">${
+          params[0]?.name ?? ''
+        }</div>`;
         for (let i = 0; i < params.length; i++) {
           const item = params[i];
-          const raw = Array.isArray(item?.value) ? item.value[item.value.length - 1] : item?.value;
-          const num = Number(raw);
-          const value = Number.isFinite(num) ? `${num.toFixed(3)}%` : '-';
+          const raw = Array.isArray(item?.value)
+            ? item.value[item.value.length - 1]
+            : item?.value;
+          const value = formatRangeTooltipValue(raw, {
+            digits: 3,
+            unit: '%',
+          });
           result += `
             <div style="display:flex;align-items:center;font-size:14px;line-height:22px;">
-              <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${item?.color || '#5B8FF9'};margin-right:5px;"></span>
+              <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${
+                item?.color || '#5B8FF9'
+              };margin-right:5px;"></span>
               <span>${item?.seriesName || '-'}:&nbsp;</span>
               <span style="font-weight:bold;">${value}</span>
             </div>
@@ -572,7 +597,7 @@ export const getRangeOptions = (data) => {
     ],
     xAxis: {
       type: 'category',
-      data: data[0].data.map((item) => timeParse(+item.timestamp)),
+      data: normalizedData[0].data.map((item) => timeParse(item.timestamp)),
       axisLabel: {
         formatter: function (value) {
           return timeParse(value, 'HH:mm');
@@ -594,31 +619,32 @@ export const getRangeOptions = (data) => {
         },
       },
     },
-    series: data.map((item) => ({
-      ...item,
-      type: 'line',
-      // areaStyle: {
-      //   normal: {
-      //     color: {
-      //       type: 'linear',
-      //       x: 0, // 渐变起始点 0%
-      //       y: 0, // 渐变起始点 0%
-      //       x2: 0, // 渐变结束点 100%
-      //       y2: 1, // 渐变结束点 100%
-      //       colorStops: [
-      //         {
-      //           offset: 0,
-      //           color: 'rgba(34, 139, 34, 0.16)', // 渐变起始颜色
-      //         },
-      //         {
-      //           offset: 1,
-      //           color: 'rgba(34, 139, 34, 0.00)', // 渐变结束颜色
-      //         },
-      //       ],
-      //       global: false, // 缺省为 false
-      //     },
-      //   },
-      // },
-    })),
+    series: normalizedData.map((item) =>
+      buildRangeLineSeries({
+        ...item,
+        // areaStyle: {
+        //   normal: {
+        //     color: {
+        //       type: 'linear',
+        //       x: 0, // 渐变起始点 0%
+        //       y: 0, // 渐变起始点 0%
+        //       x2: 0, // 渐变结束点 100%
+        //       y2: 1, // 渐变结束点 100%
+        //       colorStops: [
+        //         {
+        //           offset: 0,
+        //           color: 'rgba(34, 139, 34, 0.16)', // 渐变起始颜色
+        //         },
+        //         {
+        //           offset: 1,
+        //           color: 'rgba(34, 139, 34, 0.00)', // 渐变结束颜色
+        //         },
+        //       ],
+        //       global: false, // 缺省为 false
+        //     },
+        //   },
+        // },
+      }),
+    ),
   };
 };

--- a/packages/web/projects/vgpu/views/node/admin/getOptions.js
+++ b/packages/web/projects/vgpu/views/node/admin/getOptions.js
@@ -1,29 +1,26 @@
 import { timeParse } from '@/utils';
-
-const normalizePoints = (points = []) => {
-  return points
-    .map((point) => {
-      if (Array.isArray(point)) {
-        return { timestamp: Number(point[0]), value: Number(point[1]) };
-      }
-      return {
-        timestamp: Number(point?.timestamp),
-        value: Number(point?.value),
-      };
-    })
-    .filter((item) => Number.isFinite(item.timestamp) && Number.isFinite(item.value));
-};
+import {
+  buildRangeLineSeries,
+  formatRangeTooltipValue,
+  normalizeRangeValues,
+} from '../../../metrics/range-vector-state.mjs';
 
 const buildPercentTooltipFormatter = () => {
   return (params) => {
     if (!Array.isArray(params) || params.length === 0) return '';
-    let result = `<div style="margin-bottom:5px;">${params[0]?.axisValueLabel || params[0]?.name || ''}</div>`;
+    let result = `<div style="margin-bottom:5px;">${
+      params[0]?.axisValueLabel || params[0]?.name || ''
+    }</div>`;
     for (let i = 0; i < params.length; i++) {
       const item = params[i];
-      const num = Number(item?.value);
-      const value = Number.isFinite(num) ? `${num.toFixed(3)}%` : '-';
+      const value = formatRangeTooltipValue(item?.value, {
+        digits: 3,
+        unit: '%',
+      });
       result += `<div style="display:flex;align-items:center;font-size:14px;line-height:22px;">
-          <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${item?.color || '#5B8FF9'};margin-right:5px;"></span>
+          <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background-color:${
+            item?.color || '#5B8FF9'
+          };margin-right:5px;"></span>
           <span>${item?.seriesName || '-'}:&nbsp;</span>
           <span style="font-weight:bold;">${value}</span>
         </div>`;
@@ -32,10 +29,15 @@ const buildPercentTooltipFormatter = () => {
   };
 };
 
-export const getRangeOptions = ({ allocation = [], usage = [] }, t = (v) => v) => {
-  const normalizedAllocation = normalizePoints(allocation);
-  const normalizedUsage = normalizePoints(usage);
-  const xDataSource = normalizedAllocation.length ? normalizedAllocation : normalizedUsage;
+export const getRangeOptions = (
+  { allocation = [], usage = [] },
+  t = (v) => v,
+) => {
+  const normalizedAllocation = normalizeRangeValues(allocation);
+  const normalizedUsage = normalizeRangeValues(usage);
+  const xDataSource = normalizedAllocation.length
+    ? normalizedAllocation
+    : normalizedUsage;
   return {
     animation: false,
     legend: {
@@ -80,10 +82,9 @@ export const getRangeOptions = ({ allocation = [], usage = [] }, t = (v) => v) =
       },
     },
     series: [
-      {
+      buildRangeLineSeries({
         name: t('dashboard.allocRateLegend'),
-        data: normalizedAllocation.map((item) => item.value),
-        type: 'line',
+        data: normalizedAllocation,
         itemStyle: {
           color: '#5B8FF9',
         },
@@ -91,11 +92,10 @@ export const getRangeOptions = ({ allocation = [], usage = [] }, t = (v) => v) =
           width: 3,
           color: '#5B8FF9',
         },
-      },
-      {
+      }),
+      buildRangeLineSeries({
         name: t('dashboard.usageRateLegend'),
-        data: normalizedUsage.map((item) => item.value),
-        type: 'line',
+        data: normalizedUsage,
         itemStyle: {
           color: '#42C090',
         },
@@ -103,7 +103,7 @@ export const getRangeOptions = ({ allocation = [], usage = [] }, t = (v) => v) =
           width: 3,
           color: '#42C090',
         },
-      },
+      }),
     ],
   };
 };

--- a/server/api/v1/monitor.proto
+++ b/server/api/v1/monitor.proto
@@ -53,6 +53,7 @@ message QueryRangeRequest {
 message SamplePair {
   float value = 1;
   int64 timestamp = 2;
+  bool missing = 3;
 }
 
 message SampleStream {

--- a/server/internal/service/monitor.go
+++ b/server/internal/service/monitor.go
@@ -74,9 +74,9 @@ func fillLessSamplePoint(startTime, endTime time.Time, step time.Duration, value
 	for !currentTime.After(endTime) {
 		currentTimestamp := currentTime.UnixMilli()
 		if value, exists := existingPoints[currentTimestamp]; exists {
-			filledValues = append(filledValues, &pb.SamplePair{Value: value, Timestamp: currentTimestamp})
+			filledValues = append(filledValues, &pb.SamplePair{Value: value, Timestamp: currentTimestamp, Missing: false})
 		} else {
-			filledValues = append(filledValues, &pb.SamplePair{Value: 0, Timestamp: currentTimestamp})
+			filledValues = append(filledValues, &pb.SamplePair{Value: 0, Timestamp: currentTimestamp, Missing: true})
 		}
 		currentTime = currentTime.Add(step)
 	}

--- a/server/internal/service/monitor_test.go
+++ b/server/internal/service/monitor_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	pb "vgpu/api/v1"
+
+	kratosjson "github.com/go-kratos/kratos/v2/encoding/json"
+)
+
+func TestSamplePairJSONKeepsZeroDistinctFromMissing(t *testing.T) {
+	tests := []struct {
+		name    string
+		pair    *pb.SamplePair
+		missing bool
+	}{
+		{name: "real zero", pair: &pb.SamplePair{Value: 0, Timestamp: 1_000}},
+		{name: "missing slot", pair: &pb.SamplePair{Value: 0, Timestamp: 2_000, Missing: true}, missing: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := kratosjson.MarshalOptions.Marshal(tt.pair)
+			if err != nil {
+				t.Fatalf("marshal sample pair: %v", err)
+			}
+
+			var fields map[string]any
+			if err := json.Unmarshal(payload, &fields); err != nil {
+				t.Fatalf("decode sample pair JSON: %v", err)
+			}
+			if value, ok := fields["value"]; !ok || value != float64(0) {
+				t.Fatalf("value field = %#v (present %t), want an explicit zero", value, ok)
+			}
+			if missing, ok := fields["missing"].(bool); !ok || missing != tt.missing {
+				t.Fatalf("missing field = %#v, want %t", fields["missing"], tt.missing)
+			}
+		})
+	}
+}
+
+func TestFillLessSamplePointPreservesRealZeroAndMarksInternalGap(t *testing.T) {
+	start := time.UnixMilli(1_000)
+	end := time.UnixMilli(3_000)
+	values := []*pb.SamplePair{
+		{Value: 0, Timestamp: 1_000},
+		{Value: 2, Timestamp: 3_000},
+	}
+
+	got := fillLessSamplePoint(start, end, time.Second, values)
+	want := []*pb.SamplePair{
+		{Value: 0, Timestamp: 1_000, Missing: false},
+		{Value: 0, Timestamp: 2_000, Missing: true},
+		{Value: 2, Timestamp: 3_000, Missing: false},
+	}
+	assertSamplePairs(t, got, want)
+}
+
+func TestFillLessSamplePointMarksLeadingAndTrailingGaps(t *testing.T) {
+	start := time.UnixMilli(1_000)
+	end := time.UnixMilli(5_000)
+	values := []*pb.SamplePair{
+		{Value: 7, Timestamp: 3_000},
+	}
+
+	got := fillLessSamplePoint(start, end, time.Second, values)
+	want := []*pb.SamplePair{
+		{Value: 0, Timestamp: 1_000, Missing: true},
+		{Value: 0, Timestamp: 2_000, Missing: true},
+		{Value: 7, Timestamp: 3_000, Missing: false},
+		{Value: 0, Timestamp: 4_000, Missing: true},
+		{Value: 0, Timestamp: 5_000, Missing: true},
+	}
+	assertSamplePairs(t, got, want)
+}
+
+func TestFillLessSamplePointKeepsVictoriaMetricsAlignment(t *testing.T) {
+	start := time.UnixMilli(1_000)
+	end := time.UnixMilli(3_500)
+	values := []*pb.SamplePair{
+		{Value: 0, Timestamp: 1_500},
+		{Value: 9, Timestamp: 3_500},
+	}
+
+	got := fillLessSamplePoint(start, end, time.Second, values)
+	want := []*pb.SamplePair{
+		{Value: 0, Timestamp: 1_500, Missing: false},
+		{Value: 0, Timestamp: 2_500, Missing: true},
+		{Value: 9, Timestamp: 3_500, Missing: false},
+	}
+	assertSamplePairs(t, got, want)
+}
+
+func assertSamplePairs(t *testing.T, got, want []*pb.SamplePair) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("sample count = %d, want %d: got %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].GetValue() != want[i].GetValue() ||
+			got[i].GetTimestamp() != want[i].GetTimestamp() ||
+			got[i].GetMissing() != want[i].GetMissing() {
+			t.Errorf("sample %d = {value:%v timestamp:%d missing:%t}, want {value:%v timestamp:%d missing:%t}",
+				i,
+				got[i].GetValue(), got[i].GetTimestamp(), got[i].GetMissing(),
+				want[i].GetValue(), want[i].GetTimestamp(), want[i].GetMissing(),
+			)
+		}
+	}
+}


### PR DESCRIPTION
/kind bug

Range queries currently fill missing timestamps with `value: 0`, so charts cannot distinguish a scrape gap from a real idle sample.

This change:

- marks only server-generated slots as `missing`, while preserving real zero values;
- normalizes range responses once and renders missing values as chart gaps with `-` tooltips;
- keeps the existing dense time grid and Prometheus/VictoriaMetrics alignment behavior.

`SamplePair.missing` is an additive protobuf field. Older clients ignore it, and the Kratos JSON contract continues to emit explicit zero values.

Verification:

- `GOTOOLCHAIN=local go test ./...`
- Web tests: 29/29 passed
- ESLint and Prettier on changed web files
- production Vite build and `verify:vite-env`

Advances #28; this PR only fixes gaps inside returned range streams.
