### PR TITLE
refactor(server): keep unified entry HTTP-only

### DIFF
--- a/server/cmd/hami-webui/main.go
+++ b/server/cmd/hami-webui/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/log"
-	"github.com/go-kratos/kratos/v2/transport/grpc"
 	kratoshttp "github.com/go-kratos/kratos/v2/transport/http"
 
 	_ "go.uber.org/automaxprocs"
@@ -161,7 +160,6 @@ func backendRequestTimeout(bootstrap *conf.Bootstrap) time.Duration {
 func newApp(
 	ctx context.Context,
 	logger log.Logger,
-	gs *grpc.Server,
 	hs *kratoshttp.Server,
 	mc *exporter.MetricsGenerator,
 	ws *webentry.LifecycleServer,
@@ -173,7 +171,7 @@ func newApp(
 		kratos.Version(Version),
 		kratos.Metadata(map[string]string{}),
 		kratos.Logger(logger),
-		kratos.Server(gs, hs, mc, ws),
+		kratos.Server(hs, mc, ws),
 	)
 }
 

--- a/server/cmd/hami-webui/wire.go
+++ b/server/cmd/hami-webui/wire.go
@@ -22,7 +22,7 @@ func initApp(configPath string, web webConfig, ctx context.Context) (*kratos.App
 		internal.ProviderSet,
 		data.ProviderSet,
 		biz.ProviderSet,
-		server.ProviderSet,
+		server.NewHTTPServer,
 		service.ProviderSet,
 		exporter.ProviderSet,
 		newWebServer,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Keeps the new, unreleased `hami-webui` command limited to its two supported HTTP listeners. The gRPC server has no repository client, container port, Service, Ingress, or documented consumer, so starting it only exposed an unused Pod-IP socket.

The released `server` command and Chart 1.x gRPC configuration are unchanged.

**Verification:**

- `make -C server verify`
- root `make verify`
- Wire regeneration contains no gRPC provider for `cmd/hami-webui`
- independent repository consumer and compatibility review
