### PR TITLE
fix(metrics): restore physical device memory contract

### DIFF
--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -82,7 +82,7 @@ export default {
     computeUsageRateDescription:
       'Equal-weight average of provider-native, device-level compute utilization across reporting devices. Definitions may differ by provider; this is not compute allocation.',
     memUsageRateDescription:
-      'Used memory divided by HAMi-registered memory capacity across devices reporting memory-use data. With memory overcommit, this is not physical memory occupancy.',
+      'Vendor-reported used physical memory divided by vendor-reported physical capacity across devices that provide both values. Devices without matching telemetry are excluded; this is not memory allocation.',
     metricHelpLabel: 'View metric definition for {metric}',
     metricNoData: 'No metric data',
     metricInvalid: 'Invalid metric value',
@@ -103,7 +103,7 @@ export default {
     cpuCoreUnit: 'Core',
     systemMemoryTotal: 'Total Memory',
     memory: 'Memory',
-    memoryTotal: 'Total GPU Memory',
+    memoryTotal: 'Schedulable GPU Memory',
     schedulable: 'Schedulable',
     unschedulable: 'Unschedulable',
     allocated: 'Allocated',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -82,7 +82,7 @@ export default {
     computeUsageRateDescription:
       '所有已上报设备的厂商原生设备级算力利用率等权平均。不同厂商口径可能不同；它不是算力分配率。',
     memUsageRateDescription:
-      '已上报显存使用数据的设备，其已用显存 ÷ HAMi 注册容量。启用显存超配时，该值不等于物理显存占用率。',
+      '同时上报物理显存已用量和物理容量的设备，其已用量 ÷ 物理容量。缺少任一遥测值的设备不参与计算；它不是显存分配率。',
     metricHelpLabel: '查看{metric}指标说明',
     metricNoData: '暂无指标数据',
     metricInvalid: '指标值无效',
@@ -103,7 +103,7 @@ export default {
     cpuCoreUnit: 'Core',
     systemMemoryTotal: '内存总量',
     memory: '显存',
-    memoryTotal: 'GPU 显存总量',
+    memoryTotal: '可调度 GPU 显存',
     schedulable: '可调度',
     unschedulable: '禁止调度',
     allocated: '已分配',

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -13,7 +13,6 @@ import (
 	"vgpu/internal/conf"
 	"vgpu/internal/data/prom"
 	"vgpu/internal/provider/metax"
-	"vgpu/internal/provider/mlu"
 	"vgpu/internal/service"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -28,6 +27,8 @@ var ProviderSet = wire.NewSet(
 const (
 	defaultGenerateInterval = 30 * time.Second
 	defaultGenerateTimeout  = 60 * time.Second
+	bytesPerKiB             = 1024
+	bytesPerMiB             = bytesPerKiB * 1024
 )
 
 var (
@@ -253,17 +254,17 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 		// 超配比指标
 		s.set(HamiVCoreScaling, float64(device.Devcore)/100, device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		s.set(HamiCoreSize, 100, device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-		deviceMemUsed, err := s.deviceMemUsed(ctx, provider, device.Id)
-		if err == nil {
+		deviceMemUsed, memoryUsedErr := s.deviceMemUsed(ctx, provider, device.Id)
+		if memoryUsedErr == nil {
 			s.set(HamiMemoryUsed, float64(deviceMemUsed), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-			if device.Devmem > 0 {
-				s.set(HamiMemoryUtil, roundToOneDecimal(100*float64(deviceMemUsed/float32(device.Devmem))), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-			}
 		}
-		s.set(HamiMemorySize, float64(device.Devmem), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-		deviceMemSize, err := s.deviceMemTotal(ctx, provider, device.Id)
-		if err == nil && deviceMemSize > 0 {
+		deviceMemSize, memorySizeErr := s.deviceMemTotal(ctx, provider, device.Id)
+		if memorySizeErr == nil && deviceMemSize > 0 {
+			s.set(HamiMemorySize, float64(deviceMemSize), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 			s.set(HamiVMemoryScaling, roundToOneDecimal(float64(float32(device.Devmem)/deviceMemSize)), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+			if memoryUsedErr == nil {
+				s.set(HamiMemoryUtil, roundToOneDecimal(100*float64(deviceMemUsed/deviceMemSize)), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+			}
 		}
 		actualCoreUtil, err := s.deviceCoreUtil(ctx, provider, device.Id)
 		if err == nil {
@@ -468,14 +469,7 @@ func (s *MetricsGenerator) deviceMemUsed(ctx context.Context, provider, deviceUU
 	if err != nil {
 		return val, err
 	}
-	if provider == biz.CambriconGPUDevice {
-		val = val / mlu.CambriconMemUnit
-	} else if provider == biz.HygonGPUDevice {
-		val = val / 1024 / 1024
-	} else if provider == biz.MetaxGPUDevice {
-		val = val / 1024
-	}
-	return val, err
+	return deviceMemoryToMiB(provider, val), nil
 }
 
 // 卡显存总量
@@ -495,16 +489,22 @@ func (s *MetricsGenerator) deviceMemTotal(ctx context.Context, provider, deviceU
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	val, err := s.queryInstantVal(ctx, query)
+	val, err := s.queryRequiredInstantVal(ctx, query)
 	if err != nil {
 		return val, err
 	}
-	if provider == biz.CambriconGPUDevice || provider == biz.MetaxGPUDevice {
-		val = val / 1024
-	} else if provider == biz.HygonGPUDevice {
-		val = val / 1024 / 1024
+	return deviceMemoryToMiB(provider, val), nil
+}
+
+func deviceMemoryToMiB(provider string, value float32) float32 {
+	switch provider {
+	case biz.CambriconGPUDevice, biz.HygonGPUDevice:
+		return value / bytesPerMiB
+	case biz.MetaxGPUDevice:
+		return value / bytesPerKiB
+	default:
+		return value
 	}
-	return val, err
 }
 
 // 卡算力利用率

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"errors"
+	"io"
 	"math"
 	"strings"
 	"testing"
@@ -10,21 +11,53 @@ import (
 	pb "vgpu/api/v1"
 	"vgpu/internal/biz"
 	"vgpu/internal/provider/metax"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type fakeInstantQuerier struct {
-	responses []*pb.InstantResponse
-	queries   []string
+	responses        []*pb.InstantResponse
+	responsesByQuery map[string]*pb.InstantResponse
+	errorsByQuery    map[string]error
+	queries          []string
 }
 
 func (f *fakeInstantQuerier) QueryInstant(_ context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
 	f.queries = append(f.queries, req.GetQuery())
+	if err, ok := f.errorsByQuery[req.GetQuery()]; ok {
+		return nil, err
+	}
+	if res, ok := f.responsesByQuery[req.GetQuery()]; ok {
+		return res, nil
+	}
 	if len(f.responses) == 0 {
 		return &pb.InstantResponse{}, nil
 	}
 	res := f.responses[0]
 	f.responses = f.responses[1:]
 	return res, nil
+}
+
+type fakeNodeRepo struct {
+	devices []*biz.DeviceInfo
+}
+
+func (f *fakeNodeRepo) ListAll(context.Context) ([]*biz.Node, error) {
+	return nil, nil
+}
+
+func (f *fakeNodeRepo) GetNode(context.Context, string) (*biz.Node, error) {
+	return nil, nil
+}
+
+func (f *fakeNodeRepo) ListAllDevices(context.Context) ([]*biz.DeviceInfo, error) {
+	return f.devices, nil
+}
+
+func (f *fakeNodeRepo) FindDeviceByAliasId(string) (*biz.DeviceInfo, error) {
+	return nil, nil
 }
 
 func TestNvidiaTaskCoreUsedQueryIncludesIdleSamples(t *testing.T) {
@@ -97,11 +130,314 @@ func TestDeviceUsageMetricsDistinguishMissingFromIdle(t *testing.T) {
 }
 
 func TestDeviceUsageMetricsRejectNonFiniteSamples(t *testing.T) {
-	for _, value := range []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))} {
-		generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: value}}}}}}
-		_, err := generator.deviceCoreUtil(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
-		if !errors.Is(err, errNoMetricData) {
-			t.Fatalf("expected errNoMetricData for %v, got %v", value, err)
+	queries := []struct {
+		name string
+		read func(*MetricsGenerator) (float32, error)
+	}{
+		{name: "memory used", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.deviceMemUsed(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+		}},
+		{name: "memory total", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.deviceMemTotal(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+		}},
+		{name: "compute", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.deviceCoreUtil(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+		}},
+	}
+	values := []struct {
+		name  string
+		value float32
+	}{
+		{name: "NaN", value: float32(math.NaN())},
+		{name: "positive infinity", value: float32(math.Inf(1))},
+		{name: "negative infinity", value: float32(math.Inf(-1))},
+	}
+
+	for _, query := range queries {
+		for _, value := range values {
+			t.Run(query.name+"/"+value.name, func(t *testing.T) {
+				generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: value.value}}}}}}
+				_, err := query.read(generator)
+				if !errors.Is(err, errNoMetricData) {
+					t.Fatalf("expected errNoMetricData for %v, got %v", value.value, err)
+				}
+			})
+		}
+	}
+}
+
+func TestDeviceMemoryQueriesConvertVendorUnitsToMiB(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		raw      float32
+		wantMiB  float32
+	}{
+		{name: "NVIDIA already reports MiB", provider: biz.NvidiaGPUDevice, raw: 1024, wantMiB: 1024},
+		{name: "Cambricon reports bytes", provider: biz.CambriconGPUDevice, raw: 1024 * 1024 * 1024, wantMiB: 1024},
+		{name: "Ascend already reports MiB", provider: biz.AscendGPUDevice, raw: 1024, wantMiB: 1024},
+		{name: "Hygon reports bytes", provider: biz.HygonGPUDevice, raw: 1024 * 1024 * 1024, wantMiB: 1024},
+		{name: "MetaX keeps existing KiB assumption", provider: biz.MetaxGPUDevice, raw: 1024 * 1024, wantMiB: 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: tt.raw}}}}}}
+			used, err := generator.deviceMemUsed(context.Background(), tt.provider, "device-1")
+			if err != nil || used != tt.wantMiB {
+				t.Fatalf("deviceMemUsed() = (%v, %v), want (%v, nil)", used, err, tt.wantMiB)
+			}
+
+			generator.monitorService = &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: tt.raw}}}}}
+			total, err := generator.deviceMemTotal(context.Background(), tt.provider, "device-1")
+			if err != nil || total != tt.wantMiB {
+				t.Fatalf("deviceMemTotal() = (%v, %v), want (%v, nil)", total, err, tt.wantMiB)
+			}
+		})
+	}
+}
+
+func TestGenerateDeviceMetricsSeparatesPhysicalAndSchedulableMemory(t *testing.T) {
+	const (
+		deviceID      = "GPU-physical-contract"
+		nodeName      = "node-physical-contract"
+		deviceType    = "A100"
+		schedulableMB = 81920
+		physicalMB    = 40960
+		usedMB        = 10240
+	)
+	usedQuery := `avg(DCGM_FI_DEV_FB_USED{UUID="GPU-physical-contract"})`
+	totalQuery := `avg(DCGM_FI_DEV_FB_FREE{UUID="GPU-physical-contract"})+avg(DCGM_FI_DEV_FB_USED{UUID="GPU-physical-contract"})`
+	generator := newDeviceMetricsTestGenerator(
+		&biz.DeviceInfo{
+			Id:       deviceID,
+			Devmem:   schedulableMB,
+			Devcore:  100,
+			Count:    1,
+			Type:     deviceType,
+			NodeName: nodeName,
+			Provider: biz.NvidiaGPUDevice,
+		},
+		map[string]*pb.InstantResponse{
+			usedQuery:  instantValue(usedMB),
+			totalQuery: instantValue(physicalMB),
+		},
+	)
+
+	if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+		t.Fatalf("GenerateDeviceMetrics() error = %v", err)
+	}
+	labels := []string{nodeName, biz.NvidiaGPUDevice, deviceType, deviceID, "", ""}
+	assertTrackedGaugeValue(t, generator, HamiVmemorySize, labels, schedulableMB)
+	assertTrackedGaugeValue(t, generator, HamiMemorySize, labels, physicalMB)
+	assertTrackedGaugeValue(t, generator, HamiMemoryUsed, labels, usedMB)
+	assertTrackedGaugeValue(t, generator, HamiMemoryUtil, labels, 25)
+	assertTrackedGaugeValue(t, generator, HamiVMemoryScaling, labels, 2)
+}
+
+func TestGenerateDeviceMetricsOmitsPhysicalUtilizationWithoutMatchingCoverage(t *testing.T) {
+	tests := []struct {
+		name              string
+		deviceID          string
+		responses         map[string]*pb.InstantResponse
+		wantPhysicalSize  bool
+		wantPhysicalUsed  bool
+		wantPhysicalUtil  bool
+		wantMemoryScaling bool
+	}{
+		{
+			name:     "used without total",
+			deviceID: "GPU-used-only",
+			responses: map[string]*pb.InstantResponse{
+				`avg(DCGM_FI_DEV_FB_USED{UUID="GPU-used-only"})`: instantValue(512),
+			},
+			wantPhysicalUsed: true,
+		},
+		{
+			name:     "total without used",
+			deviceID: "GPU-total-only",
+			responses: map[string]*pb.InstantResponse{
+				`avg(DCGM_FI_DEV_FB_FREE{UUID="GPU-total-only"})+avg(DCGM_FI_DEV_FB_USED{UUID="GPU-total-only"})`: instantValue(40960),
+			},
+			wantPhysicalSize:  true,
+			wantMemoryScaling: true,
+		},
+		{
+			name:     "zero total is not capacity",
+			deviceID: "GPU-zero-total",
+			responses: map[string]*pb.InstantResponse{
+				`avg(DCGM_FI_DEV_FB_FREE{UUID="GPU-zero-total"})+avg(DCGM_FI_DEV_FB_USED{UUID="GPU-zero-total"})`: instantValue(0),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := newDeviceMetricsTestGenerator(
+				&biz.DeviceInfo{
+					Id:       tt.deviceID,
+					Devmem:   81920,
+					Devcore:  100,
+					Count:    1,
+					Type:     "A100",
+					NodeName: "node-coverage-" + tt.deviceID,
+					Provider: biz.NvidiaGPUDevice,
+				},
+				tt.responses,
+			)
+
+			if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+				t.Fatalf("GenerateDeviceMetrics() error = %v", err)
+			}
+			labels := []string{"node-coverage-" + tt.deviceID, biz.NvidiaGPUDevice, "A100", tt.deviceID, "", ""}
+			assertGaugeTracked(t, generator, HamiMemorySize, labels, tt.wantPhysicalSize)
+			assertGaugeTracked(t, generator, HamiMemoryUsed, labels, tt.wantPhysicalUsed)
+			assertGaugeTracked(t, generator, HamiMemoryUtil, labels, tt.wantPhysicalUtil)
+			assertGaugeTracked(t, generator, HamiVMemoryScaling, labels, tt.wantMemoryScaling)
+		})
+	}
+}
+
+func TestCommitCyclePrunesPhysicalMemorySeriesWhenTelemetryDisappears(t *testing.T) {
+	const (
+		deviceID   = "GPU-prune-physical-contract"
+		nodeName   = "node-prune-physical-contract"
+		deviceType = "A100"
+	)
+	usedQuery := `avg(DCGM_FI_DEV_FB_USED{UUID="GPU-prune-physical-contract"})`
+	totalQuery := `avg(DCGM_FI_DEV_FB_FREE{UUID="GPU-prune-physical-contract"})+avg(DCGM_FI_DEV_FB_USED{UUID="GPU-prune-physical-contract"})`
+	generator := newDeviceMetricsTestGenerator(
+		&biz.DeviceInfo{
+			Id:       deviceID,
+			Devmem:   81920,
+			Devcore:  100,
+			Count:    1,
+			Type:     deviceType,
+			NodeName: nodeName,
+			Provider: biz.NvidiaGPUDevice,
+		},
+		map[string]*pb.InstantResponse{
+			usedQuery:  instantValue(10240),
+			totalQuery: instantValue(40960),
+		},
+	)
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+		t.Fatalf("first GenerateDeviceMetrics() error = %v", err)
+	}
+	generator.commitCycle()
+	labels := map[string]string{
+		"node":           nodeName,
+		"provider":       biz.NvidiaGPUDevice,
+		"device_type":    deviceType,
+		"device_uuid":    deviceID,
+		"driver_version": "",
+		"device_no":      "",
+	}
+	assertGaugeLabelsPresent(t, HamiMemorySize, labels, true)
+	assertGaugeLabelsPresent(t, HamiMemoryUsed, labels, true)
+	assertGaugeLabelsPresent(t, HamiMemoryUtil, labels, true)
+	assertGaugeLabelsPresent(t, HamiVMemoryScaling, labels, true)
+
+	// A successful cycle with no vendor memory telemetry must retain the
+	// schedulable inventory while pruning physical series from the registry.
+	generator.monitorService = &fakeInstantQuerier{responsesByQuery: map[string]*pb.InstantResponse{}}
+	if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+		t.Fatalf("second GenerateDeviceMetrics() error = %v", err)
+	}
+	generator.commitCycle()
+
+	assertGaugeLabelsPresent(t, HamiVmemorySize, labels, true)
+	assertGaugeLabelsPresent(t, HamiMemorySize, labels, false)
+	assertGaugeLabelsPresent(t, HamiMemoryUsed, labels, false)
+	assertGaugeLabelsPresent(t, HamiMemoryUtil, labels, false)
+	assertGaugeLabelsPresent(t, HamiVMemoryScaling, labels, false)
+}
+
+func newDeviceMetricsTestGenerator(device *biz.DeviceInfo, responses map[string]*pb.InstantResponse) *MetricsGenerator {
+	return &MetricsGenerator{
+		nodeUsecase: biz.NewNodeUsecase(
+			&fakeNodeRepo{devices: []*biz.DeviceInfo{device}},
+			log.NewStdLogger(io.Discard),
+		),
+		monitorService: &fakeInstantQuerier{responsesByQuery: responses},
+		log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+	}
+}
+
+func instantValue(value float32) *pb.InstantResponse {
+	return &pb.InstantResponse{Data: []*pb.Sample{{Value: value}}}
+}
+
+func assertTrackedGaugeValue(
+	t *testing.T,
+	generator *MetricsGenerator,
+	gauge *prometheus.GaugeVec,
+	labels []string,
+	want float64,
+) {
+	t.Helper()
+	assertGaugeTracked(t, generator, gauge, labels, true)
+	if got := testutil.ToFloat64(gauge.WithLabelValues(labels...)); got != want {
+		t.Fatalf("gauge value = %v, want %v", got, want)
+	}
+}
+
+func assertGaugeTracked(
+	t *testing.T,
+	generator *MetricsGenerator,
+	gauge *prometheus.GaugeVec,
+	labels []string,
+	want bool,
+) {
+	t.Helper()
+	key := cellKey{gauge: gauge, joined: strings.Join(labels, labelSep)}
+	_, got := generator.current[key]
+	if got != want {
+		t.Fatalf("gauge tracked = %t, want %t", got, want)
+	}
+}
+
+func assertGaugeLabelsPresent(
+	t *testing.T,
+	gauge *prometheus.GaugeVec,
+	wantLabels map[string]string,
+	want bool,
+) {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(gauge)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	found := false
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			matches := true
+			for _, pair := range metric.GetLabel() {
+				value, ok := wantLabels[pair.GetName()]
+				if !ok || value != pair.GetValue() {
+					matches = false
+					break
+				}
+			}
+			if matches && len(metric.GetLabel()) == len(wantLabels) {
+				found = true
+				break
+			}
+		}
+	}
+	if found != want {
+		t.Fatalf("gauge label set present = %t, want %t; labels = %v", found, want, wantLabels)
+	}
+}
+
+func deleteTrackedTestCells(generator *MetricsGenerator) {
+	for _, cells := range []map[cellKey]cell{generator.current, generator.prev} {
+		for _, tracked := range cells {
+			tracked.gauge.DeleteLabelValues(tracked.labels...)
 		}
 	}
 }

