### PR TITLE
refactor(dev): make local workflows reproducible and release-safe

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -39,6 +39,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'server/.go-version'
+              - 'server/Makefile'
               - 'server/cmd/web-entry/**'
               - 'server/go.mod'
               - 'server/go.sum'
@@ -70,22 +71,21 @@ jobs:
       - name: Verify toolchain versions
         run: bash scripts/verify-toolchain-versions.sh
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: make bootstrap
       - name: Test Web
-        run: pnpm --filter hami-webui-web run test
-      - name: Build web and verify environment boundary
-        run: pnpm run verify:vite-env
-      - name: Pre-compress Web assets
-        run: pnpm run precompress:web-assets
+        run: make test
+      - name: Verify Vite environment boundary
+        run: make verify-vite-env
+      - name: Build Web assets
+        run: make build
       - name: Build Go Web entry
-        working-directory: server
-        run: mkdir -p build && GOTOOLCHAIN=local go build -mod=readonly -trimpath -o build/web-entry ./cmd/web-entry
+        run: make build-web-entry
       - name: Test Web-entry contract
-        run: pnpm run test:web-entry-contract
+        run: make test-web-entry-contract
       - name: Install Chromium for Web-entry browser tests
         run: pnpm exec playwright install --with-deps --only-shell chromium
       - name: Test base-path and iframe browser contract
-        run: pnpm run test:web-entry-browser
+        run: make test-web-entry-browser
 
   lint:
     runs-on: ubuntu-latest
@@ -101,11 +101,9 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Lint Web-entry tooling
-        run: pnpm run lint
-      - name: Lint web
-        run: pnpm --filter hami-webui-web run lint
+        run: make bootstrap
+      - name: Lint Web-entry tooling and Web
+        run: make lint
 
   # Single required status check: green only if every frontend job passed (or
   # there were no frontend-relevant changes).

--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -62,16 +62,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install codegen tools (wire / kratos / protoc-gen-*)
         run: make install-deps
-      - name: Generate proto + wire
-        run: make generate
-      - name: Verify module metadata
-        run: make verify-mod
-      - name: Build
-        run: go build ./...
-      - name: Vet
-        run: go vet ./...
-      - name: Unit tests
-        run: go test ./...
+      - name: Generate, build, vet, and test
+        run: make verify
 
   lint:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ When you're ready to contribute, it's time to create a pull request.
 ### Pull request review and merge
 
 1. Sign off every commit to satisfy the Developer Certificate of Origin (DCO).
-2. Wait for the required frontend, backend, and DCO checks to pass.
+2. Wait for all required checks to pass.
 3. A reviewer records the code review in GitHub and writes `/lgtm` when the change is ready.
 4. An approver listed in the relevant `OWNERS` file approves the change. An approver can select **Approve** in the GitHub review and put `/lgtm` in the review body to grant both `lgtm` and `approved` in one step.
 5. After the required checks and both labels are present, Tide merges the pull request through `hami-robot`.

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,73 @@
-VERSION?=latest
-DOCKER_IMAGE=projecthami/hami-webui-fe
-PROJECT_NAME?=test-project
+.DEFAULT_GOAL := help
 
-# 按项目最小化构建
-ROUTE_FILE=packages/web/src/router/index.js
-PROJECT_PATH=packages/web/projects/
-DISABLED_PROJECTS?=""
+PNPM ?= pnpm
+DOCKER ?= docker
+DOCKER_IMAGE ?= hami-webui-frontend
+VERSION ?= dev
+PLATFORM ?=
+DOCKER_PLATFORM_FLAG := $(if $(strip $(PLATFORM)),--platform $(PLATFORM),)
 
-.PHONY: install-modules
-install-modules:
-	pnpm install
+.PHONY: help
+help:
+	@printf '%s\n' \
+		'Local HAMi-WebUI development:' \
+		'  make bootstrap              Install locked Node.js dependencies' \
+		'  make dev                    Start the Vite development server' \
+		'  make lint                   Lint Web-entry tooling and Vue sources' \
+		'  make test                   Run Vue unit and contract tests' \
+		'  make build                  Build and pre-compress browser assets' \
+		'  make verify-vite-env        Check the Vite environment boundary' \
+		'  make build-web-entry        Build the production Go Web entry' \
+		'  make verify                 Run all frontend and Web-entry checks' \
+		'  make build-image            Build a local frontend image' \
+		'' \
+		'Use PLATFORM=linux/amd64 (or linux/arm64) for an explicit image platform.'
 
