### PR TITLE
fix: secure external Prometheus TLS

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -53,8 +53,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | dcgm-exporter.serviceMonitor.enabled | bool | `true`                                                                             |  |
 | dcgm-exporter.serviceMonitor.honorLabels | bool | `false`                                                                            |  |
 | dcgm-exporter.serviceMonitor.interval | string | `"15s"`                                                                            |  |
-| externalPrometheus.address | string | `"http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"` |  |
-| externalPrometheus.enabled | bool | `false`                                                                            |  |
+| externalPrometheus.address | string | `"http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"` | Prometheus or VictoriaMetrics HTTP API address. |
+| externalPrometheus.enabled | bool | `false`                                                                            | Use an existing metrics backend instead of the bundled address. |
+| externalPrometheus.timeout | string | `"1m"` | Timeout sent with each upstream PromQL request. |
+| externalPrometheus.tls.insecureSkipVerify | bool | `false` | Disable HTTPS certificate verification. Use only as a temporary break-glass setting. |
+| externalPrometheus.tls.serverName | string | `""` | Optional certificate name override for the HTTPS endpoint. |
+| externalPrometheus.tls.existingSecret | string | `""` | Existing Secret containing private-CA or mTLS files. The Chart never creates this Secret. |
+| externalPrometheus.tls.caKey | string | `""` | Secret data key containing the CA certificate. |
+| externalPrometheus.tls.certKey | string | `""` | Secret data key containing the client certificate; configure with `keyKey`. |
+| externalPrometheus.tls.keyKey | string | `""` | Secret data key containing the client private key; configure with `certKey`. |
 | frontend.basePath | string | `"/"` | Public URL prefix served by the official Go Web entry; use the same non-stripped Ingress path. |
 | frontend.frameAncestors | list or null | `null` | CSP framing allowlist. `null` preserves existing behavior, `[]` blocks framing, and a list allows explicit parents. |
 | frontend.livenessProbe.enabled | bool | `true` | Enable the Web-entry liveness probe. |
