### PR TITLE
fix(web): escape card type tooltip text

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,7 @@
     "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:metrics && pnpm run test:workload && pnpm run test:ui-contracts",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
-    "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs",
     "test:ui-contracts": "node --test projects/vgpu/views/card/admin/node-detail-location.test.mjs"
   },

--- a/packages/web/projects/vgpu/metrics/tooltip-html.mjs
+++ b/packages/web/projects/vgpu/metrics/tooltip-html.mjs
@@ -1,0 +1,15 @@
+export const escapeTooltipHtmlText = (value) =>
+  String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+export const formatCardTypeTooltip = ({ name, value }, unit) => {
+  const suffix = unit ? ` ${escapeTooltipHtmlText(unit)}` : '';
+
+  return `${escapeTooltipHtmlText(name)}: ${escapeTooltipHtmlText(
+    value,
+  )}${suffix}`;
+};

--- a/packages/web/projects/vgpu/metrics/tooltip-html.test.mjs
+++ b/packages/web/projects/vgpu/metrics/tooltip-html.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  escapeTooltipHtmlText,
+  formatCardTypeTooltip,
+} from './tooltip-html.mjs';
+
+test('card type tooltip treats device metadata as text', () => {
+  const deviceType =
+    'Ascend910B<img src=x onerror="globalThis.compromised=true">';
+  const tooltip = formatCardTypeTooltip(
+    { name: deviceType, value: 2 },
+    'cards',
+  );
+
+  assert.equal(
+    tooltip,
+    'Ascend910B&lt;img src=x onerror=&quot;globalThis.compromised=true&quot;&gt;: 2 cards',
+  );
+  assert.doesNotMatch(tooltip, /<\s*(?:img|script)\b/i);
+});
+
+test('tooltip text escapes every HTML-significant character', () => {
+  assert.equal(
+    escapeTooltipHtmlText(`A&B <C> "D" 'E'`),
+    'A&amp;B &lt;C&gt; &quot;D&quot; &#39;E&#39;',
+  );
+});
+
+test('normal card type tooltips keep their existing presentation', () => {
+  assert.equal(
+    formatCardTypeTooltip({ name: 'Ascend910B', value: 2 }, '张'),
+    'Ascend910B: 2 张',
+  );
+  assert.equal(
+    formatCardTypeTooltip({ name: 'NVIDIA A100', value: 1 }, ''),
+    'NVIDIA A100: 1',
+  );
+});

--- a/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
+++ b/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
@@ -5,6 +5,7 @@ import {
   formatRangeTooltipValue,
   normalizeRangeValues,
 } from '../../../metrics/range-vector-state.mjs';
+import { formatCardTypeTooltip } from '../../../metrics/tooltip-html.mjs';
 import nodeApi from '~/vgpu/api/node';
 import { MessagePlugin } from 'tdesign-vue-next';
 import i18n from '@/locales';
@@ -326,8 +327,7 @@ export const getCardOptions = (list, chartWidth) => {
       confine: true,
       formatter: (params) => {
         const unit = i18n.global.t('common.unitSheet');
-        const suffix = unit ? ` ${unit}` : '';
-        return `${params.name}: ${params.value}${suffix}`;
+        return formatCardTypeTooltip(params, unit);
       },
     },
     color: CARD_PIE_COLORS,


### PR DESCRIPTION
/kind bug

GPU model names come from runtime device metadata and are rendered by ECharts' HTML tooltip. Treat the model name, count, and translated unit as text before returning the formatter output, so malformed metadata cannot create tooltip elements.

This only changes the card-type tooltip boundary; normal labels and chart behavior remain unchanged.

Verification:
- 51 metric contract tests, including malicious metadata and normal display cases
- complete Web tests and production build
- Web and changed-file lint