--- a/server/internal/exporter/metrics.go
+++ b/server/internal/exporter/metrics.go
@@ -51,7 +51,7 @@ var (
 
 	HamiVMemoryScaling = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_vmemory_scaling",
-		Help: "GPU virtual memory Scaling",
+		Help: "HAMi-registered schedulable memory divided by vendor-reported physical memory",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiVgpuCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -61,7 +61,7 @@ var (
 
 	HamiVmemorySize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_vmemory_size",
-		Help: "Total vMemory size",
+		Help: "HAMi-registered schedulable device memory, unit is 'MiB'",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiVcoreSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -71,17 +71,17 @@ var (
 
 	HamiMemoryUsed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_memory_used",
-		Help: "Actual memory usage, unit is 'MB' ",
+		Help: "Vendor-reported used physical device memory, unit is 'MiB'",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiMemorySize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_memory_size",
-		Help: "Actual memory size, unit is 'MB' ",
+		Help: "Vendor-reported total physical device memory, unit is 'MiB'",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiMemoryUtil = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_memory_util",
-		Help: "Actual Memory Util percent 0-100",
+		Help: "Vendor-reported used physical memory divided by total physical memory, percent 0-100",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiCoreSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
/kind bug

`hami_memory_size` and `hami_memory_util` currently use HAMi's registered schedulable memory, although the metrics' original contract and HELP text describe physical memory. This makes physical usage appear lower when memory overcommit is enabled.

This change:

- keeps `hami_vmemory_size` as schedulable memory;
- restores `hami_memory_size` and `hami_memory_util` to vendor-reported physical memory;
- omits physical capacity and dependent ratios when matching telemetry is unavailable;
- converts Cambricon device memory from bytes to MiB;
- labels schedulable capacity and physical utilization explicitly in the UI.

This restores the contract used in v1.0.1-v1.0.3 without adding a second metric. Clusters using memory overcommit may see physical capacity decrease and physical utilization increase at the upgrade boundary. The Cambricon conversion does not address the separate discovery, resource-name, annotation, or VF-mapping work tracked in #44.

Verification: `go test ./...`, `go vet ./...`, WebUI tests and lint, production Vite build, and a two-cycle stale-series pruning test.

Fixes #28
