### PR TITLE
chore(api): use English operation summaries

### DIFF
--- a/server/api/v1/card.proto
+++ b/server/api/v1/card.proto
@@ -14,7 +14,7 @@ service Card {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "显卡列表";
+      summary: "List accelerators";
     };
   }
 
@@ -24,7 +24,7 @@ service Card {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "显卡类型";
+      summary: "List accelerator types";
     };
   }
 
@@ -33,7 +33,7 @@ service Card {
       get: "/v1/gpu"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "显卡详情";
+      summary: "Get accelerator details";
     };
   }
 }

--- a/server/api/v1/container.proto
+++ b/server/api/v1/container.proto
@@ -14,7 +14,7 @@ service Container {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "任务列表";
+      summary: "List workloads";
     };
   }
   rpc GetContainer (GetContainerReq) returns (ContainerReply) {
@@ -22,7 +22,7 @@ service Container {
       get: "/v1/container"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "任务详情";
+      summary: "Get workload details";
     };
   }
 }

--- a/server/api/v1/metadata_test.go
+++ b/server/api/v1/metadata_test.go
@@ -1,0 +1,68 @@
+package v1
+
+import (
+	"testing"
+
+	openapiv2 "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestPublicOperationSummaries(t *testing.T) {
+	want := map[protoreflect.FullName]string{
+		"api.v1.Card.GetAllGPUs":            "List accelerators",
+		"api.v1.Card.GetAllGPUTypes":        "List accelerator types",
+		"api.v1.Card.GetGPU":                "Get accelerator details",
+		"api.v1.Container.GetAllContainers": "List workloads",
+		"api.v1.Container.GetContainer":     "Get workload details",
+		"api.v1.Node.GetSummary":            "Get cluster resource summary",
+		"api.v1.Node.GetAllNodes":           "List nodes",
+		"api.v1.Node.GetNode":               "Get node details",
+		"api.v1.Monitor.QueryRange":         "Query range vector",
+		"api.v1.Monitor.QueryInstant":       "Query instant vector",
+		"api.v1.Monitor.Summary":            "Get resource usage summary",
+	}
+
+	files := []protoreflect.FileDescriptor{
+		File_api_v1_card_proto,
+		File_api_v1_container_proto,
+		File_api_v1_node_proto,
+		File_api_v1_monitor_proto,
+	}
+
+	for _, file := range files {
+		services := file.Services()
+		for serviceIndex := 0; serviceIndex < services.Len(); serviceIndex++ {
+			methods := services.Get(serviceIndex).Methods()
+			for methodIndex := 0; methodIndex < methods.Len(); methodIndex++ {
+				method := methods.Get(methodIndex)
+				wantSummary, ok := want[method.FullName()]
+				if !ok {
+					continue
+				}
+				if got := openAPISummary(t, method); got != wantSummary {
+					t.Errorf("%s summary = %q, want %q", method.FullName(), got, wantSummary)
+				}
+				delete(want, method.FullName())
+			}
+		}
+	}
+
+	for method, summary := range want {
+		t.Errorf("operation %s with summary %q was not generated", method, summary)
+	}
+}
+
+func openAPISummary(t *testing.T, method protoreflect.MethodDescriptor) string {
+	t.Helper()
+	options, ok := method.Options().(*descriptorpb.MethodOptions)
+	if !ok || !proto.HasExtension(options, openapiv2.E_Openapiv2Operation) {
+		t.Fatalf("%s has no OpenAPI operation metadata", method.FullName())
+	}
+	operation, ok := proto.GetExtension(options, openapiv2.E_Openapiv2Operation).(*openapiv2.Operation)
+	if !ok {
+		t.Fatalf("%s has invalid OpenAPI operation metadata", method.FullName())
+	}
+	return operation.GetSummary()
+}

--- a/server/api/v1/monitor.proto
+++ b/server/api/v1/monitor.proto
@@ -14,7 +14,7 @@ service Monitor {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "查询区间向量"
+      summary: "Query range vector"
     };
   }
 
@@ -24,7 +24,7 @@ service Monitor {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "查询瞬时向量"
+      summary: "Query instant vector"
     };
   }
 
@@ -34,7 +34,7 @@ service Monitor {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "资源使用情况概览"
+      summary: "Get resource usage summary"
     };
   }
 }

--- a/server/api/v1/node.proto
+++ b/server/api/v1/node.proto
@@ -14,7 +14,7 @@ service Node {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "首页统计";
+      summary: "Get cluster resource summary";
     };
   }
 
@@ -24,7 +24,7 @@ service Node {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "节点列表";
+      summary: "List nodes";
     };
   }
 
@@ -33,7 +33,7 @@ service Node {
       get: "/v1/node"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "节点详情";
+      summary: "Get node details";
     };
   }
 }


### PR DESCRIPTION
The runtime Swagger UI is generated from protobuf descriptors, so the existing Chinese operation summaries leak into a public API contract.

This replaces all 11 summaries with concise English text and adds a descriptor-level test that verifies exactly what the runtime Swagger handler reads. `server/openapi.yaml` is not changed because it is not used by the runtime.

Verification: `make -C server verify`.

Part of #211.
