### PR TITLE
build: add unified HAMi-WebUI image target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,38 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  unified-image-changes:
+    name: Detect unified image changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      unified: ${{ steps.filter.outputs.unified == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            unified:
+              - '.browserslistrc'
+              - '.dockerignore'
+              - '.github/workflows/ci.yaml'
+              - 'Dockerfile'
+              - 'Makefile'
+              - 'package.json'
+              - 'packages/web/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'scripts/precompress-web-assets.mjs'
+              - 'server/**'
+              - 'test/unified-image/**'
+
   validate-images:
     name: Build ${{ matrix.name }} image
     if: github.event_name == 'pull_request'
@@ -146,12 +172,105 @@ jobs:
           docker stop --time 5 "${container}" >/dev/null
           [[ "$(docker inspect --format '{{.State.ExitCode}}' "${container}")" == "0" ]]
 
+  unified-runtime-smoke:
+    name: Smoke unified image runtime
+    if: needs.unified-image-changes.outputs.unified == 'true'
+    needs: unified-image-changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build unified image (amd64)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: unified
+          platforms: linux/amd64
+          load: true
+          tags: hami-webui:unified-runtime-smoke-amd64
+          cache-from: type=gha,scope=unified-runtime
+          cache-to: type=gha,mode=max,scope=unified-runtime
+
+      - name: Build unified image (arm64)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: unified
+          platforms: linux/arm64
+          load: true
+          tags: hami-webui:unified-runtime-smoke-arm64
+          cache-from: type=gha,scope=unified-runtime
+          cache-to: type=gha,mode=max,scope=unified-runtime
+
+      - name: Start pinned Kubernetes API
+        shell: bash
+        run: |
+          set -euo pipefail
+          kind_version=v0.27.0
+          kind_sha256=a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b
+          kind_bin="${RUNNER_TEMP}/bin/kind"
+          mkdir -p "$(dirname "${kind_bin}")"
+          curl --fail --silent --show-error --location \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64" \
+            --output "${kind_bin}"
+          echo "${kind_sha256}  ${kind_bin}" | sha256sum --check
+          chmod 0755 "${kind_bin}"
+          dirname "${kind_bin}" >>"${GITHUB_PATH}"
+
+          "${kind_bin}" create cluster \
+            --name hami-webui-unified-smoke \
+            --image kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507 \
+            --wait 120s
+          "${kind_bin}" get kubeconfig \
+            --name hami-webui-unified-smoke \
+            --internal >"${RUNNER_TEMP}/hami-webui-unified-smoke.kubeconfig"
+          chmod 0600 "${RUNNER_TEMP}/hami-webui-unified-smoke.kubeconfig"
+
+      - name: Test amd64 runtime
+        run: |
+          test/unified-image/runtime-smoke.sh \
+            hami-webui:unified-runtime-smoke-amd64 \
+            linux/amd64 \
+            kind \
+            "${RUNNER_TEMP}/hami-webui-unified-smoke.kubeconfig"
+
+      - name: Test arm64 runtime
+        run: |
+          test/unified-image/runtime-smoke.sh \
+            hami-webui:unified-runtime-smoke-arm64 \
+            linux/arm64 \
+            kind \
+            "${RUNNER_TEMP}/hami-webui-unified-smoke.kubeconfig"
+
+      - name: Delete smoke cluster
+        if: always()
+        shell: bash
+        run: |
+          if [[ -x "${RUNNER_TEMP}/bin/kind" ]]; then
+            "${RUNNER_TEMP}/bin/kind" delete cluster --name hami-webui-unified-smoke
+          fi
+
   pr-images-required:
     name: pr-images-required
     if: github.event_name == 'pull_request' && always()
     needs:
+      - unified-image-changes
       - validate-images
       - frontend-runtime-smoke
+      - unified-runtime-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate image build results
@@ -162,6 +281,15 @@ jobs:
           fi
           if [[ "${{ needs.frontend-runtime-smoke.result }}" != "success" ]]; then
             echo "Frontend runtime smoke did not complete successfully: ${{ needs.frontend-runtime-smoke.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.unified-image-changes.result }}" != "success" ]]; then
