### PR TITLE
fix(web): respect browser language defaults

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,10 +6,11 @@
     "lint": "eslint --ext .js,.mjs,.vue build src test vite.config.js",
     "build": "vite build",
     "dev": "vite",
-    "test": "pnpm run test:dev-proxy && pnpm run test:svg-icons && pnpm run test:echarts-runtime && pnpm run test:metrics && pnpm run test:workload && pnpm run test:ui-contracts",
+    "test": "pnpm run test:dev-proxy && pnpm run test:svg-icons && pnpm run test:echarts-runtime && pnpm run test:i18n && pnpm run test:metrics && pnpm run test:workload && pnpm run test:ui-contracts",
     "test:dev-proxy": "node --test test/vite-dev-proxy.contract.test.mjs",
     "test:svg-icons": "node --test test/svg-icons-plugin.test.mjs",
     "test:echarts-runtime": "node --test test/echarts-runtime.test.mjs",
+    "test:i18n": "node --test test/locale-resolution.test.mjs",
     "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/detail-resource-state.test.mjs projects/vgpu/hooks/use-detail-resource.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/monitor/overview/workload-distribution.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs",
     "test:ui-contracts": "node --test projects/vgpu/views/card/admin/node-detail-location.test.mjs"

--- a/packages/web/projects/vgpu/views/task/admin/top.vue
+++ b/packages/web/projects/vgpu/views/task/admin/top.vue
@@ -94,7 +94,7 @@ const topConfig = computed(() => [
         key: 'vgpu',
         data: [],
         nameKey: 'container_pod_uuid',
-        unit: '个',
+        unit: t('dashboard.vgpuSlotUnit'),
         query: 'topk(5, avg by (container_pod_uuid) (hami_container_vgpu_allocated))',
       },
     ],

--- a/packages/web/src/locales/index.js
+++ b/packages/web/src/locales/index.js
@@ -2,31 +2,24 @@ import { createI18n } from 'vue-i18n';
 import Cookies from 'js-cookie';
 import enLocale from './en';
 import zhLocale from './zh';
+import { resolveLanguage } from './language.mjs';
 
-// 定义语言 Key
 export const LANG_KEY = 'language';
 
-// 获取当前语言
 export const getLanguage = () => {
-  const chooseLanguage = Cookies.get(LANG_KEY);
-  if (chooseLanguage) return chooseLanguage;
+  const browserLanguage =
+    typeof navigator === 'undefined'
+      ? undefined
+      : navigator.language || navigator.browserLanguage;
 
-  // 如果没有选择过，自动检测浏览器语言
-  const language = (navigator.language || navigator.browserLanguage).toLowerCase();
-  const locales = [enLocale, zhLocale];
-  for (const locale of locales) {
-    if (language.indexOf(locale) > -1) {
-      return locale;
-    }
-  }
-  return 'zh'; // 默认中文
+  return resolveLanguage(Cookies.get(LANG_KEY), browserLanguage);
 };
 
 const i18n = createI18n({
-  legacy: false, // 使用 Composition API
+  legacy: false,
   locale: getLanguage(),
   fallbackLocale: 'en',
-  globalInjection: true, // 全局注入 $t
+  globalInjection: true,
   messages: {
     en: enLocale,
     zh: zhLocale,

--- a/packages/web/src/locales/language.mjs
+++ b/packages/web/src/locales/language.mjs
@@ -1,0 +1,12 @@
+export const SUPPORTED_LANGUAGES = Object.freeze(['en', 'zh']);
+
+const normalizeLanguage = (language) =>
+  typeof language === 'string' ? language.trim().toLowerCase() : '';
+
+export function resolveLanguage(preferredLanguage, browserLanguage) {
+  const preferred = normalizeLanguage(preferredLanguage);
+  if (SUPPORTED_LANGUAGES.includes(preferred)) return preferred;
+
+  const browser = normalizeLanguage(browserLanguage).replaceAll('_', '-');
+  return browser === 'zh' || browser.startsWith('zh-') ? 'zh' : 'en';
+}

--- a/packages/web/src/views/error-page/401.vue
+++ b/packages/web/src/views/error-page/401.vue
@@ -6,7 +6,6 @@
     <el-row>
       <el-col :span="12">
         <h1 class="text-jumbo text-ginormous">{{ $t('error.401.oops') }}</h1>
-        gif来源<a href="https://zh.airbnb.com/" target="_blank">airbnb</a> 页面
         <h2>{{ $t('error.401.noPermission') }}</h2>
         <h6>{{ $t('error.401.contactLeader') }}</h6>
         <ul class="list-unstyled">

--- a/packages/web/test/locale-resolution.test.mjs
+++ b/packages/web/test/locale-resolution.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveLanguage } from '../src/locales/language.mjs';
+
+test('a supported saved preference overrides the browser language', () => {
+  assert.equal(resolveLanguage('en', 'zh-CN'), 'en');
+  assert.equal(resolveLanguage('zh', 'en-US'), 'zh');
+});
+
+test('Chinese browser locales resolve to Chinese', () => {
+  assert.equal(resolveLanguage(undefined, 'zh'), 'zh');
+  assert.equal(resolveLanguage(undefined, 'zh-CN'), 'zh');
+  assert.equal(resolveLanguage(undefined, 'zh_TW'), 'zh');
+});
+
+test('other browser locales use the English fallback', () => {
+  assert.equal(resolveLanguage(undefined, 'en-US'), 'en');
+  assert.equal(resolveLanguage(undefined, 'ja-JP'), 'en');
+  assert.equal(resolveLanguage(undefined, undefined), 'en');
+});
+
+test('an invalid saved preference does not become an application locale', () => {
+  assert.equal(resolveLanguage('fr', 'zh-CN'), 'zh');
+  assert.equal(resolveLanguage('zh-CN', 'en-US'), 'en');
+});

--- a/test/web-entry/web-entry.browser.test.mjs
+++ b/test/web-entry/web-entry.browser.test.mjs
@@ -677,6 +677,36 @@ test('runtime base path and framing policy work in Chromium', async(t) => {
   })
 }, { timeout: 120_000 })
 
