### PR TITLE
fix(deps): update js-cookie security baseline

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,7 @@
     "echarts": "5.4.3",
     "element-plus": "^2.4.1",
     "generate-avatar": "1.4.10",
-    "js-cookie": "3.0.5",
+    "js-cookie": "3.0.8",
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "nprogress": "0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 1.4.10
         version: 1.4.10
       js-cookie:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.8
+        version: 3.0.8
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2003,9 +2003,8 @@ packages:
   js-base64@2.6.4:
     resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5042,7 +5041,7 @@ snapshots:
 
   js-base64@2.6.4: {}
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**

Updates `js-cookie` from 3.0.5 to 3.0.8.

[GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j) affects versions through 3.0.5 and is patched in 3.0.7. This uses 3.0.8 because the follow-up release restores the ES5 compatibility and Node metadata accidentally regressed in 3.0.7.

HAMi-WebUI only reads and writes the fixed `language` cookie without caller-provided attributes, so the advisory's untrusted-attributes path is not currently reachable. The update still removes the vulnerable direct-dependency baseline and its two alert records.

**Verification**

- frozen install resolves only `js-cookie@3.0.8`
- root and Web lint
- full Web test suite
- production Web build and Vite environment check
- 10 Web-entry contract tests
- 5 Chromium base-path and iframe tests