### PR TITLE
chore(web): normalize private package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "hami-webui",
-  "version": "0.0.1",
   "description": "",
   "author": "",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=24.0.0 <25"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hami-webui-web",
-  "version": "0.1.0",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "lint": "eslint --ext .js,.mjs,.vue build src test vite.config.js",
     "build": "vite build",


### PR DESCRIPTION
## What

- remove stale `0.0.1` / `0.1.0` versions from the two private pnpm workspaces
- align their package metadata with the repository's Apache-2.0 license

## Why

Those versions came from the initial scaffold and only appeared in pnpm lifecycle banners. They have never participated in HAMi-WebUI releases, whose stable identity is enforced through the Helm Chart, Git tag, image tags and digests.

Keeping the private workspace versions synchronized would add redundant release-version sources. npm permits unpublished private packages to omit `version`, so removing the fields makes that boundary explicit.

## Verification

- `pnpm install --frozen-lockfile` (lockfile unchanged)
- `make verify`