+            echo "Unified image change detection did not complete successfully: ${{ needs.unified-image-changes.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.unified-image-changes.outputs.unified }}" == "true" && \
+                "${{ needs.unified-runtime-smoke.result }}" != "success" ]]; then
+            echo "Unified image runtime smoke did not complete successfully: ${{ needs.unified-runtime-smoke.result }}"
             exit 1
           fi
           echo "All image builds passed."

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,11 @@ RUN pnpm --filter hami-webui-web run build
 # these siblings when the client advertises gzip support.
 RUN pnpm run precompress:web-assets
 
-FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:e8c859f5632dcfde7b32d2012b4351728f6437930887c2f6a91ea242459e5514 AS web-entry-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:e8c859f5632dcfde7b32d2012b4351728f6437930887c2f6a91ea242459e5514 AS go-base
 
 WORKDIR /src/server
+
+FROM go-base AS web-entry-builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH
@@ -39,7 +41,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOTOOLCHAIN=local \
     go build -mod=readonly -trimpath -o /out/web-entry ./cmd/web-entry
 
-FROM scratch
+FROM scratch AS frontend-runtime
 
 WORKDIR /apps
 
@@ -58,3 +60,69 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD ["/apps/web-entry", "--healthcheck"]
 
 ENTRYPOINT ["/apps/web-entry"]
+
+FROM go-base AS unified-builder
+
+ARG BUILDARCH
+ARG TARGETARCH
+ARG PROTOC_VERSION=28.3
+ARG PROTOC_SHA256_AMD64=0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f
+ARG PROTOC_SHA256_ARM64=1de522032a8b194002fe35cab86d747848238b5e4de4f99648372079f5b46f9a
+ARG DEBIAN_SNAPSHOT=20260824T000000Z
+ARG UNZIP_VERSION=6.0-28
+
+# Match the pinned backend toolchain while the released backend image remains
+# independently buildable from server/Dockerfile.
+RUN sed -i -E \
+      -e "s|https?://deb.debian.org/debian-security|https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}|g" \
+      -e "s|https?://deb.debian.org/debian|https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}|g" \
+    /etc/apt/sources.list.d/debian.sources && \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get install -y --no-install-recommends "unzip=${UNZIP_VERSION}" && \
+    test -s /etc/ssl/certs/ca-certificates.crt && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN case "${BUILDARCH}" in \
+      amd64) protoc_arch="x86_64"; protoc_sha="${PROTOC_SHA256_AMD64}" ;; \
+      arm64) protoc_arch="aarch_64"; protoc_sha="${PROTOC_SHA256_ARM64}" ;; \
+      *) echo "unsupported build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSLo /tmp/protoc.zip \
+      "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip" && \
+    echo "${protoc_sha}  /tmp/protoc.zip" | sha256sum -c - && \
+    unzip -q /tmp/protoc.zip -d /usr/local && \
+    rm /tmp/protoc.zip
+
+COPY server/Makefile ./
+RUN make install-deps
+
+COPY server/go.mod server/go.sum ./
+RUN go mod download
+
+COPY server/ ./
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    make generate verify-mod build-linux TARGET_ARCH=${TARGETARCH} DIRS=hami-webui
+
+FROM scratch AS unified
+
+WORKDIR /apps
+
+COPY --from=unified-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=unified-builder /usr/share/zoneinfo/ /usr/share/zoneinfo/
+COPY --from=unified-builder --chown=65532:65532 /src/server/build/hami-webui /apps/hami-webui
+COPY --from=web-builder --chown=65532:65532 /src/public/ /apps/public/
+
+USER 65532:65532
+
+EXPOSE 3000 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/apps/hami-webui", "--healthcheck"]
+
+ENTRYPOINT ["/apps/hami-webui"]
+CMD ["--conf", "/apps/config/config.yaml"]
+
+# Keep the released frontend image as the implicit Docker build target until
+# the Chart and release controller migrate atomically in their own PRs.
+FROM frontend-runtime AS frontend

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PNPM ?= pnpm
 DOCKER ?= docker
 DOCKER_IMAGE ?= hami-webui-frontend