+test('browser language selects English without leaking active Chinese UI text', async() => {
+  const target = await startWebEntry({ frameAncestors: undefined })
+  const page = await browser.newPage({ locale: 'en-US' })
+
+  try {
+    await page.goto(
+      `${target}${basePath}admin/vgpu/task/admin`,
+      { waitUntil: 'domcontentloaded' }
+    )
+    await page.locator('.lang-text').filter({ hasText: 'English' }).waitFor()
+
+    const requestsCard = page.locator('.task-top-box .home-block').nth(1)
+    await requestsCard.locator('.title')
+      .filter({ hasText: 'Workload Requests Top5' })
+      .waitFor()
+    await requestsCard.locator('.t-radio-button')
+      .filter({ hasText: 'vGPU' })
+      .click()
+    const value = requestsCard.locator('.tab-top-value').first()
+    await value.waitFor()
+    assert.equal((await value.textContent()).trim(), '0.4 slots')
+
+    await page.goto(`${target}${basePath}401`, { waitUntil: 'domcontentloaded' })
+    await page.getByText('You do not have permission to access this page').waitFor()
+    assert.equal((await page.locator('body').textContent()).includes('gif来源'), false)
+  } finally {
+    await page.close()
+  }
+}, { timeout: 60_000 })
+
 test('detail pages expose truthful asynchronous resource states', async(t) => {
   const target = await startWebEntry({ frameAncestors: undefined })
 


### PR DESCRIPTION
This fixes the Web locale contract without mixing in the broader source-comment cleanup tracked in #211.

- resolve only supported saved locales
- map `zh-*` browser locales to Chinese and default other locales to English
- replace the visible vGPU count suffix with the localized slot unit
- remove legacy Chinese copy from the 401 page
- cover locale resolution with unit tests and the English path in Chromium

Verification: `make verify` (including 14/14 Chromium tests).

Part of #211.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved language selection for saved preferences and browser locales, including Chinese locale variants.
  - Added English localization for vGPU slot units and verified translated dashboard content.

- **Bug Fixes**
  - Prevented browser-language detection issues in non-browser environments.
  - Removed unintended source attribution text from the unauthorized-access page.

- **Tests**
  - Expanded automated coverage for language resolution, English localization, dashboard labels, and unauthorized-access messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->