### PR TITLE
chore(web): remove unused Vue WebSocket plugin

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,6 @@
     "vue-count-to": "1.0.13",
     "vue-echarts": "^6.7.3",
     "vue-i18n": "9",
-    "vue-native-websocket-vue3": "^3.1.7",
     "vue-router": "^4.0.3",
     "vuedraggable": "^4.1.0",
     "vuex": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       vue-i18n:
         specifier: '9'
         version: 9.14.5(vue@3.5.25(typescript@5.9.3))
-      vue-native-websocket-vue3:
-        specifier: ^3.1.7
-        version: 3.1.8(core-js@3.47.0)(vue@3.5.25(typescript@5.9.3))
       vue-router:
         specifier: ^4.0.3
         version: 4.6.4(vue@3.5.25(typescript@5.9.3))
@@ -2951,12 +2948,6 @@ packages:
     resolution: {integrity: sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==}
     engines: {node: '>= 16'}
     peerDependencies:
-      vue: ^3.0.0
-
-  vue-native-websocket-vue3@3.1.8:
-    resolution: {integrity: sha512-Ck5g//zndFvFWlddhWeKTbbe4wbbZBegMMf49XLrhc3+hHlfBLn2xDC7wsEb0uMFCfiXGiQEqzfl8YQ8qBQeIQ==}
-    peerDependencies:
-      core-js: ^3.6.5
       vue: ^3.0.0
 
   vue-router@4.6.4:
@@ -6138,12 +6129,6 @@ snapshots:
       '@intlify/core-base': 9.14.5
       '@intlify/shared': 9.14.5
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.25(typescript@5.9.3)
-
-  vue-native-websocket-vue3@3.1.8(core-js@3.47.0)(vue@3.5.25(typescript@5.9.3)):
-    dependencies:
-      core-js: 3.47.0
-      file-entry-cache: 6.0.1
       vue: 3.5.25(typescript@5.9.3)
 
   vue-router@4.6.4(vue@3.5.25(typescript@5.9.3)):


### PR DESCRIPTION
**What this PR does / why we need it**

Removes the unused `vue-native-websocket-vue3` dependency.

The plugin has no import, registration, or runtime use anywhere in the repository. Its removal is independent of the Socket.IO cleanup in #197 and does not remove an existing WebSocket product path.

The lockfile change removes only the plugin entry; shared Vue, `core-js`, and `file-entry-cache` dependencies remain.

**Verification**

- `pnpm install --frozen-lockfile`
- root and Web lint
- full Web test suite
- production Web build
- `verify:vite-env`
- dependency graph contains no `vue-native-websocket-vue3`