+UNIFIED_DOCKER_IMAGE ?= hami-webui
 VERSION ?= dev
 PLATFORM ?=
 DOCKER_PLATFORM_FLAG := $(if $(strip $(PLATFORM)),--platform $(PLATFORM),)
@@ -20,6 +21,7 @@ help:
 		'  make build-web-entry        Build the production Go Web entry' \
 		'  make verify                 Run all frontend and Web-entry checks' \
 		'  make build-image            Build a local frontend image' \
+		'  make build-unified-image    Build the candidate single-process image' \
 		'' \
 		'Use PLATFORM=linux/amd64 (or linux/arm64) for an explicit image platform.'
 
@@ -71,3 +73,9 @@ verify: lint test verify-vite-env build build-web-entry
 .PHONY: build-image
 build-image:
 	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) -t $(DOCKER_IMAGE):$(VERSION) .
+
+# The unified image remains an explicit development target until the Chart and
+# release controller migrate to the single-image contract.
+.PHONY: build-unified-image
+build-unified-image:
+	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) --target unified -t $(UNIFIED_DOCKER_IMAGE):$(VERSION) .

--- a/server/cmd/hami-webui/main.go
+++ b/server/cmd/hami-webui/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -30,6 +31,8 @@ const (
 	defaultStaticDir        = "/apps/public"
 	defaultBasePath         = "/"
 	defaultFrameAncestors   = "null"
+	defaultHealthcheckURL   = "http://127.0.0.1:3000/health_check"
+	healthcheckTimeout      = 3 * time.Second
 	defaultRequestTimeout   = 60 * time.Second
 )
 
