### PR TITLE
fix(server): preserve Prometheus results with warnings

### DIFF
--- a/server/internal/app.go
+++ b/server/internal/app.go
@@ -40,7 +40,7 @@ func NewLogger() log.Logger {
 	)
 }
 
-func NewPromClient(c *conf.Bootstrap) *prom.Client {
+func NewPromClient(c *conf.Bootstrap, logger log.Logger) *prom.Client {
 	timeout, err := time.ParseDuration(c.Prometheus.Timeout)
 	if err != nil {
 		panic(err)
@@ -55,7 +55,7 @@ func NewPromClient(c *conf.Bootstrap) *prom.Client {
 			InsecureSkipVerify: c.Prometheus.Tls.InsecureSkipVerify,
 		}
 	}
-	client, err := prom.NewClient(c.Prometheus.Address, timeout, c.Prometheus.Auth, tlsConfig)
+	client, err := prom.NewClient(c.Prometheus.Address, timeout, c.Prometheus.Auth, tlsConfig, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/server/internal/data/prom/client.go
+++ b/server/internal/data/prom/client.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-kratos/kratos/v2/log"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promconfig "github.com/prometheus/common/config"
@@ -15,6 +16,7 @@ import (
 type Client struct {
 	client  api.Client
 	timeout time.Duration
+	log     *log.Helper
 }
 
 type TLSConfig struct {
@@ -37,7 +39,7 @@ func (t *authorizationRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	return t.next.RoundTrip(clone)
 }
 
-func NewClient(address string, timeout time.Duration, auth string, tlsConfig TLSConfig) (*Client, error) {
+func NewClient(address string, timeout time.Duration, auth string, tlsConfig TLSConfig, logger log.Logger) (*Client, error) {
 	httpConfig := promconfig.DefaultHTTPClientConfig
 	httpConfig.TLSConfig = promconfig.TLSConfig{
 		CAFile:             tlsConfig.CAFile,
@@ -59,12 +61,12 @@ func NewClient(address string, timeout time.Duration, auth string, tlsConfig TLS
 		RoundTripper: roundTripper,
 	})
 	if err != nil {
-		fmt.Printf("Error creating client: %v\n", err)
-		return nil, fmt.Errorf("error creating client: %v", err)
+		return nil, fmt.Errorf("create Prometheus client: %w", err)
 	}
 	return &Client{
-		client,
-		timeout,
+		client:  client,
+		timeout: timeout,
+		log:     log.NewHelper(log.With(logger, "module", "prometheus-client")),
 	}, nil
 }
 
@@ -77,12 +79,15 @@ func (c *Client) Query(ctx context.Context, query string) (model.Value, error) {
 	v1api := v1.NewAPI(c.client)
 	result, warnings, err := v1api.Query(ctx, query, time.Now(), v1.WithTimeout(c.timeout))
 	if err != nil {
-		fmt.Printf("Error querying Prometheus: %v\n", err)
-		return result, fmt.Errorf("error querying Prometheus: %v", err)
+		return result, fmt.Errorf("query Prometheus: %w", err)
 	}
 	if len(warnings) > 0 {
-		fmt.Printf("Warnings: %v\n", warnings)
-		return result, fmt.Errorf("warnings: %v", warnings)
+		c.log.WithContext(ctx).Warnw(
+			"msg", "Prometheus query completed with warnings",
+			"operation", "instant",
+			"warning_count", len(warnings),
+			"warnings", []string(warnings),
+		)
 	}
 	return result, nil
 }
@@ -92,12 +97,15 @@ func (c *Client) QueryRange(ctx context.Context, query string, r v1.Range) (mode
 	v1api := v1.NewAPI(c.client)
 	result, warnings, err := v1api.QueryRange(ctx, query, r, v1.WithTimeout(c.timeout))
 	if err != nil {
-		fmt.Printf("Error querying Prometheus: %v\n", err)
-		return result, fmt.Errorf("error querying Prometheus: %v", err)
+		return result, fmt.Errorf("query Prometheus range: %w", err)
 	}
 	if len(warnings) > 0 {
-		fmt.Printf("Warnings: %v\n", warnings)
-		return result, fmt.Errorf("warnings: %v", warnings)
+		c.log.WithContext(ctx).Warnw(
+			"msg", "Prometheus query completed with warnings",
+			"operation", "range",
+			"warning_count", len(warnings),
+			"warnings", []string(warnings),
+		)
 	}
 	return result, nil
 }

--- a/server/internal/data/prom/client_test.go
+++ b/server/internal/data/prom/client_test.go
@@ -3,14 +3,22 @@ package prom
 import (
 	"context"
 	"encoding/pem"
+	"fmt"
 	"io"
-	"log"
+	stdlog "log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-kratos/kratos/v2/log"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 )
 
 func TestTLSVerificationDefaultsToEnabled(t *testing.T) {
@@ -56,7 +64,7 @@ func TestLegacyAuthorizationHeaderIsPreserved(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
-	client, err := NewClient(server.URL, time.Second, authorization, TLSConfig{})
+	client, err := NewClient(server.URL, time.Second, authorization, TLSConfig{}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}
@@ -74,7 +82,7 @@ func newTLSTestServer(t *testing.T) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.Config.ErrorLog = stdlog.New(io.Discard, "", 0)
 	server.StartTLS()
 	t.Cleanup(server.Close)
 	return server
@@ -82,11 +90,173 @@ func newTLSTestServer(t *testing.T) *httptest.Server {
 
 func newTestClient(t *testing.T, address string, tlsConfig TLSConfig) *Client {
 	t.Helper()
-	client, err := NewClient(address, time.Second, "", tlsConfig)
+	client, err := NewClient(address, time.Second, "", tlsConfig, log.NewStdLogger(io.Discard))
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}
 	return client
+}
+
+func TestQueryReturnsSuccessfulResultWithWarnings(t *testing.T) {
+	logger := &recordingLogger{}
+	server := newPrometheusAPIServer(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v1/query" {
+			http.Error(w, "unexpected query path", http.StatusNotFound)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"test"},"value":[1788050000,"42"]}]},"warnings":["partial response"]}`)
+	})
+	client := newTestClientWithLogger(t, server.URL, TLSConfig{}, logger)
+
+	value, err := client.Query(context.Background(), "up")
+	if err != nil {
+		t.Fatalf("Query returned a warning as an error: %v", err)
+	}
+	vector, ok := value.(model.Vector)
+	if !ok || len(vector) != 1 || vector[0].Value != 42 {
+		t.Fatalf("Query result = %#v, want one sample with value 42", value)
+	}
+	logger.requireWarning(t, "instant", "partial response")
+}
+
+func TestQueryRangeReturnsSuccessfulResultWithWarnings(t *testing.T) {
+	logger := &recordingLogger{}
+	server := newPrometheusAPIServer(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v1/query_range" {
+			http.Error(w, "unexpected query range path", http.StatusNotFound)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"job":"test"},"values":[[1788050000,"1"],[1788050060,"2"]]}]},"warnings":["partial range"]}`)
+	})
+	client := newTestClientWithLogger(t, server.URL, TLSConfig{}, logger)
+
+	value, err := client.QueryRange(context.Background(), "up", v1.Range{
+		Start: time.Unix(1788050000, 0),
+		End:   time.Unix(1788050060, 0),
+		Step:  time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("QueryRange returned a warning as an error: %v", err)
+	}
+	matrix, ok := value.(model.Matrix)
+	if !ok || len(matrix) != 1 || len(matrix[0].Values) != 2 {
+		t.Fatalf("QueryRange result = %#v, want one series with two samples", value)
+	}
+	logger.requireWarning(t, "range", "partial range")
+}
+
+func TestQueryPreservesPrometheusErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantError  string
+	}{
+		{
+			name:       "API error",
+			statusCode: http.StatusUnprocessableEntity,
+			response:   `{"status":"error","errorType":"bad_data","error":"invalid query"}`,
+			wantError:  "invalid query",
+		},
+		{
+			name:       "HTTP error",
+			statusCode: http.StatusServiceUnavailable,
+			response:   "service unavailable",
+			wantError:  "server_error",
+		},
+		{
+			name:       "invalid response",
+			statusCode: http.StatusOK,
+			response:   `{"status":"success","data":`,
+			wantError:  "bad_response",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newPrometheusAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.response)
+			})
+			client := newTestClient(t, server.URL, TLSConfig{})
+
+			if _, err := client.Query(context.Background(), "invalid("); err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Query error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestQueryPreservesTransportErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	address := server.URL
+	server.Close()
+	client := newTestClient(t, address, TLSConfig{})
+
+	if _, err := client.Query(context.Background(), "up"); err == nil {
+		t.Fatal("Query with an unavailable Prometheus endpoint succeeded")
+	}
+}
+
+func newPrometheusAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		handler(w, req)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestClientWithLogger(t *testing.T, address string, tlsConfig TLSConfig, logger log.Logger) *Client {
+	t.Helper()
+	client, err := NewClient(address, time.Second, "", tlsConfig, logger)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return client
+}
+
+type logEntry struct {
+	level   log.Level
+	keyvals []any
+}
+
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (l *recordingLogger) Log(level log.Level, keyvals ...any) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, logEntry{level: level, keyvals: append([]any(nil), keyvals...)})
+	return nil
+}
+
+func (l *recordingLogger) requireWarning(t *testing.T, operation, warning string) {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.entries) != 1 {
+		t.Fatalf("log entries = %#v, want one warning", l.entries)
+	}
+	entry := l.entries[0]
+	if entry.level != log.LevelWarn {
+		t.Fatalf("log level = %v, want warning", entry.level)
+	}
+	fields := make(map[any]any, len(entry.keyvals)/2)
+	for i := 0; i+1 < len(entry.keyvals); i += 2 {
+		fields[entry.keyvals[i]] = entry.keyvals[i+1]
+	}
+	if fields["operation"] != operation {
+		t.Fatalf("operation = %v, want %q", fields["operation"], operation)
+	}
+	if fields["warning_count"] != 1 {
+		t.Fatalf("warning_count = %v, want 1", fields["warning_count"])
+	}
+	if !reflect.DeepEqual(fields["warnings"], []string{warning}) {
+		t.Fatalf("warnings = %#v, want %q", fields["warnings"], warning)
+	}
 }
 
 func request(t *testing.T, client *Client, address string) error {

--- a/server/internal/service/allocation_capacity_test.go
+++ b/server/internal/service/allocation_capacity_test.go
@@ -60,7 +60,7 @@ func TestAllocationListsKeepRegisteredMemoryCapacity(t *testing.T) {
 	podRepo := &capacityTestPodRepo{}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{})
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/server/internal/service/empty_filters_test.go
+++ b/server/internal/service/empty_filters_test.go
@@ -44,7 +44,7 @@ func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
 	}}}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{})
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

Prometheus can return usable query data together with non-critical warnings. The client currently converts those warnings into an error, so callers discard valid instant and range results.

This change returns successful data unchanged and records one structured warning with the operation, count, and details. Real transport, HTTP, PromQL, and response-decoding errors still propagate with wrapped causes.

**Verification**

- data-plus-warning tests for instant and range queries
- structured warning fields asserted with a recording logger
- API, HTTP, malformed-response, and transport error coverage
- `make -C server verify`
- `go test -race ./internal/data/prom ./internal/service`

Fixes #220.