@@ -160,6 +167,22 @@ externalPrometheus:
 ```
 
 Here, replace <your-prometheus-address> with the actual domain or internal Ingress address for your Prometheus instance.
+
+HTTPS certificates are verified by default. For an endpoint signed by a private
+CA, create a Secret and reference its data key instead of placing PEM material
+in values:
+
+```yaml
+externalPrometheus:
+  enabled: true
+  address: "https://prometheus.example.com"
+  tls:
+    existingSecret: "prometheus-ca"
+    caKey: "ca.crt"
+```
+
+See the [installation guide](../../docs/installation/helm/index.md#https-external-prometheus)
+for Secret creation, mTLS, and the upgrade boundary.
 
 #### Scenario 2: If no Prometheus or Operator is installed in the cluster
 

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -85,6 +85,48 @@ dependency chart's own helpers so its naming and override rules cannot drift.
 {{- end -}}
 
 {{/*
+Validate the HTTPS trust material used by an external Prometheus endpoint.
+Secret values are mounted as files; only their key names appear in rendered
+configuration.
+*/}}
+{{- define "hami-webui.validatePrometheusTLS" -}}
+{{- $external := default (dict) .Values.externalPrometheus -}}
+{{- $rawTLS := get $external "tls" -}}
+{{- if and $rawTLS (not (kindIs "map" $rawTLS)) -}}
+{{- fail "externalPrometheus.tls must be a map" -}}
+{{- end -}}
+{{- $tls := default (dict) $rawTLS -}}
+{{- range $field := list "serverName" "existingSecret" "caKey" "certKey" "keyKey" -}}
+{{- if and (hasKey $tls $field) (not (kindIs "string" (get $tls $field))) -}}
+{{- fail (printf "externalPrometheus.tls.%s must be a string" $field) -}}
+{{- end -}}
+{{- end -}}
+{{- if and (hasKey $tls "insecureSkipVerify") (not (kindIs "bool" (get $tls "insecureSkipVerify"))) -}}
+{{- fail "externalPrometheus.tls.insecureSkipVerify must be a boolean" -}}
+{{- end -}}
+{{- $secretName := default "" (get $tls "existingSecret") -}}
+{{- $caKey := default "" (get $tls "caKey") -}}
+{{- $certKey := default "" (get $tls "certKey") -}}
+{{- $keyKey := default "" (get $tls "keyKey") -}}
+{{- if .Values.externalPrometheus.enabled -}}
+{{- if ne (empty $certKey) (empty $keyKey) -}}
+{{- fail "externalPrometheus.tls.certKey and keyKey must be configured together" -}}
+{{- end -}}
+{{- if and (empty $secretName) (or $caKey $certKey $keyKey) -}}
+{{- fail "externalPrometheus.tls.existingSecret is required when a TLS key is configured" -}}
+{{- end -}}
+{{- if and $secretName (not (or $caKey $certKey $keyKey)) -}}
+{{- fail "externalPrometheus.tls must reference at least one key from existingSecret" -}}
+{{- end -}}
+{{- range $key := list $caKey $certKey $keyKey -}}
+{{- if and $key (not (regexMatch "^[A-Za-z0-9._-]+$" $key)) -}}
+{{- fail (printf "externalPrometheus TLS Secret key %q is invalid" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "hami-webui.chart" -}}

--- a/charts/hami-webui/templates/configmap.yaml
+++ b/charts/hami-webui/templates/configmap.yaml
@@ -1,3 +1,9 @@
+{{- include "hami-webui.validatePrometheusTLS" . -}}
+{{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
+{{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
+{{- $prometheusTLSSecret := default "" (get $prometheusTLS "existingSecret") -}}
+{{- $prometheusCAKey := default "" (get $prometheusTLS "caKey") -}}
+{{- $prometheusCertKey := default "" (get $prometheusTLS "certKey") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,6 +21,20 @@ data:
     prometheus:
       address: {{ include "hami-webui.prometheusAddress" . }}
       timeout: {{ .Values.externalPrometheus.timeout | default "1m" }}
+      {{- if (get $externalPrometheus "enabled") }}
+      tls:
+        insecure_skip_verify: {{ default false (get $prometheusTLS "insecureSkipVerify") }}
+        {{- with (get $prometheusTLS "serverName") }}
+        server_name: {{ . | quote }}
+        {{- end }}
+        {{- if and (get $externalPrometheus "enabled") $prometheusTLSSecret $prometheusCAKey }}
+        ca_file: "/apps/prometheus-tls/ca.crt"
+        {{- end }}
+        {{- if and (get $externalPrometheus "enabled") $prometheusTLSSecret $prometheusCertKey }}
+        cert_file: "/apps/prometheus-tls/tls.crt"
+        key_file: "/apps/prometheus-tls/tls.key"
+        {{- end }}
+      {{- end }}
     exporter:
       interval: {{ .Values.metricsExporter.interval | default "30s" }}
       timeout:  {{ .Values.metricsExporter.timeout  | default "60s" }}

--- a/charts/hami-webui/templates/deployment.yaml
+++ b/charts/hami-webui/templates/deployment.yaml
@@ -1,6 +1,11 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.podAnnotations) (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)) -}}
 {{- $frontendEnv := default (list) .Values.env.frontend -}}
 {{- $frontendSettings := default (dict) .Values.frontend -}}
+{{- include "hami-webui.validatePrometheusTLS" . -}}
+{{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
+{{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
+{{- $prometheusTLSSecret := default "" (get $prometheusTLS "existingSecret") -}}
+{{- $mountPrometheusTLS := and (get $externalPrometheus "enabled") (ne $prometheusTLSSecret "") -}}
 {{- $frontendProxyTimeoutOverridden := false -}}
 {{- $frontendBasePathOverridden := false -}}
 {{- $frontendFrameAncestorsOverridden := false -}}
@@ -146,6 +151,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /apps/config/
+            {{- if $mountPrometheusTLS }}
+            - name: prometheus-tls
+              mountPath: /apps/prometheus-tls/
+              readOnly: true
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -162,3 +172,21 @@ spec:
         - name: config
           configMap:
             name: {{ include "hami-webui.fullname" . }}-config
+        {{- if $mountPrometheusTLS }}
+        - name: prometheus-tls
+          secret:
+            secretName: {{ $prometheusTLSSecret | quote }}
+            items:
+              {{- with (get $prometheusTLS "caKey") }}
+              - key: {{ . | quote }}
+                path: ca.crt
+              {{- end }}
+              {{- with (get $prometheusTLS "certKey") }}
+              - key: {{ . | quote }}
+                path: tls.crt
+              {{- end }}
+              {{- with (get $prometheusTLS "keyKey") }}
+              - key: {{ . | quote }}
+                path: tls.key
+              {{- end }}
+        {{- end }}

--- a/charts/hami-webui/values.schema.json
+++ b/charts/hami-webui/values.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "externalPrometheus": {
+      "type": "object",
+      "properties": {
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "insecureSkipVerify": {
+              "type": "boolean"
+            },
+            "serverName": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "caKey": {
+              "type": "string"
+            },
+            "certKey": {
+              "type": "string"
+            },
+            "keyKey": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -182,6 +182,18 @@ externalPrometheus:
   address: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"
   # Single PromQL upstream timeout (sent to Prometheus / VictoriaMetrics as the &timeout= parameter).
   timeout: "1m"
+  tls:
+    # HTTPS certificates are verified by default. Use this only as a temporary
+    # escape hatch when a CA cannot yet be supplied.
+    insecureSkipVerify: false
+    # Optional certificate name override for HTTPS endpoints.
+    serverName: ""
+    # Mount trust material from an existing Secret. Set caKey for a private CA;
+    # set certKey and keyKey together when the endpoint requires mTLS.
+    existingSecret: ""
+    caKey: ""
+    certKey: ""
+    keyKey: ""
 
 # Web-entry runtime settings and health probes. The probes report the frontend
 # container's own health; backend readiness is gated separately below.

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -59,6 +59,44 @@ To set up the HAMi-WebUI Helm repository so that you download the correct HAMi-W
 
    You should get the expected both 'hami-webui' and 'hami-webui-dcgm-exporter' in running state if installation is successful.
 
+### HTTPS external Prometheus
+
+HAMi-WebUI verifies HTTPS certificates with the container's system trust store
+by default. No TLS values are required for a publicly trusted endpoint.
+
+For a private CA, create a Secret in the HAMi-WebUI namespace and reference its
+data key:
+
+```bash
+kubectl create secret generic hami-webui-prometheus-tls \
+  --namespace kube-system \
+  --from-file=ca.crt=/path/to/prometheus-ca.crt
+```
+
+```yaml
+externalPrometheus:
+  enabled: true
+  address: "https://prometheus.example.com"
+  tls:
+    existingSecret: hami-webui-prometheus-tls
+    caKey: ca.crt
+```
+
+When Prometheus requires mutual TLS, add the client certificate and key to the
+same Secret and configure `certKey` and `keyKey` together. `serverName` is
+available when certificate verification must use a name different from the URL
+host. Secret contents are mounted only into the backend container; they are not
+copied into the rendered ConfigMap.
+
+`insecureSkipVerify: true` remains available only as an explicit temporary
+escape hatch. It disables certificate-chain and host-name verification and
+should not replace configuring the correct CA.
+
+HAMi-WebUI 2.0.0 enables certificate verification by default; earlier versions
+silently skipped it for every HTTPS Prometheus endpoint. Before upgrading an
+installation that relies on an untrusted self-signed certificate, configure its
+CA as shown above or explicitly opt into the temporary insecure setting.
+
 ### Prometheus scrape labels
 
 HAMi's vgpu-monitor exposes workload identity as `namespace`, `pod`, and

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -219,6 +219,96 @@ external_render="$(helm template test "${work_dir}/hami-webui" \
   --set 'kube-prometheus-stack.prometheus.enabled=true' \
   --show-only templates/configmap.yaml)"
 grep -Fq "address: ${external_address}" <<<"${external_render}"
+grep -Fq 'insecure_skip_verify: false' <<<"${external_render}"
+
+external_deployment_render="$(render_template templates/deployment.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=${external_address}")"
+if grep -Fq 'prometheus-tls' <<<"${external_deployment_render}"; then
+  echo "External Prometheus must not mount TLS material unless a Secret is configured" >&2
+  exit 1
+fi
+
+prometheus_tls_ca_config="$(render_template templates/configmap.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.tls.existingSecret=prometheus-ca' \
+  --set-string 'externalPrometheus.tls.caKey=company-ca.pem')"
+prometheus_tls_ca_deployment="$(render_template templates/deployment.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.tls.existingSecret=prometheus-ca' \
+  --set-string 'externalPrometheus.tls.caKey=company-ca.pem')"
+if ! grep -Fq 'ca_file: "/apps/prometheus-tls/ca.crt"' <<<"${prometheus_tls_ca_config}" ||
+  grep -Eq 'prometheus-ca|company-ca\.pem' <<<"${prometheus_tls_ca_config}" ||
+  ! grep -Fq 'secretName: "prometheus-ca"' <<<"${prometheus_tls_ca_deployment}" ||
+  ! grep -A1 -F 'key: "company-ca.pem"' <<<"${prometheus_tls_ca_deployment}" | grep -Fq 'path: ca.crt' ||
+  [[ "$(grep -c 'name: prometheus-tls' <<<"${prometheus_tls_ca_deployment}")" -ne 2 ]] ||
+  ! grep -A2 -F 'mountPath: /apps/prometheus-tls/' <<<"${prometheus_tls_ca_deployment}" | grep -Fq 'readOnly: true'; then
+  echo "Private-CA Secret was not rendered as a backend-only fixed-path mount" >&2
+  exit 1
+fi
+
+prometheus_mtls_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.tls.serverName=prometheus.internal' \
+  --set-string 'externalPrometheus.tls.existingSecret=prometheus-mtls' \
+  --set-string 'externalPrometheus.tls.caKey=root.pem' \
+  --set-string 'externalPrometheus.tls.certKey=client.pem' \
+  --set-string 'externalPrometheus.tls.keyKey=client-key.pem' \
+  --show-only templates/configmap.yaml \
+  --show-only templates/deployment.yaml)"
+for expected in \
+  'server_name: "prometheus.internal"' \
+  'ca_file: "/apps/prometheus-tls/ca.crt"' \
+  'cert_file: "/apps/prometheus-tls/tls.crt"' \
+  'key_file: "/apps/prometheus-tls/tls.key"' \
+  'key: "root.pem"' \
+  'key: "client.pem"' \
+  'key: "client-key.pem"'; do
+  if ! grep -Fq "${expected}" <<<"${prometheus_mtls_render}"; then
+    echo "mTLS rendering is missing ${expected}" >&2
+    exit 1
+  fi
+done
+
+prometheus_insecure_render="$(render_template templates/configmap.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set 'externalPrometheus.tls.insecureSkipVerify=true')"
+grep -Fq 'insecure_skip_verify: true' <<<"${prometheus_insecure_render}"
+
+disabled_tls_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --set-string 'externalPrometheus.tls.existingSecret=unused-tls' \
+  --set-string 'externalPrometheus.tls.caKey=ca.pem' \
+  --show-only templates/configmap.yaml \
+  --show-only templates/deployment.yaml)"
+if grep -Eq 'prometheus-tls|insecure_skip_verify|unused-tls|ca\.pem' <<<"${disabled_tls_render}"; then
+  echo "Disabled external Prometheus unexpectedly rendered TLS configuration" >&2
+  exit 1
+fi
+
+for invalid_prometheus_tls in \
+  '--set-string=externalPrometheus.tls.insecureSkipVerify=true' \
+  '--set-string=externalPrometheus.tls.unknownField=value' \
+  '--set=externalPrometheus.enabled=true --set-string=externalPrometheus.tls.certKey=tls.crt' \
+  '--set=externalPrometheus.enabled=true --set-string=externalPrometheus.tls.keyKey=tls.key' \
+  '--set=externalPrometheus.enabled=true --set-string=externalPrometheus.tls.caKey=ca.crt' \
+  '--set=externalPrometheus.enabled=true --set-string=externalPrometheus.tls.existingSecret=empty-secret'; do
+  read -r -a invalid_args <<<"${invalid_prometheus_tls}"
+  if helm template test "${work_dir}/hami-webui" "${invalid_args[@]}" >/dev/null 2>&1; then
+    echo "Invalid external Prometheus TLS values were accepted: ${invalid_prometheus_tls}" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq 'kind: Secret' <<<"${prometheus_mtls_render}"; then
+  echo "The Chart must reference, not create, Prometheus credential Secrets" >&2
+  exit 1
+fi
 
 deployment_with_address() {
   helm template test "${work_dir}/hami-webui" \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,9 +16,10 @@ ARG UNZIP_VERSION=6.0-28
 RUN sed -i -E \
       -e "s|https?://deb.debian.org/debian-security|https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}|g" \
       -e "s|https?://deb.debian.org/debian|https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}|g" \
-      /etc/apt/sources.list.d/debian.sources && \
+    /etc/apt/sources.list.d/debian.sources && \
     apt-get -o Acquire::Check-Valid-Until=false update && \
     apt-get install -y --no-install-recommends "unzip=${UNZIP_VERSION}" && \
+    test -s /etc/ssl/certs/ca-certificates.crt && \
     rm -rf /var/lib/apt/lists/*
 
 # Install the exact protoc release used by CI. The archive checksum makes this
@@ -52,4 +53,5 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM debian:bookworm-20260824-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /src/build/ /apps/

--- a/server/go.mod
+++ b/server/go.mod
@@ -48,11 +48,13 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/server/internal/app.go
+++ b/server/internal/app.go
@@ -45,7 +45,17 @@ func NewPromClient(c *conf.Bootstrap) *prom.Client {
 	if err != nil {
 		panic(err)
 	}
-	client, err := prom.NewClient(c.Prometheus.Address, timeout, c.Prometheus.Auth)
+	tlsConfig := prom.TLSConfig{}
+	if c.Prometheus.Tls != nil {
+		tlsConfig = prom.TLSConfig{
+			CAFile:             c.Prometheus.Tls.CaFile,
+			CertFile:           c.Prometheus.Tls.CertFile,
+			KeyFile:            c.Prometheus.Tls.KeyFile,
+			ServerName:         c.Prometheus.Tls.ServerName,
+			InsecureSkipVerify: c.Prometheus.Tls.InsecureSkipVerify,
+		}
+	}
+	client, err := prom.NewClient(c.Prometheus.Address, timeout, c.Prometheus.Auth, tlsConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/server/internal/conf/conf.proto
+++ b/server/internal/conf/conf.proto
@@ -31,6 +31,15 @@ message Prometheus {
   string address = 1;
   string timeout = 2;
   string auth = 3;
+  PrometheusTLS tls = 4;
+}
+
+message PrometheusTLS {
+  string ca_file = 1;
+  string cert_file = 2;
+  string key_file = 3;
+  string server_name = 4;
+  bool insecure_skip_verify = 5;
 }
 
 // Exporter controls the background /metrics collector that periodically refreshes the

--- a/server/internal/data/prom/client.go
+++ b/server/internal/data/prom/client.go
@@ -2,13 +2,13 @@ package prom
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	promconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )
 
@@ -17,27 +17,46 @@ type Client struct {
 	timeout time.Duration
 }
 
-type CustomTransport struct {
+type TLSConfig struct {
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	ServerName         string
+	InsecureSkipVerify bool
+}
+
+type authorizationRoundTripper struct {
 	auth string
-	*http.Transport
+	next http.RoundTripper
 }
 
-func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", t.auth)
-	return t.Transport.RoundTrip(req)
+func (t *authorizationRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header = req.Header.Clone()
+	clone.Header.Set("Authorization", t.auth)
+	return t.next.RoundTrip(clone)
 }
 
-func NewClient(address string, timeout time.Duration, auth string) (*Client, error) {
+func NewClient(address string, timeout time.Duration, auth string, tlsConfig TLSConfig) (*Client, error) {
+	httpConfig := promconfig.DefaultHTTPClientConfig
+	httpConfig.TLSConfig = promconfig.TLSConfig{
+		CAFile:             tlsConfig.CAFile,
+		CertFile:           tlsConfig.CertFile,
+		KeyFile:            tlsConfig.KeyFile,
+		ServerName:         tlsConfig.ServerName,
+		InsecureSkipVerify: tlsConfig.InsecureSkipVerify,
+	}
+	roundTripper, err := promconfig.NewRoundTripperFromConfig(httpConfig, "hami-webui-prometheus")
+	if err != nil {
+		return nil, fmt.Errorf("create Prometheus HTTP transport: %w", err)
+	}
+	if auth != "" {
+		roundTripper = &authorizationRoundTripper{auth: auth, next: roundTripper}
+	}
+
 	client, err := api.NewClient(api.Config{
-		Address: address,
-		RoundTripper: &CustomTransport{
-			auth: auth,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
-		},
+		Address:      address,
+		RoundTripper: roundTripper,
 	})
 	if err != nil {
 		fmt.Printf("Error creating client: %v\n", err)

--- a/server/internal/data/prom/client_test.go
+++ b/server/internal/data/prom/client_test.go
@@ -1,0 +1,104 @@
+package prom
+
+import (
+	"context"
+	"encoding/pem"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTLSVerificationDefaultsToEnabled(t *testing.T) {
+	server := newTLSTestServer(t)
+	client := newTestClient(t, server.URL, TLSConfig{})
+
+	if err := request(t, client, server.URL); err == nil {
+		t.Fatal("request with an untrusted certificate succeeded")
+	}
+}
+
+func TestTLSVerificationCanBeExplicitlyDisabled(t *testing.T) {
+	server := newTLSTestServer(t)
+	client := newTestClient(t, server.URL, TLSConfig{InsecureSkipVerify: true})
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request with explicit insecure mode failed: %v", err)
+	}
+}
+
+func TestTLSVerificationUsesConfiguredCA(t *testing.T) {
+	server := newTLSTestServer(t)
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	certificate := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+	if err := os.WriteFile(caFile, certificate, 0o600); err != nil {
+		t.Fatalf("write CA file: %v", err)
+	}
+	client := newTestClient(t, server.URL, TLSConfig{CAFile: caFile})
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request with configured CA failed: %v", err)
+	}
+}
+
+func TestLegacyAuthorizationHeaderIsPreserved(t *testing.T) {
+	const authorization = "Bearer test-token"
+	received := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		received <- req.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.URL, time.Second, authorization, TLSConfig{})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request with authorization failed: %v", err)
+	}
+	if got := <-received; got != authorization {
+		t.Fatalf("Authorization header = %q, want %q", got, authorization)
+	}
+}
+
+func newTLSTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestClient(t *testing.T, address string, tlsConfig TLSConfig) *Client {
+	t.Helper()
+	client, err := NewClient(address, time.Second, "", tlsConfig)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return client
+}
+
+func request(t *testing.T, client *Client, address string) error {
+	t.Helper()
+	connection, err := client.Conn()
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, address, nil)
+	if err != nil {
+		return err
+	}
+	_, _, err = connection.Do(context.Background(), req)
+	return err
+}

--- a/server/internal/service/allocation_capacity_test.go
+++ b/server/internal/service/allocation_capacity_test.go
@@ -60,7 +60,7 @@ func TestAllocationListsKeepRegisteredMemoryCapacity(t *testing.T) {
 	podRepo := &capacityTestPodRepo{}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "")
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{})
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/server/internal/service/empty_filters_test.go
+++ b/server/internal/service/empty_filters_test.go
@@ -44,7 +44,7 @@ func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
 	}}}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "")
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{})
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}


### PR DESCRIPTION
## Why

The Prometheus client has skipped certificate-chain and host-name verification for every HTTPS endpoint since the initial import. The Chart also had no way to supply a private CA or mTLS identity.

## What changed

- verify upstream HTTPS certificates by default using the Prometheus common transport
- keep insecureSkipVerify only as an explicit break-glass value
- mount private-CA or mTLS files from an existing Secret into the backend only
- validate TLS values and invalid Secret key combinations during Helm rendering
- include the system CA bundle in the final backend image
- document the upgrade boundary for installations that relied on untrusted self-signed certificates

The Chart references existing Secrets and never renders certificate or key contents into a ConfigMap.

## Verification

- make -C server verify
- go test -race ./internal/data/prom
- bash scripts/verify-chart.sh
- make verify

Closes #219.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTPS support for external Prometheus connections.
  * Supports certificate verification, custom server names, private CA certificates, and mutual TLS using existing Secrets.
  * Added an explicit option to disable certificate verification when necessary.

* **Bug Fixes**
  * External Prometheus certificates are now verified by default instead of being implicitly skipped.

* **Documentation**
  * Added Helm configuration and upgrade guidance for secure Prometheus connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->