@@ -50,8 +53,10 @@ type webConfig struct {
 }
 
 type options struct {
-	configPath string
-	web        webConfig
+	configPath     string
+	web            webConfig
+	healthcheck    bool
+	healthcheckURL string
 }
 
 func main() {
@@ -65,6 +70,9 @@ func run(args []string, lookupEnv func(string) (string, bool)) error {
 	config, err := parseOptions(args, lookupEnv)
 	if err != nil {
 		return fmt.Errorf("invalid command-line options: %w", err)
+	}
+	if config.healthcheck {
+		return performHealthcheck(config.healthcheckURL)
 	}
 	ctx := context.Background()
 	app, cleanup, err := initApp(config.configPath, config.web, ctx)
@@ -88,6 +96,8 @@ func parseOptions(args []string, lookupEnv func(string) (string, bool)) (options
 	flags.StringVar(&config.web.staticDir, "static-dir", envOrDefault(lookupEnv, "HAMI_WEBUI_STATIC_DIR", defaultStaticDir), "SPA static directory")
 	flags.StringVar(&config.web.basePath, "base-path", envOrDefault(lookupEnv, "HAMI_WEBUI_BASE_PATH", defaultBasePath), "external URL base path")
 	flags.StringVar(&frameAncestorsJSON, "frame-ancestors-json", envOrDefault(lookupEnv, "HAMI_WEBUI_FRAME_ANCESTORS_JSON", defaultFrameAncestors), "JSON array of allowed iframe ancestors, [] to deny all, or null to omit")
+	flags.BoolVar(&config.healthcheck, "healthcheck", false, "check the running Web entry and exit")
+	flags.StringVar(&config.healthcheckURL, "healthcheck-url", envOrDefault(lookupEnv, "HAMI_WEBUI_HEALTHCHECK_URL", defaultHealthcheckURL), "health-check URL")
 	if err := flags.Parse(args); err != nil {
 		return options{}, err
 	}
@@ -98,6 +108,35 @@ func parseOptions(args []string, lookupEnv func(string) (string, bool)) (options
 		return options{}, errors.New("frame ancestors must be null or a JSON array of allowed sources")
 	}
 	return config, nil
+}
+
+func performHealthcheck(rawURL string) error {
+	target, err := url.Parse(rawURL)
+	if err != nil || target.Host == "" || (target.Scheme != "http" && target.Scheme != "https") || target.User != nil || target.Fragment != "" {
+		return errors.New("health check configuration is invalid")
+	}
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target.String(), nil)
+	if err != nil {
+		return errors.New("health check configuration is invalid")
+	}
+	client := &http.Client{
+		Timeout: healthcheckTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return errors.New("HAMi-WebUI health check failed")
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4<<10))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return errors.New("HAMi-WebUI health check returned a non-success status")
+	}
+	return nil
 }
 
 func envOrDefault(lookupEnv func(string) (string, bool), key, fallback string) string {

--- a/server/cmd/hami-webui/main_test.go
+++ b/server/cmd/hami-webui/main_test.go
@@ -29,7 +29,9 @@ func TestParseOptionsUsesDocumentedDefaults(t *testing.T) {
 		config.web.listenAddress != defaultWebListenAddress ||
 		config.web.staticDir != defaultStaticDir ||
 		config.web.basePath != defaultBasePath ||
-		config.web.frameAncestors != nil {
+		config.web.frameAncestors != nil ||
+		config.healthcheck ||
+		config.healthcheckURL != defaultHealthcheckURL {
 		t.Fatalf("defaults = %+v", config)
 	}
 }
@@ -42,6 +44,7 @@ func TestParseOptionsFlagsOverrideEnvironment(t *testing.T) {
 		"HAMI_WEBUI_STATIC_DIR":           "/env/public",
 		"HAMI_WEBUI_BASE_PATH":            "/env-ui/",
 		"HAMI_WEBUI_FRAME_ANCESTORS_JSON": `[]`,
+		"HAMI_WEBUI_HEALTHCHECK_URL":      "http://health-from-env/health_check",
 	}
 	lookup := func(key string) (string, bool) {
 		value, ok := environment[key]
@@ -53,6 +56,8 @@ func TestParseOptionsFlagsOverrideEnvironment(t *testing.T) {
 		"--static-dir=/flag/public",
 		"--base-path=/flag-ui/",
 		`--frame-ancestors-json=["'self'"]`,
+		"--healthcheck",
+		"--healthcheck-url=http://health-from-flag/health_check",
 	}, lookup)
 	if err != nil {
 		t.Fatalf("parseOptions: %v", err)
@@ -63,6 +68,66 @@ func TestParseOptionsFlagsOverrideEnvironment(t *testing.T) {
 		config.web.basePath != "/flag-ui/" ||
 		len(config.web.frameAncestors) != 1 || config.web.frameAncestors[0] != "'self'" {
 		t.Fatalf("flags did not override environment: %+v", config)
+	}
+	if !config.healthcheck || config.healthcheckURL != "http://health-from-flag/health_check" {
+		t.Fatalf("health-check flags did not override environment: %+v", config)
+	}
+}
+
+func TestPerformHealthcheckRequiresSuccessStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "success", status: http.StatusNoContent},
+		{name: "redirect", status: http.StatusFound, wantErr: true},
+		{name: "client error", status: http.StatusNotFound, wantErr: true},
+		{name: "server error", status: http.StatusServiceUnavailable, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+			if err := performHealthcheck(server.URL); (err != nil) != tt.wantErr {
+				t.Fatalf("performHealthcheck error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHealthcheckModeDoesNotInitializeApplication(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	lookup := func(key string) (string, bool) {
+		if key == "HAMI_WEBUI_HEALTHCHECK_URL" {
+			return server.URL, true
+		}
+		return "", false
+	}
+	if err := run([]string{"--healthcheck", "--conf=/does/not/exist"}, lookup); err != nil {
+		t.Fatalf("health check initialized application dependencies: %v", err)
+	}
+}
+
+func TestHealthcheckRejectsCredentialsWithoutExposingThem(t *testing.T) {
+	t.Parallel()
+
+	const secret = "do-not-print-this"
+	err := performHealthcheck("http://user:" + secret + "@backend/health_check")
+	if err == nil {
+		t.Fatal("performHealthcheck accepted credentials")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("health-check error exposed URL credentials")
 	}
 }
 

--- a/test/unified-image/runtime-smoke.sh
+++ b/test/unified-image/runtime-smoke.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 IMAGE PLATFORM DOCKER_NETWORK KUBECONFIG" >&2
+  exit 2
+fi
+
+image=$1
+platform=$2
+network=$3
+kubeconfig=$4
+expected_arch=${platform##*/}
+
+for command in curl docker node; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "required command is unavailable: ${command}" >&2
+    exit 2
+  fi
+done
+
+if [[ ! -r "${kubeconfig}" ]]; then
+  echo "kubeconfig is not readable: ${kubeconfig}" >&2
+  exit 2
+fi
+
+workdir=$(mktemp -d)
+container="hami-webui-unified-smoke-${expected_arch}-${RANDOM}"
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if docker container inspect "${container}" >/dev/null 2>&1; then
+    if [[ ${status} -ne 0 ]]; then
+      docker logs "${container}" >&2
+    fi
+    docker rm --force "${container}" >/dev/null 2>&1
+  fi
+  rm -rf "${workdir}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+cat >"${workdir}/config.yaml" <<'EOF'
+server:
+  http:
+    addr: 0.0.0.0:8000
+    timeout: 60s
+prometheus:
+  # No devices match the smoke-test selectors, so the collector must remain
+  # healthy without depending on an upstream Prometheus process.
+  address: http://127.0.0.1:9
+  timeout: 1s
+exporter:
+  interval: 3600s
+  timeout: 1s
+node_selectors:
+  NVIDIA: hami-webui-smoke-nvidia=true
+  Ascend: hami-webui-smoke-ascend=true
+  DCU: hami-webui-smoke-dcu=true
+  MLU: hami-webui-smoke-mlu=true
+  Metax: hami-webui-smoke-metax=true
+EOF
+cp "${kubeconfig}" "${workdir}/kubeconfig"
+chmod 0444 "${workdir}/config.yaml" "${workdir}/kubeconfig"
+
+inspect() {
+  docker image inspect --format "$1" "${image}"
+}
+
+[[ "$(inspect '{{.Architecture}}')" == "${expected_arch}" ]]
+[[ "$(inspect '{{.Config.User}}')" == "65532:65532" ]]
+[[ "$(inspect '{{json .Config.Entrypoint}}')" == '["/apps/hami-webui"]' ]]
+[[ "$(inspect '{{json .Config.Cmd}}')" == '["--conf","/apps/config/config.yaml"]' ]]
+[[ "$(inspect '{{json .Config.Healthcheck.Test}}')" == '["CMD","/apps/hami-webui","--healthcheck"]' ]]
+
+docker run --detach \
+  --platform "${platform}" \
+  --name "${container}" \
+  --network "${network}" \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --env KUBECONFIG=/apps/smoke/kubeconfig \
+  --env HAMI_WEBUI_BASE_PATH=/gpu-ui/ \
+  --env "HAMI_WEBUI_FRAME_ANCESTORS_JSON=[\"'self'\",\"https://portal.example.com\"]" \
+  --mount "type=bind,src=${workdir}/config.yaml,dst=/apps/config/config.yaml,readonly" \
+  --mount "type=bind,src=${workdir}/kubeconfig,dst=/apps/smoke/kubeconfig,readonly" \
+  --publish 127.0.0.1::3000 \
+  --publish 127.0.0.1::8000 \
+  "${image}" >/dev/null
+
+published_port() {
+  docker port "${container}" "$1/tcp" | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1
+}
+
+public_port=$(published_port 3000)
+backend_port=$(published_port 8000)
+curl_local=(curl --noproxy '*' --connect-timeout 3 --max-time 15)
+curl_probe=(curl --noproxy '*' --connect-timeout 1 --max-time 2)
+
+for _ in {1..45}; do
+  if "${curl_probe[@]}" --fail --silent --show-error "http://127.0.0.1:${public_port}/health_check" >/dev/null; then
+    break
+  fi
+  if [[ "$(docker inspect --format '{{.State.Running}}' "${container}")" != "true" ]]; then
+    echo "unified container exited before becoming ready" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+"${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${public_port}/health_check" >/dev/null
+"${curl_local[@]}" --fail --silent --show-error \
+  --output "${workdir}/index.html" \
+  "http://127.0.0.1:${public_port}/gpu-ui/"
+grep -Fq '<base data-hami-webui-base href="/gpu-ui/">' "${workdir}/index.html"
+"${curl_local[@]}" --silent --show-error --head \
+  --output "${workdir}/headers" \
+  "http://127.0.0.1:${public_port}/gpu-ui/"
+tr -d '\r' <"${workdir}/headers" >"${workdir}/headers.normalized"
+grep -Fq "Content-Security-Policy: frame-ancestors 'self' https://portal.example.com" \
+  "${workdir}/headers.normalized"
+
+api_response="${workdir}/nodes.json"
+api_status=$("${curl_local[@]}" --silent --show-error \
+  --header 'Content-Type: application/json' \
+  --data '{"filters":{}}' \
+  --output "${api_response}" \
+  --write-out '%{http_code}' \
+  "http://127.0.0.1:${public_port}/gpu-ui/api/vgpu/v1/nodes")
+[[ "${api_status}" == "200" ]]
+node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${api_response}"
+
+for private_path in /gpu-ui/metrics /gpu-ui/readyz; do
+  [[ "$("${curl_local[@]}" --silent --output /dev/null --write-out '%{http_code}' \
+    "http://127.0.0.1:${public_port}${private_path}")" == "404" ]]
+done
+
+"${curl_local[@]}" --fail --silent --show-error \
+  --output "${workdir}/readyz" \
+  "http://127.0.0.1:${backend_port}/readyz"
+grep -Fq 'ok' "${workdir}/readyz"
+"${curl_local[@]}" --fail --silent --show-error \
+  --output "${workdir}/metrics" \
+  "http://127.0.0.1:${backend_port}/metrics"
+grep -Fq '# HELP' "${workdir}/metrics"
+
+docker exec "${container}" /apps/hami-webui --healthcheck
+mkdir "${workdir}/public"
+docker cp "${container}:/etc/ssl/certs/ca-certificates.crt" "${workdir}/ca-certificates.crt" >/dev/null
+docker cp "${container}:/usr/share/zoneinfo/Etc/UTC" "${workdir}/UTC" >/dev/null
+docker cp "${container}:/apps/public/." "${workdir}/public" >/dev/null
+[[ -s "${workdir}/ca-certificates.crt" ]]
+[[ -s "${workdir}/UTC" ]]
+[[ -s "${workdir}/public/index.html" ]]
+find "${workdir}/public/static" -type f -name '*.gz' -print -quit | grep -q .
+
+docker stop --time 15 "${container}" >/dev/null
+[[ "$(docker inspect --format '{{.State.ExitCode}}' "${container}")" == "0" ]]
+docker rm "${container}" >/dev/null
+container=""
+
+echo "Unified runtime smoke passed for ${platform}."


### PR DESCRIPTION
/kind feature

## What

- add an explicit `unified` Docker target containing the Go application and built Web assets;
- add an image-local health check that does not initialize Kubernetes or Prometheus clients;
- validate amd64 and arm64 images against a pinned Kind API, including the public/API contract, admin isolation, non-root read-only execution, and graceful shutdown.

The implicit Docker target remains the existing frontend image. Chart 1.x and the release controller are unchanged; their single-image migration stays in separate PRs.

## Verification

- `make verify`
- `make -C server verify`
- `actionlint` 1.7.7 and ShellCheck
- local runtime smoke on `linux/amd64` and `linux/arm64`

Progresses #209.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified container image bundling the WebUI backend and frontend assets.
  * Added configurable health-check mode with endpoint validation, timeout protection, and secure URL handling.
  * Added a build target for creating the unified image.

* **Bug Fixes**
  * Improved container health and runtime validation across supported architectures.
  * Strengthened runtime security with read-only filesystem support, dropped capabilities, and no-new-privileges enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->