### PR TITLE
fix(api): accept requests without filters

### DIFF
--- a/server/internal/service/card.go
+++ b/server/internal/service/card.go
@@ -21,7 +21,10 @@ func NewCardService(node *biz.NodeUsecase, pod *biz.PodUseCase, ms *MonitorServi
 }
 
 func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*pb.GPUsReply, error) {
-	filters := req.Filters
+	filters := req.GetFilters()
+	if filters == nil {
+		filters = &pb.GetAllGpusReq_Filters{}
+	}
 	deviceInfos, err := s.node.ListAllDevices(ctx)
 	if err != nil {
 		return nil, err
@@ -111,7 +114,10 @@ func (s *CardService) GetAllGPUTypes(ctx context.Context, req *pb.GetAllGpusReq)
 	var res = &pb.GPUsReply{List: []*pb.GPUReply{}}
 	seenTypes := make(map[string]struct{})
 
-	filters := req.Filters
+	filters := req.GetFilters()
+	if filters == nil {
+		filters = &pb.GetAllGpusReq_Filters{}
+	}
 	provider := strings.Trim(filters.Provider, " ")
 	for _, device := range deviceInfos {
 		if provider != "" && provider != device.Provider {

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -55,7 +55,10 @@ func matchesWorkloadName(podName, containerName, filter string) bool {
 }
 
 func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllContainersReq) (*pb.ContainersReply, error) {
-	filters := req.Filters
+	filters := req.GetFilters()
+	if filters == nil {
+		filters = &pb.GetAllContainersReq_Filters{}
+	}
 	containers, err := s.pod.ListAllContainers(ctx)
 	if err != nil {
 		return nil, err

--- a/server/internal/service/empty_filters_test.go
+++ b/server/internal/service/empty_filters_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kratos/kratos/v2/log"
+	pb "vgpu/api/v1"
+	"vgpu/internal/biz"
+	"vgpu/internal/data/prom"
+)
+
+func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	defer prometheus.Close()
+
+	device := &biz.DeviceInfo{
+		Id:       "GPU-1",
+		AliasId:  "GPU-1",
+		NodeName: "node-a",
+		NodeUid:  "node-uid-a",
+	}
+	nodeRepo := &capacityTestNodeRepo{
+		nodes: []*biz.Node{{
+			Name:    "node-a",
+			Uid:     "node-uid-a",
+			Devices: []*biz.DeviceInfo{device},
+		}},
+		devices: []*biz.DeviceInfo{device},
+	}
+	podRepo := &emptyFiltersPodRepo{containers: []*biz.Container{{
+		Name:      "worker",
+		PodName:   "job-a",
+		NodeName:  "node-a",
+		NodeUID:   "node-uid-a",
+		Namespace: "default",
+	}}}
+	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
+	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	monitor := NewMonitorService(promClient, nodeUsecase, podUsecase)
+	nodes := NewNodeService(
+		nodeUsecase,
+		podUsecase,
+		biz.NewSummaryUseCase(nodeRepo, podRepo, log.DefaultLogger),
+		monitor,
+	)
+	cards := NewCardService(nodeUsecase, podUsecase, monitor)
+	containers := NewContainerService(nodeUsecase, podUsecase)
+
+	tests := []struct {
+		name   string
+		invoke func() error
+	}{
+		{
+			name: "summary",
+			invoke: func() error {
+				_, err := nodes.GetSummary(context.Background(), &pb.GetSummaryReq{})
+				return err
+			},
+		},
+		{
+			name: "nodes",
+			invoke: func() error {
+				_, err := nodes.GetAllNodes(context.Background(), &pb.GetAllNodesReq{})
+				return err
+			},
+		},
+		{
+			name: "cards",
+			invoke: func() error {
+				_, err := cards.GetAllGPUs(context.Background(), &pb.GetAllGpusReq{})
+				return err
+			},
+		},
+		{
+			name: "card types",
+			invoke: func() error {
+				_, err := cards.GetAllGPUTypes(context.Background(), &pb.GetAllGpusReq{})
+				return err
+			},
+		},
+		{
+			name: "containers",
+			invoke: func() error {
+				_, err := containers.GetAllContainers(context.Background(), &pb.GetAllContainersReq{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.invoke(); err != nil {
+				t.Fatalf("request without filters returned an error: %v", err)
+			}
+		})
+	}
+}
+
+type emptyFiltersPodRepo struct {
+	containers []*biz.Container
+}
+
+func (r *emptyFiltersPodRepo) ListAll(context.Context) ([]*biz.Container, error) {
+	return r.containers, nil
+}
+
+func (*emptyFiltersPodRepo) FindOne(context.Context, string, string) (*biz.Container, error) {
+	return nil, nil
+}

--- a/server/internal/service/node.go
+++ b/server/internal/service/node.go
@@ -27,7 +27,10 @@ func NewNodeService(uc *biz.NodeUsecase, pod *biz.PodUseCase, summary *biz.Summa
 }
 
 func (s *NodeService) GetSummary(ctx context.Context, req *pb.GetSummaryReq) (*pb.DeviceSummaryReply, error) {
-	filters := req.Filters
+	filters := req.GetFilters()
+	if filters == nil {
+		filters = &pb.GetSummaryReq_Filters{}
+	}
 	var res = &pb.DeviceSummaryReply{}
 	t, err := s.summary.GetGPUSummary(ctx, filters.DeviceId, filters.NodeUid, filters.Type)
 	copier.Copy(&res, &t)
@@ -35,7 +38,10 @@ func (s *NodeService) GetSummary(ctx context.Context, req *pb.GetSummaryReq) (*p
 }
 
 func (s *NodeService) GetAllNodes(ctx context.Context, req *pb.GetAllNodesReq) (*pb.NodesReply, error) {
-	filters := req.Filters
+	filters := req.GetFilters()
+	if filters == nil {
+		filters = &pb.GetAllNodesReq_Filters{}
+	}
 	nodes, err := s.uc.ListAllNodes(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Requests such as `POST /v1/summary` with `{}` leave the optional nested `filters` message unset. Five list and summary service methods dereferenced that field, so a valid unfiltered request reached the recovery middleware as an internal error.

Treat a missing filter object as an empty filter and add a regression test covering summary, node, card, card-type, and workload lists with non-empty fixtures.

**Which issue(s) this PR fixes**:

Fixes #108

Supersedes the nil-filter portion of #109; thanks @CN-Antonio for diagnosing it. The readiness changes in that PR are intentionally outside this fix.

**Verification**:

- `go test -count=1 ./...`
- `go vet ./...`
- `go mod tidy -diff`
- the same checks in the pinned Go 1.26.7 Linux image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests without filter fields no longer cause errors or crashes when retrieving summaries, nodes, GPUs, GPU types, or containers.
  * Filtering behavior remains unchanged when filters are provided.

* **Tests**
  * Added coverage to verify service requests work correctly with empty filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->