### PR TITLE
refactor(server): add unified application entry

### DIFF
--- a/server/cmd/hami-webui/main.go
+++ b/server/cmd/hami-webui/main.go
@@ -1,0 +1,182 @@
+// Command hami-webui runs the HAMi-WebUI API, metrics collector and public Web
+// entry in one process.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"vgpu/internal/conf"
+	"vgpu/internal/exporter"
+	"vgpu/internal/webentry"
+
+	"github.com/go-kratos/kratos/v2"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/go-kratos/kratos/v2/transport/grpc"
+	kratoshttp "github.com/go-kratos/kratos/v2/transport/http"
+
+	_ "go.uber.org/automaxprocs"
+)
+
+const (
+	defaultConfigPath       = "../../config/config.yaml"
+	defaultWebListenAddress = ":3000"
+	defaultStaticDir        = "/apps/public"
+	defaultBasePath         = "/"
+	defaultFrameAncestors   = "null"
+	defaultRequestTimeout   = 60 * time.Second
+)
+
+var (
+	// Name is the name of the compiled software.
+	Name string
+	// Version is the version of the compiled software.
+	Version string
+
+	id, _ = os.Hostname()
+)
+
+type webConfig struct {
+	listenAddress  string
+	staticDir      string
+	basePath       string
+	frameAncestors []string
+}
+
+type options struct {
+	configPath string
+	web        webConfig
+}
+
+func main() {
+	if err := run(os.Args[1:], os.LookupEnv); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, lookupEnv func(string) (string, bool)) error {
+	config, err := parseOptions(args, lookupEnv)
+	if err != nil {
+		return fmt.Errorf("invalid command-line options: %w", err)
+	}
+	ctx := context.Background()
+	app, cleanup, err := initApp(config.configPath, config.web, ctx)
+	if err != nil {
+		return fmt.Errorf("initialize application: %w", err)
+	}
+	defer cleanup()
+	if err := app.Run(); err != nil {
+		return fmt.Errorf("run application: %w", err)
+	}
+	return nil
+}
+
+func parseOptions(args []string, lookupEnv func(string) (string, bool)) (options, error) {
+	config := options{}
+	var frameAncestorsJSON string
+	flags := flag.NewFlagSet("hami-webui", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&config.configPath, "conf", defaultConfigPath, "backend config path")
+	flags.StringVar(&config.web.listenAddress, "listen-address", envOrDefault(lookupEnv, "HAMI_WEBUI_LISTEN_ADDRESS", defaultWebListenAddress), "public HTTP listen address")
+	flags.StringVar(&config.web.staticDir, "static-dir", envOrDefault(lookupEnv, "HAMI_WEBUI_STATIC_DIR", defaultStaticDir), "SPA static directory")
+	flags.StringVar(&config.web.basePath, "base-path", envOrDefault(lookupEnv, "HAMI_WEBUI_BASE_PATH", defaultBasePath), "external URL base path")
+	flags.StringVar(&frameAncestorsJSON, "frame-ancestors-json", envOrDefault(lookupEnv, "HAMI_WEBUI_FRAME_ANCESTORS_JSON", defaultFrameAncestors), "JSON array of allowed iframe ancestors, [] to deny all, or null to omit")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, errors.New("unexpected positional arguments")
+	}
+	if err := json.Unmarshal([]byte(frameAncestorsJSON), &config.web.frameAncestors); err != nil {
+		return options{}, errors.New("frame ancestors must be null or a JSON array of allowed sources")
+	}
+	return config, nil
+}
+
+func envOrDefault(lookupEnv func(string) (string, bool), key, fallback string) string {
+	if value, ok := lookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func newWebServer(config webConfig, bootstrap *conf.Bootstrap, api *kratoshttp.Server) (*webentry.LifecycleServer, error) {
+	handler, err := newWebHandler(config, api)
+	if err != nil {
+		return nil, err
+	}
+	requestTimeout := backendRequestTimeout(bootstrap)
+	server, err := webentry.NewHTTPServer(webentry.HTTPServerConfig{
+		Address:        config.listenAddress,
+		Handler:        handler,
+		RequestTimeout: requestTimeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure public HTTP server: %w", err)
+	}
+	managed, err := webentry.NewLifecycleServer(server)
+	if err != nil {
+		return nil, fmt.Errorf("configure public HTTP lifecycle: %w", err)
+	}
+	return managed, nil
+}
+
+func newWebHandler(config webConfig, api http.Handler) (http.Handler, error) {
+	if config.staticDir == "" {
+		return nil, errors.New("static directory must not be empty")
+	}
+	handler, err := webentry.NewHandler(webentry.HandlerConfig{
+		StaticFS:       os.DirFS(config.staticDir),
+		APIHandler:     api,
+		BasePath:       config.basePath,
+		FrameAncestors: config.frameAncestors,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure public Web handler: %w", err)
+	}
+	return handler, nil
+}
+
+func backendRequestTimeout(bootstrap *conf.Bootstrap) time.Duration {
+	if bootstrap == nil || bootstrap.Server == nil || bootstrap.Server.Http == nil || bootstrap.Server.Http.Timeout == nil {
+		return defaultRequestTimeout
+	}
+	if timeout := bootstrap.Server.Http.Timeout.AsDuration(); timeout != 0 {
+		return timeout
+	}
+	return defaultRequestTimeout
+}
+
+// newApp registers both HTTP listeners in the same lifecycle. The public Web
+// listener invokes the backend HTTP server directly as an http.Handler; it does
+// not use a loopback proxy.
+func newApp(
+	ctx context.Context,
+	logger log.Logger,
+	gs *grpc.Server,
+	hs *kratoshttp.Server,
+	mc *exporter.MetricsGenerator,
+	ws *webentry.LifecycleServer,
+) *kratos.App {
+	return kratos.New(
+		kratos.Context(ctx),
+		kratos.ID(id),
+		kratos.Name(Name),
+		kratos.Version(Version),
+		kratos.Metadata(map[string]string{}),
+		kratos.Logger(logger),
+		kratos.Server(gs, hs, mc, ws),
+	)
+}
+
+func getNodeSelectors(c *conf.Bootstrap) map[string]string {
+	return c.NodeSelectors
+}

--- a/server/cmd/hami-webui/main_test.go
+++ b/server/cmd/hami-webui/main_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"vgpu/internal/conf"
+
+	"github.com/go-kratos/kratos/v2/transport"
+	kratoshttp "github.com/go-kratos/kratos/v2/transport/http"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestParseOptionsUsesDocumentedDefaults(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseOptions(nil, func(string) (string, bool) { return "", false })
+	if err != nil {
+		t.Fatalf("parseOptions: %v", err)
+	}
+	if config.configPath != defaultConfigPath ||
+		config.web.listenAddress != defaultWebListenAddress ||
+		config.web.staticDir != defaultStaticDir ||
+		config.web.basePath != defaultBasePath ||
+		config.web.frameAncestors != nil {
+		t.Fatalf("defaults = %+v", config)
+	}
+}
+
+func TestParseOptionsFlagsOverrideEnvironment(t *testing.T) {
+	t.Parallel()
+
+	environment := map[string]string{
+		"HAMI_WEBUI_LISTEN_ADDRESS":       ":3100",
+		"HAMI_WEBUI_STATIC_DIR":           "/env/public",
+		"HAMI_WEBUI_BASE_PATH":            "/env-ui/",
+		"HAMI_WEBUI_FRAME_ANCESTORS_JSON": `[]`,
+	}
+	lookup := func(key string) (string, bool) {
+		value, ok := environment[key]
+		return value, ok
+	}
+	config, err := parseOptions([]string{
+		"--conf=/flag/config.yaml",
+		"--listen-address=:3200",
+		"--static-dir=/flag/public",
+		"--base-path=/flag-ui/",
+		`--frame-ancestors-json=["'self'"]`,
+	}, lookup)
+	if err != nil {
+		t.Fatalf("parseOptions: %v", err)
+	}
+	if config.configPath != "/flag/config.yaml" ||
+		config.web.listenAddress != ":3200" ||
+		config.web.staticDir != "/flag/public" ||
+		config.web.basePath != "/flag-ui/" ||
+		len(config.web.frameAncestors) != 1 || config.web.frameAncestors[0] != "'self'" {
+		t.Fatalf("flags did not override environment: %+v", config)
+	}
+}
+
+func TestParseOptionsRejectsInvalidFrameAncestors(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"", "{}", `"'self'"`, `["'self'",1]`, "[] trailing"} {
+		t.Run(raw, func(t *testing.T) {
+			lookup := func(key string) (string, bool) {
+				if key == "HAMI_WEBUI_FRAME_ANCESTORS_JSON" {
+					return raw, true
+				}
+				return "", false
+			}
+			if _, err := parseOptions(nil, lookup); err == nil {
+				t.Fatalf("parseOptions accepted frame ancestors %q", raw)
+			}
+		})
+	}
+}
+
+func TestWebHandlerInvokesKratosAPIDirectly(t *testing.T) {
+	t.Parallel()
+
+	staticDir := newStaticDir(t)
+	api := kratoshttp.NewServer()
+	api.Handle("/v1/contract-probe", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := transport.FromServerContext(r.Context()); !ok {
+			t.Error("request is missing Kratos server transport context")
+		}
+		if r.URL.RequestURI() != "/v1/contract-probe?limit=10" {
+			t.Errorf("request URI = %q", r.URL.RequestURI())
+		}
+		if r.Header.Get("X-Hami-Probe") != "preserved" {
+			t.Errorf("request header was not preserved")
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		if string(body) != `{"name":"worker"}` {
+			t.Errorf("request body = %q", body)
+		}
+		w.Header().Set("X-Hami-Response", "preserved")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+
+	handler, err := newWebHandler(webConfig{
+		staticDir:      staticDir,
+		basePath:       "/gpu-ui/",
+		frameAncestors: []string{"'self'"},
+	}, api)
+	if err != nil {
+		t.Fatalf("newWebHandler: %v", err)
+	}
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/gpu-ui/api/vgpu/v1/contract-probe?limit=10",
+		bytes.NewBufferString(`{"name":"worker"}`),
+	)
+	request.Header.Set("X-Hami-Probe", "preserved")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted || response.Body.String() != `{"ok":true}` {
+		t.Fatalf("response = {%d %q}, want {202 %q}", response.Code, response.Body.String(), `{"ok":true}`)
+	}
+	if response.Header().Get("X-Hami-Response") != "preserved" {
+		t.Error("response header was not preserved")
+	}
+}
+
+func TestWebHandlerKeepsBackendOnlyRoutesPrivate(t *testing.T) {
+	t.Parallel()
+
+	apiCalled := false
+	api := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler, err := newWebHandler(webConfig{
+		staticDir: newStaticDir(t),
+		basePath:  "/gpu-ui/",
+	}, api)
+	if err != nil {
+		t.Fatalf("newWebHandler: %v", err)
+	}
+	for _, requestPath := range []string{
+		"/gpu-ui/metrics",
+		"/gpu-ui/readyz",
+		"/gpu-ui/q/openapi.yaml",
+		"/gpu-ui/api/vgpu/v2/private",
+		"/gpu-ui/api/vgpu/../metrics",
+	} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, requestPath, nil))
+		if response.Code != http.StatusNotFound {
+			t.Errorf("%s status = %d, want 404", requestPath, response.Code)
+		}
+	}
+	if apiCalled {
+		t.Fatal("backend handler was called for a private or unsupported route")
+	}
+}
+
+func TestBackendRequestTimeoutUsesConfigOrSafeDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := backendRequestTimeout(nil); got != defaultRequestTimeout {
+		t.Fatalf("nil config timeout = %s, want %s", got, defaultRequestTimeout)
+	}
+	configured := 17 * time.Second
+	bootstrap := &conf.Bootstrap{
+		Server: &conf.Server{
+			Http: &conf.Server_HTTP{Timeout: durationpb.New(configured)},
+		},
+	}
+	if got := backendRequestTimeout(bootstrap); got != configured {
+		t.Fatalf("configured timeout = %s, want %s", got, configured)
+	}
+}
+
+func newStaticDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	index := `<html><head><base data-hami-webui-base href="/"></head><body>HAMi</body></html>`
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(index), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	return dir
+}
+
+func TestWebHandlerPreservesKratosJSONNotFound(t *testing.T) {
+	t.Parallel()
+
+	api := kratoshttp.NewServer(
+		kratoshttp.NotFoundHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"reason":"ROUTE_NOT_FOUND"}`)
+		})),
+	)
+	handler, err := newWebHandler(webConfig{staticDir: newStaticDir(t)}, api)
+	if err != nil {
+		t.Fatalf("newWebHandler: %v", err)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/vgpu/v1/missing", nil))
+	if response.Code != http.StatusNotFound || !strings.Contains(response.Body.String(), "ROUTE_NOT_FOUND") {
+		t.Fatalf("response = {%d %q}, want Kratos JSON 404", response.Code, response.Body.String())
+	}
+}

--- a/server/cmd/hami-webui/wire.go
+++ b/server/cmd/hami-webui/wire.go
@@ -1,0 +1,32 @@
+//go:build wireinject
+// +build wireinject
+
+package main
+
+import (
+	"context"
+
+	"vgpu/internal"
+	"vgpu/internal/biz"
+	"vgpu/internal/data"
+	"vgpu/internal/exporter"
+	"vgpu/internal/server"
+	"vgpu/internal/service"
+
+	"github.com/go-kratos/kratos/v2"
+	"github.com/google/wire"
+)
+
+func initApp(configPath string, web webConfig, ctx context.Context) (*kratos.App, func(), error) {
+	panic(wire.Build(
+		internal.ProviderSet,
+		data.ProviderSet,
+		biz.ProviderSet,
+		server.ProviderSet,
+		service.ProviderSet,
+		exporter.ProviderSet,
+		newWebServer,
+		newApp,
+		getNodeSelectors,
+	))
+}

--- a/server/cmd/web-entry/main.go
+++ b/server/cmd/web-entry/main.go
@@ -108,9 +108,9 @@ func run(args []string, lookupEnv func(string) (string, bool)) error {
 		return errors.New("cannot open Web-entry listener")
 	}
 	server, err := webentry.NewHTTPServer(webentry.HTTPServerConfig{
-		Address:      config.listenAddress,
-		Handler:      handler,
-		ProxyTimeout: proxyTimeout,
+		Address:        config.listenAddress,
+		Handler:        handler,
+		RequestTimeout: proxyTimeout,
 	})
 	if err != nil {
 		_ = listener.Close()

--- a/server/internal/webentry/lifecycle.go
+++ b/server/internal/webentry/lifecycle.go
@@ -1,0 +1,94 @@
+package webentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+)
+
+// LifecycleServer adapts the bounded public HTTP server to the lifecycle used
+// by the HAMi-WebUI application. It opens the listener in Start, propagates
+// serve failures to the application, and force-closes connections if graceful
+// shutdown exceeds the application deadline.
+type LifecycleServer struct {
+	server *http.Server
+
+	mu       sync.Mutex
+	listener net.Listener
+	started  bool
+	stopped  bool
+}
+
+// NewLifecycleServer wraps a public HTTP server without opening its listener.
+func NewLifecycleServer(server *http.Server) (*LifecycleServer, error) {
+	if server == nil {
+		return nil, errors.New("HTTP server is required")
+	}
+	if server.Addr == "" {
+		return nil, errors.New("HTTP listen address is required")
+	}
+	return &LifecycleServer{server: server}, nil
+}
+
+// Start opens the configured TCP listener and serves until Stop is called or
+// the HTTP server fails. A failure is returned so the application stops its
+// other transports instead of leaving a partially running process.
+func (s *LifecycleServer) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("HTTP server already started")
+	}
+	if s.stopped {
+		s.mu.Unlock()
+		return nil
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	listener, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.server.Addr, err)
+	}
+
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		_ = listener.Close()
+		return nil
+	}
+	s.listener = listener
+	s.server.BaseContext = func(net.Listener) context.Context { return ctx }
+	s.mu.Unlock()
+
+	err = normalizeServeError(s.server.Serve(listener))
+	_ = listener.Close()
+	return err
+}
+
+// Stop gracefully drains the public listener. If the caller's deadline is
+// exceeded, active connections are force-closed so application shutdown stays
+// bounded.
+func (s *LifecycleServer) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	s.stopped = true
+	listener := s.listener
+	s.mu.Unlock()
+
+	if listener == nil {
+		return nil
+	}
+	if err := s.server.Shutdown(ctx); err != nil {
+		_ = s.server.Close()
+		_ = listener.Close()
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w", ErrShutdownTimeout)
+		}
+		return fmt.Errorf("shut down HTTP server: %w", err)
+	}
+	_ = listener.Close()
+	return nil
+}

--- a/server/internal/webentry/lifecycle_test.go
+++ b/server/internal/webentry/lifecycle_test.go
@@ -1,0 +1,176 @@
+package webentry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestLifecycleServerServesAndStops(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Address:        "127.0.0.1:0",
+		Handler:        http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, "ok") }),
+		RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	lifecycle, err := NewLifecycleServer(server)
+	if err != nil {
+		t.Fatalf("NewLifecycleServer: %v", err)
+	}
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- lifecycle.Start(context.Background())
+	}()
+
+	address := waitForLifecycleAddress(t, lifecycle)
+	response, err := http.Get("http://" + address)
+	if err != nil {
+		t.Fatalf("GET public server: %v", err)
+	}
+	defer closeResponseBody(t, response.Body)
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK || string(body) != "ok" {
+		t.Fatalf("response = {%d %q}, want {200 %q}", response.StatusCode, body, "ok")
+	}
+
+	if err := lifecycle.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := <-serveResult; err != nil {
+		t.Fatalf("Start returned: %v", err)
+	}
+}
+
+func TestLifecycleServerPropagatesListenFailure(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Address:        "invalid-address",
+		RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	lifecycle, err := NewLifecycleServer(server)
+	if err != nil {
+		t.Fatalf("NewLifecycleServer: %v", err)
+	}
+	if err := lifecycle.Start(context.Background()); err == nil {
+		t.Fatal("Start succeeded with an invalid listen address")
+	}
+}
+
+func TestLifecycleServerStopBeforeStartDoesNotOpenListener(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Address:        "invalid-address",
+		RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	lifecycle, err := NewLifecycleServer(server)
+	if err != nil {
+		t.Fatalf("NewLifecycleServer: %v", err)
+	}
+	if err := lifecycle.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := lifecycle.Start(context.Background()); err != nil {
+		t.Fatalf("Start after Stop: %v", err)
+	}
+}
+
+func TestLifecycleServerBoundsGracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server, err := NewHTTPServer(HTTPServerConfig{
+		Address: "127.0.0.1:0",
+		Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			close(requestStarted)
+			<-releaseRequest
+		}),
+		RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+	lifecycle, err := NewLifecycleServer(server)
+	if err != nil {
+		t.Fatalf("NewLifecycleServer: %v", err)
+	}
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- lifecycle.Start(context.Background())
+	}()
+
+	address := waitForLifecycleAddress(t, lifecycle)
+	clientResult := make(chan struct{})
+	go func() {
+		response, getErr := http.Get("http://" + address)
+		if getErr == nil {
+			_ = response.Body.Close()
+		}
+		close(clientResult)
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach server")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if err := lifecycle.Stop(ctx); !errors.Is(err, ErrShutdownTimeout) {
+		t.Fatalf("Stop error = %v, want ErrShutdownTimeout", err)
+	}
+	close(releaseRequest)
+	select {
+	case <-clientResult:
+	case <-time.After(time.Second):
+		t.Fatal("client did not return after forced close")
+	}
+	if err := <-serveResult; err != nil {
+		t.Fatalf("Start returned: %v", err)
+	}
+}
+
+func TestNewLifecycleServerRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewLifecycleServer(nil); err == nil {
+		t.Fatal("NewLifecycleServer accepted nil")
+	}
+	if _, err := NewLifecycleServer(&http.Server{}); err == nil {
+		t.Fatal("NewLifecycleServer accepted an empty listen address")
+	}
+}
+
+func waitForLifecycleAddress(t *testing.T, server *LifecycleServer) string {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		server.mu.Lock()
+		listener := server.listener
+		server.mu.Unlock()
+		if listener != nil {
+			return listener.Addr().String()
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("server did not open its listener")
+	return ""
+}

--- a/server/internal/webentry/server.go
+++ b/server/internal/webentry/server.go
@@ -21,29 +21,30 @@ const (
 // the configured graceful-shutdown window and were forcefully disconnected.
 var ErrShutdownTimeout = errors.New("graceful shutdown timed out")
 
-// HTTPServerConfig defines the bounded public HTTP server. ProxyTimeout is used
-// to keep the outer HTTP deadline longer than the upstream proxy deadline.
+// HTTPServerConfig defines the bounded public HTTP server. RequestTimeout is
+// used to keep the outer HTTP deadline longer than the application handler's
+// own deadline, whether that handler is a reverse proxy or an in-process API.
 type HTTPServerConfig struct {
-	Address      string
-	Handler      http.Handler
-	ProxyTimeout time.Duration
+	Address        string
+	Handler        http.Handler
+	RequestTimeout time.Duration
 }
 
 // NewHTTPServer constructs an HTTP server with explicit slow-client and idle
 // connection bounds. It does not open a listener.
 func NewHTTPServer(config HTTPServerConfig) (*http.Server, error) {
-	if config.ProxyTimeout <= 0 {
-		return nil, errors.New("proxy timeout must be positive")
+	if config.RequestTimeout <= 0 {
+		return nil, errors.New("request timeout must be positive")
 	}
 	const maxDuration = time.Duration(1<<63 - 1)
-	if config.ProxyTimeout > maxDuration-defaultReadTimeout-requestTimeoutMargin {
-		return nil, errors.New("proxy timeout is too large")
+	if config.RequestTimeout > maxDuration-defaultReadTimeout-requestTimeoutMargin {
+		return nil, errors.New("request timeout is too large")
 	}
 	handler := config.Handler
 	if handler == nil {
 		handler = http.NotFoundHandler()
 	}
-	writeTimeout := defaultReadTimeout + config.ProxyTimeout + requestTimeoutMargin
+	writeTimeout := defaultReadTimeout + config.RequestTimeout + requestTimeoutMargin
 	return &http.Server{
 		Addr:              config.Address,
 		Handler:           handler,

--- a/server/internal/webentry/server_test.go
+++ b/server/internal/webentry/server_test.go
@@ -14,9 +14,9 @@ func TestNewHTTPServerUsesBoundedTimeouts(t *testing.T) {
 	t.Parallel()
 
 	server, err := NewHTTPServer(HTTPServerConfig{
-		Address:      ":3000",
-		Handler:      http.NotFoundHandler(),
-		ProxyTimeout: 65 * time.Second,
+		Address:        ":3000",
+		Handler:        http.NotFoundHandler(),
+		RequestTimeout: 65 * time.Second,
 	})
 	if err != nil {
 		t.Fatalf("NewHTTPServer: %v", err)
@@ -44,8 +44,8 @@ func TestServeShutsDownGracefully(t *testing.T) {
 		_, _ = io.WriteString(w, "done")
 	})
 	server, err := NewHTTPServer(HTTPServerConfig{
-		Handler:      handler,
-		ProxyTimeout: time.Second,
+		Handler:        handler,
+		RequestTimeout: time.Second,
 	})
 	if err != nil {
 		t.Fatalf("NewHTTPServer: %v", err)
@@ -101,8 +101,8 @@ func TestServeBoundsGracefulShutdown(t *testing.T) {
 		<-releaseRequest
 	})
 	server, err := NewHTTPServer(HTTPServerConfig{
-		Handler:      handler,
-		ProxyTimeout: time.Second,
+		Handler:        handler,
+		RequestTimeout: time.Second,
 	})
 	if err != nil {
 		t.Fatalf("NewHTTPServer: %v", err)
@@ -143,7 +143,7 @@ func TestServeBoundsGracefulShutdown(t *testing.T) {
 	}
 }
 
-func TestNewHTTPServerRejectsInvalidProxyTimeout(t *testing.T) {
+func TestNewHTTPServerRejectsInvalidRequestTimeout(t *testing.T) {
 	t.Parallel()
 
 	if _, err := NewHTTPServer(HTTPServerConfig{}); err == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Adds the non-breaking application entry needed for the Chart 2.0 single-image
migration tracked in #209.

The new `cmd/hami-webui` runs the backend HTTP and gRPC servers, background
metrics collector, and Web listener in one Kratos lifecycle. The Web handler
invokes the existing Kratos HTTP server directly, so `/api/vgpu/v1/*` keeps the
same middleware and response semantics without a loopback proxy. Backend-only
`/metrics`, `/readyz`, and `/q` routes remain unavailable on the Web listener.

This does not change the current Chart, Dockerfiles, images, or `cmd/server`.
Chart 1.x therefore keeps its existing two-container runtime.

**Verification**:

- `make -C server verify`
- `go test -race ./...` in `server/`
- repeated lifecycle and direct-handler race tests
- Linux amd64 and arm64 cross-builds for `cmd/hami-webui`
- root `make verify`, including 10 Web-entry contract and 14 Chromium tests

The unified image and Chart contract will be separate changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Web UI server for serving the application and backend API.
  - Added configurable listener address, URL base path, request timeout, and frame-ancestor security policy.
  - Added direct API routing with backend-only routes kept private.
- **Bug Fixes**
  - Improved handling of missing routes and preservation of structured API 404 responses.
  - Added graceful shutdown with forced connection cleanup when shutdown times out.
- **Validation**
  - Added validation for invalid server settings and security policy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->