-.PHONY: build-all
-build-all: install-modules build-web
+.PHONY: bootstrap
+bootstrap:
+	$(PNPM) install --frozen-lockfile --config.package-lock=true
 
-.PHONY: build-web
-build-web:
-	pnpm --filter hami-webui-web run build
+.PHONY: dev
+dev:
+	$(PNPM) --filter hami-webui-web run dev
 
-.PHONY: start-dev
-start-dev: install-modules start-web
+.PHONY: lint
+lint:
+	$(PNPM) run lint
+	$(PNPM) --filter hami-webui-web run lint
 
+.PHONY: test
+test:
+	$(PNPM) --filter hami-webui-web run test
 
-.PHONY: start-web
-start-web:
-	pnpm --filter hami-webui-web run start:dev
+.PHONY: build
+build:
+	$(PNPM) --filter hami-webui-web run build
+	$(PNPM) run precompress:web-assets
 
+.PHONY: verify-vite-env
+verify-vite-env:
+	$(PNPM) run verify:vite-env
+
+.PHONY: build-web-entry
+build-web-entry:
+	$(MAKE) -C server build-web-entry
+
+.PHONY: test-web-entry-contract
+test-web-entry-contract:
+	$(PNPM) run test:web-entry-contract
+
+.PHONY: test-web-entry-browser
+test-web-entry-browser:
+	$(PNPM) run test:web-entry-browser
+
+.PHONY: verify
+verify: lint test verify-vite-env build build-web-entry
+	$(MAKE) test-web-entry-contract
+	$(MAKE) test-web-entry-browser
+
+# This target creates one local development image. Stable multi-platform images
+# are published only by .github/workflows/release.yaml.
 .PHONY: build-image
 build-image:
-	docker build --platform linux/amd64 -t ${DOCKER_IMAGE}:${VERSION} .
-
-.PHONY: push-image
-push-image:
-	docker push ${DOCKER_IMAGE}:${VERSION}
-
-.PHONY: release
-release: build-image push-image
+	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) -t $(DOCKER_IMAGE):$(VERSION) .

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -7,9 +7,12 @@ This guide helps you get started developing HAMi-WebUI.
 Make sure you have the following dependencies installed before setting up your developer environment:
 
 - [Git](https://git-scm.com/)
+- Make
 - [Go](https://golang.org/dl/) (use the version in [`server/.go-version`](../../server/.go-version))
 - [Node.js](https://nodejs.org/) (use the version in [`.node-version`](../../.node-version))
 - [pnpm](https://pnpm.io/) (use the version in the root `package.json`)
+- [Protocol Buffers compiler](https://protobuf.dev/installation/) (`protoc`)
+- Docker, only when building local container images
 
 
 ### macOS
@@ -20,6 +23,7 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 brew install git
 brew install go
 brew install node@24
+brew install protobuf
 corepack enable
 ```
 
@@ -31,6 +35,25 @@ We recommend using the Git command-line interface to download the source code fo
 2. Open the `HAMi-WebUI` directory in your favorite code editor.
 
 For alternative ways of cloning the HAMi-WebUI repository, refer to [GitHub's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
+
+## Bootstrap local dependencies
+
+Run dependency installation explicitly once from the repository root. Normal
+build and development commands never update dependencies as a side effect.
+
+```bash
+make bootstrap
+export PATH="$(go env GOPATH)/bin:$PATH"
+make -C server bootstrap
+pnpm exec playwright install chromium
+```
+
+`make bootstrap` uses the committed lockfile and fails instead of rewriting it.
+The server bootstrap installs the pinned Go code generators; `protoc` remains a
+system prerequisite. Re-run the relevant bootstrap command only after its
+dependency or tool versions change. On Linux, use
+`pnpm exec playwright install --with-deps chromium` when Chromium's system
+libraries are not already installed.
 
 ## Build HAMi-WebUI
 
@@ -46,13 +69,17 @@ supported for Chart 1.x rollback.
 
 ### Backend
 
-Build and run the backend by running `make run` in the `server` directory of the repository. This command compiles the Go source code and starts a backend server.
+Generate the API code and start the backend from the repository root:
+
+```bash
+make -C server run
+```
 
 By default, you can access the web-ui-server-swagger at `http://localhost:8000/q/swagger-ui`.
 
 ### Frontend
 
-Start the backend first, then run `make start-dev` in the repository root. This
+Start the backend first, then run `make dev` in the repository root. This
 starts the Vite development server; NestJS is not part of the browser
 development path. Vite forwards browser requests below `/api/vgpu/v1/*`
 directly to the backend at `http://127.0.0.1:8000` and removes the
@@ -63,24 +90,26 @@ By default, you can access the web-ui at `http://localhost:3000/`.
 Set `HAMI_WEBUI_BACKEND_URL` when the backend uses a different origin:
 
 ```bash
-HAMI_WEBUI_BACKEND_URL=http://127.0.0.1:18000 make start-dev
+HAMI_WEBUI_BACKEND_URL=http://127.0.0.1:18000 make dev
 ```
 
-Before opening a frontend pull request, run the supported Vite checks:
+Before opening a pull request, run the checks for the area you changed:
 
 ```bash
-pnpm --filter hami-webui-web run lint
-pnpm --filter hami-webui-web run test
-pnpm run verify:vite-env
+make verify
+make -C server verify
+bash scripts/verify-chart.sh  # when the Helm chart changes
 ```
+
+The root verification target covers Vue lint and tests, the production asset
+build, the Go Web entry, and its HTTP and Chromium contracts. The server target
+generates code before building, vetting, and testing every Go package. CI calls
+the same granular Make targets so local and pull-request behavior stay aligned.
 
 To exercise the production Web entry locally:
 
 ```bash
-pnpm install --frozen-lockfile
-pnpm --filter hami-webui-web run build
-pnpm run precompress:web-assets
-(cd server && mkdir -p build && go build -trimpath -o build/web-entry ./cmd/web-entry)
+make build build-web-entry
 server/build/web-entry --static-dir ./public
 ```
 
@@ -151,21 +180,30 @@ concern.
 
 ## Build a Docker image
 
-To build a HAMi-WebUI Frontend Docker image, run:
+To build a frontend development image for the local Docker platform, run:
 
-```
-make build-image DOCKER_IMAGE=projecthami/hami-webui-fe-oss VERSION=dev
+```bash
+make build-image
 ```
 
-The resulting image will be tagged as `projecthami/hami-webui-fe-oss:dev`. It
+The resulting image is tagged as `hami-webui-frontend:dev`. It
 contains the Go Web entry and built Vue assets, but no production Node.js
 runtime.
 
+Build the backend development image from the repository root:
 
-To build a HAMi-WebUI Backend Docker image, run from the repository root:
-
+```bash
+make -C server build-image
 ```
-make -C server build-image DOCKER_IMAGE=projecthami/hami-webui-be-oss VERSION=dev
+
+The resulting image is tagged as `hami-webui-backend:dev`. Override
+`DOCKER_IMAGE`, `VERSION`, or `PLATFORM` when a local integration environment
+needs a different tag or architecture, for example:
+
+```bash
+make build-image DOCKER_IMAGE=my-registry/hami-webui-frontend VERSION=test PLATFORM=linux/amd64
 ```
 
-The resulting image will be tagged as `projecthami/hami-webui-be-oss:dev`.
+These targets build one local development image and never push it. Stable
+multi-platform images, the Helm chart, release tag, and release notes are
+published only through the [verified release process](../releasing.md).

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -4,26 +4,28 @@ The supported development server is Vite. Start the Go backend first; see the
 [developer guide](../../docs/contribute/developer-guide.md) for the complete
 workflow and backend URL override.
 
+Run the supported commands from the repository root.
+
 ## Project setup
 
-```
-pnpm install
+```bash
+make bootstrap
 ```
 
 ### Compiles and hot-reloads for development
 
-```
-pnpm run start:dev
+```bash
+make dev
 ```
 
 ### Compiles and minifies for production
 
-```
-pnpm run build
+```bash
+make build
 ```
 
-### Lints and fixes files
+### Verify before a pull request
 
-```
-pnpm run lint
+```bash
+make verify
 ```

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,12 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "vite",
-    "start:dev": "vite",
     "lint": "eslint --ext .js,.mjs,.vue build src test vite.config.js",
     "build": "vite build",
     "dev": "vite",
-    "build:vite": "vite build",
     "test": "pnpm run test:dev-proxy && pnpm run test:svg-icons && pnpm run test:echarts-runtime && pnpm run test:metrics && pnpm run test:workload && pnpm run test:ui-contracts",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
     "test:svg-icons": "node --test test/svg-icons-plugin.test.mjs",

--- a/scripts/verify-vite-env-boundary.mjs
+++ b/scripts/verify-vite-env-boundary.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import assert from 'node:assert/strict'
-import { readdir, readFile } from 'node:fs/promises'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -12,8 +13,6 @@ const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..'
 )
-const outputDirectory = path.join(repositoryRoot, 'public')
-
 const inheritedEnvironment = ['CI', 'HOME', 'PATH', 'PNPM_HOME', 'TMPDIR']
 const buildEnvironment = Object.fromEntries(
   inheritedEnvironment
@@ -27,20 +26,6 @@ Object.assign(buildEnvironment, {
   VITE_APP_REQUEST_TIMEOUT: '71234567'
 })
 
-const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-const build = spawnSync(
-  pnpm,
-  ['--filter', 'hami-webui-web', 'run', 'build'],
-  {
-    cwd: repositoryRoot,
-    env: buildEnvironment,
-    stdio: 'inherit'
-  }
-)
-if (build.status !== 0) {
-  throw new Error(`Vite build failed with status ${build.status}`)
-}
-
 const listJavaScriptFiles = async(directory) => {
   const entries = await readdir(directory, { withFileTypes: true })
   const files = await Promise.all(
@@ -53,55 +38,93 @@ const listJavaScriptFiles = async(directory) => {
   return files.flat().filter((file) => file.endsWith('.js'))
 }
 
-const bundles = await Promise.all(
-  (await listJavaScriptFiles(outputDirectory)).map((file) =>
-    readFile(file, 'utf8')
+const verifyBuildEnvironmentBoundary = async() => {
+  const outputDirectory = await mkdtemp(
+    path.join(os.tmpdir(), 'hami-webui-vite-env-')
   )
-)
-const contains = (value) => bundles.some((bundle) => bundle.includes(value))
 
-const forbiddenValues = [
-  'http://private-backend-canary.invalid:8000',
-  'HAMI_WEBUI_UNREFERENCED_CANARY',
-  'hami_webui_canary_should_not_ship',
-  '/vite-env-contract/'
-]
-const bundledForbiddenValue = forbiddenValues.find(contains)
-if (bundledForbiddenValue) {
-  throw new Error(
-    `unreferenced build environment value was bundled: ${bundledForbiddenValue}`
-  )
+  try {
+    const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+    const build = spawnSync(
+      pnpm,
+      [
+        '--filter',
+        'hami-webui-web',
+        'exec',
+        'vite',
+        'build',
+        '--outDir',
+        outputDirectory,
+        '--emptyOutDir'
+      ],
+      {
+        cwd: repositoryRoot,
+        env: buildEnvironment,
+        stdio: 'inherit'
+      }
+    )
+    if (build.status !== 0) {
+      throw new Error(`Vite build failed with status ${build.status}`)
+    }
+
+    const bundles = await Promise.all(
+      (await listJavaScriptFiles(outputDirectory)).map((file) =>
+        readFile(file, 'utf8')
+      )
+    )
+    const contains = (value) => bundles.some((bundle) => bundle.includes(value))
+
+    const forbiddenValues = [
+      'http://private-backend-canary.invalid:8000',
+      'HAMI_WEBUI_UNREFERENCED_CANARY',
+      'hami_webui_canary_should_not_ship',
+      '/vite-env-contract/'
+    ]
+    const bundledForbiddenValue = forbiddenValues.find(contains)
+    if (bundledForbiddenValue) {
+      throw new Error(
+        `unreferenced build environment value was bundled: ${bundledForbiddenValue}`
+      )
+    }
+
+    const requiredValues = ['71234567']
+    const missingRequiredValue = requiredValues.find((value) => !contains(value))
+    if (missingRequiredValue) {
+      throw new Error(
+        `allowlisted Vite value was not bundled: ${missingRequiredValue}`
+      )
+    }
+
+    const builtIndex = await readFile(
+      path.join(outputDirectory, 'index.html'),
+      'utf8'
+    )
+    if (
+      !/<base\b(?=[^>]*\bdata-hami-webui-base\b)(?=[^>]*\bhref="\/")[^>]*>/i.test(
+        builtIndex
+      )
+    ) {
+      throw new Error('built index is missing the runtime base-path marker')
+    }
+    if (
+      !/<link\b(?=[^>]*\brel="icon")(?=[^>]*\bhref="\.\/favicon\.svg")[^>]*>/i.test(
+        builtIndex
+      )
+    ) {
+      throw new Error('built index favicon is not relative to the runtime base path')
+    }
+    if (
+      builtIndex.indexOf('data-hami-webui-base') >
+      builtIndex.indexOf('href="./favicon.svg"')
+    ) {
+      throw new Error('runtime base-path marker must precede relative document URLs')
+    }
+  } finally {
+    await rm(outputDirectory, { force: true, recursive: true })
+  }
 }
 
-const requiredValues = ['71234567']
-const missingRequiredValue = requiredValues.find((value) => !contains(value))
-if (missingRequiredValue) {
-  throw new Error(
-    `allowlisted Vite value was not bundled: ${missingRequiredValue}`
-  )
-}
-
-const builtIndex = await readFile(path.join(outputDirectory, 'index.html'), 'utf8')
-if (
-  !/<base\b(?=[^>]*\bdata-hami-webui-base\b)(?=[^>]*\bhref="\/")[^>]*>/i.test(
-    builtIndex
-  )
-) {
-  throw new Error('built index is missing the runtime base-path marker')
-}
-if (
-  !/<link\b(?=[^>]*\brel="icon")(?=[^>]*\bhref="\.\/favicon\.svg")[^>]*>/i.test(
-    builtIndex
-  )
-) {
-  throw new Error('built index favicon is not relative to the runtime base path')
-}
-if (
-  builtIndex.indexOf('data-hami-webui-base') >
-  builtIndex.indexOf('href="./favicon.svg"')
-) {
-  throw new Error('runtime base-path marker must precede relative document URLs')
-}
+await verifyBuildEnvironmentBoundary()
 
 const basePathCases = [
   [undefined, '/'],

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,8 +1,13 @@
-DOCKER_IMAGE ?= projecthami/hami-webui-be
+.DEFAULT_GOAL := help
+
+DOCKER ?= docker
+DOCKER_IMAGE ?= hami-webui-backend
 CMD_PATH ?= ./cmd/
 BUILD_PATH ?= ./build/
-VERSION ?= $(shell git describe --tags --always)
-DIRS = $(shell ls $(CMD_PATH))
+VERSION ?= dev
+PLATFORM ?=
+DOCKER_PLATFORM_FLAG := $(if $(strip $(PLATFORM)),--platform $(PLATFORM),)
+DIRS ?= $(notdir $(patsubst %/,%,$(sort $(dir $(wildcard $(CMD_PATH)*/main.go)))))
 WIRE_DIRS = $(patsubst $(CMD_PATH)%/wire.go,%,$(wildcard $(CMD_PATH)*/wire.go))
 TARGET_ARCH ?= amd64
 WIRE_VERSION ?= v0.7.0
@@ -15,14 +20,37 @@ PROTOC_GEN_GO_ERRORS_VERSION ?= v2.0.0-20240322155018-41971ffa647a
 PROTOC_GEN_OPENAPI_VERSION ?= v0.6.9
 PROTO_TOOLS = \
 	protoc \
+	wire \
 	kratos \
+	protoc-gen-validate \
 	protoc-gen-go \
 	protoc-gen-go-grpc \
 	protoc-gen-go-http \
 	protoc-gen-go-errors \
 	protoc-gen-openapi
 
-# 1. Install Go dependencies
+.PHONY: help
+help:
+	@printf '%s\n' \
+		'Local HAMi-WebUI backend development:' \
+		'  make bootstrap        Install pinned Go code generators' \
+		'  make run              Generate code and start the backend' \
+		'  make test             Generate code and run all Go tests' \
+		'  make vet              Generate code and run go vet' \
+		'  make verify           Generate, build, vet, and test all Go packages' \
+		'  make build            Generate and build Linux commands for TARGET_ARCH' \
+		'  make build-local      Generate and build commands for the host platform' \
+		'  make build-web-entry  Build only the production Web entry' \
+		'  make build-image      Build a local backend image' \
+		'' \
+		'Install protoc separately before bootstrap; use PLATFORM for Docker builds.'
+
+.PHONY: bootstrap
+bootstrap:
+	$(MAKE) install-deps
+	$(MAKE) check-proto-tools
+
+# protoc is an external prerequisite; install the pinned Go generators.
 .PHONY: install-deps
 install-deps:
 	go install github.com/google/wire/cmd/wire@$(WIRE_VERSION)
@@ -34,7 +62,6 @@ install-deps:
 	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2@$(PROTOC_GEN_GO_ERRORS_VERSION)
 	go install github.com/google/gnostic/cmd/protoc-gen-openapi@$(PROTOC_GEN_OPENAPI_VERSION)
 
-# 2. Generate proto and wire files
 .PHONY: generate
 generate: generate-proto generate-wire
 
@@ -46,7 +73,7 @@ check-proto-tools:
 		if ! command -v "$$tool" >/dev/null 2>&1; then missing="$$missing $$tool"; fi; \
 	done; \
 	if [ -n "$$missing" ]; then \
-		echo "missing required protobuf tools:$$missing; install them before generating code (Go tools: 'make install-deps')" >&2; \
+		echo "missing required protobuf tools:$$missing; install protoc, run 'make install-deps', and ensure the Go bin directory is on PATH" >&2; \
 		exit 1; \
 	fi
 
@@ -56,9 +83,9 @@ generate-proto: check-proto-tools
 
 .PHONY: generate-wire
 generate-wire:
-	@ for dir in $(WIRE_DIRS); \
+	@set -eu; for dir in $(WIRE_DIRS); \
 	do \
-		cd ${CMD_PATH}$$dir/ && wire . && cd ../../; \
+		(cd "$(CMD_PATH)$$dir" && wire .); \
 	done
 
 # Verify module metadata without changing it. Release builds must not repair
@@ -67,68 +94,74 @@ generate-wire:
 verify-mod:
 	go mod tidy -diff
 
-# 3. Clean Go modules
 .PHONY: tidy-mod
 tidy-mod:
 	go mod tidy
 
-# 4. Build-related commands
 .PHONY: build-linux
 build-linux:
-	@echo "Building for GOOS=linux GOARCH=$(TARGET_ARCH)" # TARGET_ARCH 会从 make 命令传入
+	@mkdir -p "$(BUILD_PATH)"
+	@echo "Building for GOOS=linux GOARCH=$(TARGET_ARCH)"
 	@set -e; for dir in $(DIRS); \
 	do \
-		CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build -o $(BUILD_PATH)$$dir ${CMD_PATH}$$dir; \
+		CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) go build -mod=readonly -trimpath -o "$(BUILD_PATH)$$dir" "$(CMD_PATH)$$dir"; \
 		echo "Built $$dir for Linux/$(TARGET_ARCH)"; \
 	done
 
 .PHONY: build-local
-build-local:
-	@ for dir in $(DIRS); \
+build-local: generate
+	$(MAKE) verify-mod
+	@mkdir -p "$(BUILD_PATH)"
+	@set -e; for dir in $(DIRS); \
 	do \
-		go build -o $(BUILD_PATH)$$dir ${CMD_PATH}$$dir; \
+		go build -mod=readonly -trimpath -o "$(BUILD_PATH)$$dir" "$(CMD_PATH)$$dir"; \
 		echo "Built $$dir"; \
 	done
 
-# 5. Docker image commands
+.PHONY: build-web-entry
+build-web-entry:
+	@mkdir -p "$(BUILD_PATH)"
+	go build -mod=readonly -trimpath -o "$(BUILD_PATH)web-entry" ./cmd/web-entry
+
+# This target creates one local development image. Stable multi-platform images
+# are published only by ../.github/workflows/release.yaml.
 .PHONY: build-image
 build-image:
-	docker build --platform linux/amd64 -t ${DOCKER_IMAGE}:${VERSION} .
-
-.PHONY: push-image
-push-image:
-	docker push ${DOCKER_IMAGE}:${VERSION}
+	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) -t $(DOCKER_IMAGE):$(VERSION) .
 
 .PHONY: save-image
 save-image:
-	docker save -o $(BUILD_PATH)hami_webui_release_${VERSION}.tar ${DOCKER_IMAGE}:${VERSION}
-	gzip -f $(BUILD_PATH)hami_webui_release_${VERSION}.tar
+	@mkdir -p "$(BUILD_PATH)"
+	$(DOCKER) save -o "$(BUILD_PATH)hami_webui_release_$(VERSION).tar" $(DOCKER_IMAGE):$(VERSION)
+	gzip -f "$(BUILD_PATH)hami_webui_release_$(VERSION).tar"
 
-# 6. Debugging and Testing
 .PHONY: run
-run: install-deps generate run-debug
-
-.PHONY: run-debug
-run-debug:
+run: generate
+	$(MAKE) verify-mod
 	kratos run
 
-.PHONY: run-tests
-run-tests:
-	go test .
+.PHONY: test
+test: generate
+	$(MAKE) verify-mod
+	go test -mod=readonly ./...
 
-.PHONY: run-vet
-run-vet:
-	go vet ./...
+.PHONY: vet
+vet: generate
+	$(MAKE) verify-mod
+	go vet -mod=readonly ./...
 
-# 7. Cleaning
-.PHONY: clean-build
-clean-build:
+.PHONY: verify
+verify: generate
+	$(MAKE) verify-mod
+	go build -mod=readonly ./...
+	go vet -mod=readonly ./...
+	go test -mod=readonly ./...
+
+.PHONY: clean
+clean:
 	rm -rf $(BUILD_PATH)
 
-# 8. Complete build workflow
 .PHONY: build
-build: install-deps generate verify-mod build-linux
-
-# 9. Release workflow
-.PHONY: release
-release: build-image push-image
+build: generate
+	$(MAKE) verify-mod
+	$(MAKE) build-linux


### PR DESCRIPTION
/kind cleanup

Local workflows had implicit non-frozen installs, stale image defaults, duplicated CI commands, and Makefile release targets that pushed one image outside the verified release controller. The backend test wrapper also ran only `go test .`.

This makes dependency installation explicit and locked, gives frontend/Web-entry and backend verification one local/CI command path, builds local host-platform images by default, and removes the shadow push/release targets. Stable publication remains exclusively in Verified Stable Release.

Verification:

- `make verify`
- `make -C server verify`
- Actionlint on both changed workflows
- Frontend and backend local image builds
- Canonical Web asset hash unchanged by Vite environment-boundary verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Added unified Make-based commands for setup, development, linting, testing, building, and verification.
  * Added configurable Docker image, version, and platform settings.
  * Added consolidated checks for frontend, backend, contract, and browser testing.

* **Documentation**
  * Updated contribution and developer guides with the new setup, development, verification, and Docker workflows.
  * Updated web project instructions to use repository-level commands.

* **Bug Fixes**
  * Improved build-environment validation with isolated temporary output and automatic cleanup.
  * Added checks for required runtime paths, favicon configuration, and restricted environment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->