### PR TITLE
fix(web): preserve chart value accuracy

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,7 @@
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
     "test:svg-icons": "node --test test/svg-icons-plugin.test.mjs",
     "test:echarts-runtime": "node --test test/echarts-runtime.test.mjs",
-    "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
+    "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/monitor/overview/workload-distribution.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs",
     "test:ui-contracts": "node --test projects/vgpu/views/card/admin/node-detail-location.test.mjs"
   },

--- a/packages/web/projects/vgpu/components/TabTop.vue
+++ b/packages/web/projects/vgpu/components/TabTop.vue
@@ -85,7 +85,10 @@ import {
   resolveRequest,
   startRequest,
 } from '@/hooks/request-state.mjs';
-import { readRankingRows } from './tab-top-state.mjs';
+import {
+  formatRankingValue,
+  readRankingRows,
+} from './tab-top-state.mjs';
 
 const props = defineProps({
   title: String,
@@ -115,13 +118,6 @@ const handleClick = (params) => {
   }
 };
 
-const formatValue = (value, unit) => {
-  const num = Number(value) || 0;
-  const fixed = num.toFixed(0);
-  const unitText = unit && unit.trim() ? ` ${unit.trim()}` : '';
-  return `${fixed}${unitText}`;
-};
-
 const displayItems = computed(() => {
   const config = currentConfig.value.find(
     (item) => item.key === tabActive.value,
@@ -149,7 +145,7 @@ const displayItems = computed(() => {
       ...item,
       index: index + 1,
       percentage: getPercentage(item.value),
-      valueDisplay: formatValue(item.value, unit),
+      valueDisplay: formatRankingValue(item.value, unit),
     }));
 });
 

--- a/packages/web/projects/vgpu/components/tab-top-state.mjs
+++ b/packages/web/projects/vgpu/components/tab-top-state.mjs
@@ -12,6 +12,16 @@ const toFiniteValue = (value) => {
   return Number.isFinite(number) ? number : undefined;
 };
 
+export const formatRankingValue = (value, unit = '%') => {
+  const number = toFiniteValue(value) ?? 0;
+  const rounded = Math.round((number + Number.EPSILON) * 100) / 100;
+  const display = number !== 0 && rounded === 0
+    ? number > 0 ? '<0.01' : '>-0.01'
+    : String(rounded);
+  const normalizedUnit = typeof unit === 'string' ? unit.trim() : '';
+  return normalizedUnit ? `${display} ${normalizedUnit}` : display;
+};
+
 export const readRankingRows = (response, nameKey) => {
   if (!Array.isArray(response?.data)) {
     return { data: [], status: REQUEST_STATUS.INVALID };

--- a/packages/web/projects/vgpu/components/tab-top-state.test.mjs
+++ b/packages/web/projects/vgpu/components/tab-top-state.test.mjs
@@ -2,7 +2,18 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { REQUEST_STATUS } from '../../../src/hooks/request-state.mjs';
-import { readRankingRows } from './tab-top-state.mjs';
+import {
+  formatRankingValue,
+  readRankingRows,
+} from './tab-top-state.mjs';
+
+test('ranking values preserve meaningful fractional data', () => {
+  assert.equal(formatRankingValue(0.4, '%'), '0.4 %');
+  assert.equal(formatRankingValue(1.25, 'GiB'), '1.25 GiB');
+  assert.equal(formatRankingValue(4, ' '), '4');
+  assert.equal(formatRankingValue(0, '%'), '0 %');
+  assert.equal(formatRankingValue(0.004, '%'), '<0.01 %');
+});
 
 test('ranking rows preserve real zero and reject invalid-only results', () => {
   assert.deepEqual(

--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -366,6 +366,7 @@ import {
   handleChartClick,
   getRangeOptions,
 } from './getOptions';
+import { createWorkloadDistributionOptions } from './workload-distribution.mjs';
 import Block from './Block.vue';
 import './style.scss';
 import { RouterLink, useRouter } from 'vue-router';
@@ -462,83 +463,10 @@ const nodeWorkloadTop5TableData = computed(() =>
 );
 
 const nodeWorkloadDistributionOptions = computed(() => {
-  const rows = nodeWorkloadDistributionState.data || [];
-  const bucketSize = 10;
-  const maxValue = rows.length ? Math.max(...rows.map((item) => Number(item.value) || 0)) : 0;
-  const bucketCount = Math.max(1, Math.floor(maxValue / bucketSize) + 1);
-
-  const xData = Array.from({ length: bucketCount }, (_, idx) => {
-    const start = idx * bucketSize;
-    const end = start + bucketSize - 1;
-    return `${start}-${end}`;
+  return createWorkloadDistributionOptions({
+    rows: nodeWorkloadDistributionState.data,
+    translate: t,
   });
-  const yData = new Array(bucketCount).fill(0);
-
-  rows.forEach((item) => {
-    const value = Number(item.value) || 0;
-    const bucketIdx = Math.min(Math.floor(value / bucketSize), bucketCount - 1);
-    yData[bucketIdx] += 1;
-  });
-  return {
-    tooltip: {
-      trigger: 'item',
-      formatter: (item) => {
-        if (!item) return '';
-        const unit = t('common.unitCount');
-        return `${t('dashboard.workloadRange')}: ${item.name}<br/>${t('dashboard.nodeTotal')}: ${Number(item.value || 0)}${unit}`;
-      },
-    },
-    grid: {
-      left: 25,
-      right: 25,
-      top: 20,
-      bottom: 8,
-      outerBoundsMode: 'same',
-      outerBoundsContain: 'axisLabel',
-    },
-    xAxis: {
-      type: 'category',
-      data: xData,
-      axisTick: {
-        alignWithLabel: true,
-      },
-      axisLabel: {
-        color: '#697886',
-      },
-    },
-    dataZoom: [
-      {
-        type: 'inside',
-        xAxisIndex: 0,
-        filterMode: 'none',
-      },
-    ],
-    yAxis: {
-      type: 'value',
-      minInterval: 1,
-      max: 5,
-      axisLine: {
-        show: false,
-      },
-      axisTick: {
-        show: false,
-      },
-      axisLabel: {
-        color: '#697886',
-      },
-    },
-    series: [
-      {
-        data: yData,
-        type: 'bar',
-        barWidth: 24,
-        barCategoryGap: '75',
-        itemStyle: {
-          color: '#5B8FF9',
-        },
-      },
-    ],
-  };
 });
 
 // These page-specific vectors share request-state mechanics without introducing

--- a/packages/web/projects/vgpu/views/monitor/overview/workload-distribution.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/workload-distribution.mjs
@@ -1,0 +1,92 @@
+const normalizeWorkloadCount = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+};
+
+export const createWorkloadDistributionOptions = ({
+  rows = [],
+  translate,
+  bucketSize = 10,
+}) => {
+  if (!Number.isFinite(bucketSize) || bucketSize <= 0) {
+    throw new TypeError('bucketSize must be a positive number');
+  }
+
+  const values = (Array.isArray(rows) ? rows : [])
+    .map((item) => normalizeWorkloadCount(item?.value));
+  const maxValue = values.length ? Math.max(...values) : 0;
+  const bucketCount = Math.max(1, Math.floor(maxValue / bucketSize) + 1);
+  const categories = Array.from({ length: bucketCount }, (_, index) => {
+    const start = index * bucketSize;
+    return `${start}-${start + bucketSize - 1}`;
+  });
+  const counts = new Array(bucketCount).fill(0);
+
+  values.forEach((value) => {
+    const bucketIndex = Math.min(
+      Math.floor(value / bucketSize),
+      bucketCount - 1,
+    );
+    counts[bucketIndex] += 1;
+  });
+
+  return {
+    tooltip: {
+      trigger: 'item',
+      formatter: (item) => {
+        if (!item) return '';
+        const unit = translate('common.unitCount');
+        return `${translate('dashboard.workloadRange')}: ${item.name}<br/>${translate('dashboard.nodeTotal')}: ${Number(item.value || 0)}${unit}`;
+      },
+    },
+    grid: {
+      left: 25,
+      right: 25,
+      top: 20,
+      bottom: 8,
+      outerBoundsMode: 'same',
+      outerBoundsContain: 'axisLabel',
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      axisTick: {
+        alignWithLabel: true,
+      },
+      axisLabel: {
+        color: '#697886',
+      },
+    },
+    dataZoom: [
+      {
+        type: 'inside',
+        xAxisIndex: 0,
+        filterMode: 'none',
+      },
+    ],
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      axisLine: {
+        show: false,
+      },
+      axisTick: {
+        show: false,
+      },
+      axisLabel: {
+        color: '#697886',
+      },
+    },
+    series: [
+      {
+        data: counts,
+        type: 'bar',
+        barWidth: 24,
+        barCategoryGap: '75',
+        itemStyle: {
+          color: '#5B8FF9',
+        },
+      },
+    ],
+  };
+};

--- a/packages/web/projects/vgpu/views/monitor/overview/workload-distribution.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/workload-distribution.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createWorkloadDistributionOptions } from './workload-distribution.mjs';
+
+const translate = (key) => key;
+
+test('workload distribution never clips buckets containing more than five nodes', () => {
+  const options = createWorkloadDistributionOptions({
+    rows: Array.from({ length: 7 }, () => ({ value: 4 })),
+    translate,
+  });
+
+  assert.deepEqual(options.xAxis.data, ['0-9']);
+  assert.deepEqual(options.series[0].data, [7]);
+  assert.equal(Object.hasOwn(options.yAxis, 'max'), false);
+});
+
+test('workload distribution keeps boundary values in distinct buckets', () => {
+  const options = createWorkloadDistributionOptions({
+    rows: [{ value: 0 }, { value: 9 }, { value: 10 }, { value: 20 }],
+    translate,
+  });
+
+  assert.deepEqual(options.xAxis.data, ['0-9', '10-19', '20-29']);
+  assert.deepEqual(options.series[0].data, [2, 1, 1]);
+});

--- a/test/web-entry/web-entry.browser.test.mjs
+++ b/test/web-entry/web-entry.browser.test.mjs
@@ -260,6 +260,10 @@ async function assertChartRuntime(target) {
   await page.waitForFunction(
     () => document.querySelectorAll('.echarts canvas').length >= 4
   )
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll('.tab-top-value')]
+      .some((element) => element.textContent?.trim() === '0.4 %')
+  )
 
   const initialRangeRequests = rangeRequests
   await page.locator('.home-bottom-trend-filter .t-radio-button').nth(1).click()
@@ -402,7 +406,7 @@ before(async() => {
             node: 'node-1',
             provider: 'NVIDIA'
           },
-          value: 42
+          value: 0.4
         }]
       }
     } else if (pathname === '/v1/monitor/query/range-vector') {


### PR DESCRIPTION
/kind bug

The overview workload distribution capped its Y axis at 5, clipping buckets with more nodes. Top 5 panels also rounded every value to an integer, so values such as 0.4% appeared as 0%.

This removes the fixed chart cap and preserves up to two meaningful decimal places, including an explicit <0.01 display for tiny non-zero values.

Verification:
- frontend lint and 54 state/metric tests
- production build
- Chromium Web Entry contract, including rendered 0.4% text and ECharts interaction