### PR TITLE
fix(server): isolate HTTP fallback handlers

### DIFF
--- a/server/internal/server/http.go
+++ b/server/internal/server/http.go
@@ -6,12 +6,18 @@ import (
 	"vgpu/internal/conf"
 	"vgpu/internal/service"
 
+	kratoserrors "github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/metrics"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	"github.com/go-kratos/swagger-api/openapiv2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	httpReasonRouteNotFound    = "ROUTE_NOT_FOUND"
+	httpReasonMethodNotAllowed = "METHOD_NOT_ALLOWED"
 )
 
 // NewHTTPServer new an HTTP server.
@@ -39,6 +45,8 @@ func NewHTTPServer(c *conf.Bootstrap,
 			recovery.Recovery(),
 			metrics.Server(),
 		),
+		http.NotFoundHandler(httpErrorHandler(nethttp.StatusNotFound, httpReasonRouteNotFound)),
+		http.MethodNotAllowedHandler(httpErrorHandler(nethttp.StatusMethodNotAllowed, httpReasonMethodNotAllowed)),
 	}
 	if c.Server.Http.Network != "" {
 		opts = append(opts, http.Network(c.Server.Http.Network))
@@ -63,4 +71,10 @@ func NewHTTPServer(c *conf.Bootstrap,
 		_, _ = w.Write([]byte("ok"))
 	})
 	return srv
+}
+
+func httpErrorHandler(status int, reason string) nethttp.Handler {
+	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		http.DefaultErrorEncoder(w, r, kratoserrors.New(status, reason, nethttp.StatusText(status)))
+	})
 }

--- a/server/internal/server/http_test.go
+++ b/server/internal/server/http_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"vgpu/internal/conf"
+)
+
+func TestHTTPFallbackResponses(t *testing.T) {
+	defaultServeMux := nethttp.DefaultServeMux
+	nethttp.DefaultServeMux = nethttp.NewServeMux()
+	nethttp.DefaultServeMux.HandleFunc("/default-mux-probe", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusTeapot)
+	})
+	t.Cleanup(func() {
+		nethttp.DefaultServeMux = defaultServeMux
+	})
+
+	handler := newTestHTTPHandler()
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantReason string
+	}{
+		{
+			name:       "global default mux endpoint is hidden",
+			method:     nethttp.MethodGet,
+			path:       "/default-mux-probe",
+			wantStatus: nethttp.StatusNotFound,
+			wantReason: httpReasonRouteNotFound,
+		},
+		{
+			name:       "unknown route",
+			method:     nethttp.MethodGet,
+			path:       "/not-a-route",
+			wantStatus: nethttp.StatusNotFound,
+			wantReason: httpReasonRouteNotFound,
+		},
+		{
+			name:       "known route with unsupported method",
+			method:     nethttp.MethodGet,
+			path:       "/v1/nodes",
+			wantStatus: nethttp.StatusMethodNotAllowed,
+			wantReason: httpReasonMethodNotAllowed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, test.path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if contentType := response.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/json") {
+				t.Fatalf("Content-Type = %q, want application/json", contentType)
+			}
+
+			var body struct {
+				Code   int32  `json:"code"`
+				Reason string `json:"reason"`
+			}
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v; body = %s", err, response.Body.String())
+			}
+			if body.Code != int32(test.wantStatus) || body.Reason != test.wantReason {
+				t.Fatalf("error = {%d %q}, want {%d %q}", body.Code, body.Reason, test.wantStatus, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestRegisteredHTTPHandlerTakesPrecedenceOverFallback(t *testing.T) {
+	request := httptest.NewRequest(nethttp.MethodGet, "/readyz", nil)
+	response := httptest.NewRecorder()
+	newTestHTTPHandler().ServeHTTP(response, request)
+
+	if response.Code != nethttp.StatusOK || response.Body.String() != "ok" {
+		t.Fatalf("readyz response = {%d %q}, want {200 %q}", response.Code, response.Body.String(), "ok")
+	}
+}
+
+func newTestHTTPHandler() nethttp.Handler {
+	srv := NewHTTPServer(
+		&conf.Bootstrap{Server: &conf.Server{Http: &conf.Server_HTTP{}}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	return srv.Handler
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Kratos v2.7.3 falls back to the process-wide `http.DefaultServeMux` for unknown routes and method mismatches. Because the backend imports packages that register diagnostic handlers there, `/debug/vars` could expose process details instead of returning an API 404.

This configures explicit Kratos JSON handlers for 404 and 405 responses, keeping fallback requests inside the application router. It is an application-level mitigation for GO-2026-5471 while no patched Kratos release is available.

**Verification**:

- `go test -count=1 ./internal/server`
- `go test -count=1 ./...`
- Regression tests cover isolation from `http.DefaultServeMux`, unknown routes, unsupported methods, and precedence of registered routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error responses for unknown routes and unsupported methods.
  * Error responses now use a consistent JSON format with appropriate status codes and reasons.
  * Preserved normal behavior for registered endpoints, including readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->