### PR TITLE
fix(metrics): remove localized driver placeholders

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -761,10 +761,8 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 			info.DriverVersion = metric["driver"]
 			info.DeviceNo = metric["sn"]
 		case biz.AscendGPUDevice:
-			info.DriverVersion = "暂无"
 			info.DeviceNo = "ascend-" + metric["id"]
 		case biz.HygonGPUDevice:
-			info.DriverVersion = "暂无"
 			info.DeviceNo = "dcu-" + metric["minor_number"]
 		case biz.MetaxGPUDevice:
 			info.DriverVersion = metric["driver_version"]

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -197,6 +197,54 @@ func TestDeviceMemoryQueriesConvertVendorUnitsToMiB(t *testing.T) {
 	}
 }
 
+func TestDeviceAdditionalInfoKeepsUnknownDriverVersionEmpty(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		metric       map[string]string
+		wantQuery    string
+		wantDeviceNo string
+	}{
+		{
+			name:         "Ascend",
+			provider:     biz.AscendGPUDevice,
+			metric:       map[string]string{"id": "7"},
+			wantQuery:    `npu_chip_info_power{vdie_id="device-1"}`,
+			wantDeviceNo: "ascend-7",
+		},
+		{
+			name:         "Hygon",
+			provider:     biz.HygonGPUDevice,
+			metric:       map[string]string{"minor_number": "3"},
+			wantQuery:    `dcu_power_usage{device_id="device-1"}`,
+			wantDeviceNo: "dcu-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			querier := &fakeInstantQuerier{responses: []*pb.InstantResponse{{
+				Data: []*pb.Sample{{Metric: tt.metric}},
+			}}}
+			generator := &MetricsGenerator{monitorService: querier}
+
+			info, err := generator.queryDeviceAdditional(context.Background(), tt.provider, "device-1")
+			if err != nil {
+				t.Fatalf("queryDeviceAdditional() error = %v", err)
+			}
+			if len(querier.queries) != 1 || querier.queries[0] != tt.wantQuery {
+				t.Fatalf("queries = %q, want [%q]", querier.queries, tt.wantQuery)
+			}
+			if info.DriverVersion != "" {
+				t.Fatalf("driver version = %q, want empty", info.DriverVersion)
+			}
+			if info.DeviceNo != tt.wantDeviceNo {
+				t.Fatalf("device number = %q, want %q", info.DeviceNo, tt.wantDeviceNo)
+			}
+		})
+	}
+}
+
 func TestGenerateDeviceMetricsSeparatesPhysicalAndSchedulableMemory(t *testing.T) {
 	const (
 		deviceID      = "GPU-physical-contract"


### PR DESCRIPTION
Ascend and Hygon telemetry does not currently provide a driver version, but the exporter writes the Chinese UI placeholder `暂无` into the public `driver_version` Prometheus label.

This keeps an unknown driver version empty, matching the existing behavior for failed lookups and missing vendor labels. Device numbers are unchanged and covered by provider-specific tests.

Compatibility note: this changes the series identity from `driver_version="暂无"` to `driver_version=""`. Existing series will become stale normally; external queries that explicitly match the old Chinese value must remove that filter or match the empty value.

Verification: `make -C server verify`.

Part of #211.
