### PR TITLE
build: unify image publication contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,23 +294,13 @@ jobs:
           fi
           echo "All image builds passed."
 
-  publish-development-images:
-    name: Publish ${{ matrix.name }} development image
+  publish-development-image:
+    name: Publish unified development image
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: frontend
-            context: .
-            repository: hami-webui-fe-oss
-          - name: backend
-            context: ./server
-            repository: hami-webui-be-oss
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -336,11 +326,15 @@ jobs:
       - name: Build and push development image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
+          context: .
+          target: unified
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            projecthami/${{ matrix.repository }}:main
-            ghcr.io/project-hami/${{ matrix.repository }}:main
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+            projecthami/hami-webui:main
+            ghcr.io/project-hami/hami-webui:main
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=unified-development
+          cache-to: type=gha,mode=max,scope=unified-development

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,6 +153,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      packages: read
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
       candidate_tag: ${{ steps.source.outputs.candidate_tag }}
@@ -184,8 +185,15 @@ jobs:
             echo "candidate_tag=${candidate_tag}"
           } >>"${GITHUB_OUTPUT}"
 
+      - name: Require public unified image repositories
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/release/verify-image-publication-targets.sh \
+            "${GITHUB_REPOSITORY}"
+
   candidate-images:
-    name: Build ${{ matrix.component }} candidate once
+    name: Build unified candidate once
     if: inputs.phase == 'candidate'
     needs: candidate-preflight
     runs-on: ubuntu-24.04
@@ -193,18 +201,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - component: frontend
-            context: .
-            dockerhub_repository: projecthami/hami-webui-fe-oss
-            ghcr_repository: ghcr.io/project-hami/hami-webui-fe-oss
-          - component: backend
-            context: ./server
-            dockerhub_repository: projecthami/hami-webui-be-oss
-            ghcr_repository: ghcr.io/project-hami/hami-webui-be-oss
     steps:
       - name: Checkout candidate source without persisted credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -240,35 +236,36 @@ jobs:
       - name: Build once and push unique candidate references
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
+          context: .
+          target: unified
           platforms: linux/amd64,linux/arm64
           push: true
           provenance: mode=max
           sbom: true
           tags: |
-            ${{ matrix.dockerhub_repository }}:${{ needs.candidate-preflight.outputs.candidate_tag }}
-            ${{ matrix.ghcr_repository }}:${{ needs.candidate-preflight.outputs.candidate_tag }}
+            projecthami/hami-webui:${{ needs.candidate-preflight.outputs.candidate_tag }}
+            ghcr.io/project-hami/hami-webui:${{ needs.candidate-preflight.outputs.candidate_tag }}
           labels: |
             org.opencontainers.image.revision=${{ needs.candidate-preflight.outputs.source_sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          cache-from: type=gha,scope=stable-${{ matrix.component }}
-          cache-to: type=gha,mode=max,scope=stable-${{ matrix.component }}
+          cache-from: type=gha,scope=stable-webui
+          cache-to: type=gha,mode=max,scope=stable-webui
 
       - name: Record both registry digests
         run: |
           bash scripts/release/record-candidate-image.sh \
-            "${{ matrix.component }}" \
+            webui \
             "${{ needs.candidate-preflight.outputs.source_sha }}" \
             "${{ needs.candidate-preflight.outputs.candidate_tag }}" \
-            "${{ matrix.dockerhub_repository }}" \
-            "${{ matrix.ghcr_repository }}" \
-            "candidate-metadata/${{ matrix.component }}.json"
+            projecthami/hami-webui \
+            ghcr.io/project-hami/hami-webui \
+            candidate-metadata/webui.json
 
       - name: Upload image metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: release-candidate-part-${{ github.run_id }}-${{ matrix.component }}
-          path: candidate-metadata/${{ matrix.component }}.json
+          name: release-candidate-part-${{ github.run_id }}-webui
+          path: candidate-metadata/webui.json
           if-no-files-found: error
           retention-days: 2
 
@@ -325,7 +322,7 @@ jobs:
             echo
             echo "Candidate run ID: \`${GITHUB_RUN_ID}\`"
             echo "Source: \`${{ needs.candidate-preflight.outputs.source_sha }}\`"
-            echo "Use this run ID only after a release-metadata PR locks the four recorded digests."
+            echo "Use this run ID only after a release-metadata PR locks the two recorded registry digests."
           } >>"${GITHUB_STEP_SUMMARY}"
 
   prepare-release:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,12 +10,17 @@ publishing: the protected `release` environment must exist and its
 `STABLE_RELEASES_ENABLED` variable must be set to `true` after the repository,
 registry, and release acceptance gates below are configured.
 
+The unified image contract lands before the Chart 2 migration by design. Until
+that follow-up changes the production chart from `image.frontend` and
+`image.backend` to the single `image` value, release-contract verification
+fails closed and no stable release can be published.
+
 ## What “atomic” means here
 
 Docker Hub, GHCR, GitHub Pages, and GitHub Releases do not share a transaction.
 The controller therefore makes an ordered, resumable release:
 
-1. build each multi-platform image once and address it by digest;
+1. build the multi-platform `webui` image once and address it by digest;
 2. package the chart once and preserve that exact archive;
 3. test that archive against the release issue acceptance matrix while the
    `release` environment is waiting;
@@ -49,8 +54,8 @@ For stable version `X.Y.Z`:
 | Git tag and GitHub Release | `vX.Y.Z` |
 | `Chart.yaml` `version` | `X.Y.Z` |
 | `Chart.yaml` `appVersion` | `X.Y.Z` |
-| both default image tags | `vX.Y.Z` |
-| both default image digests | candidate Docker Hub manifest digests |
+| default `webui` image tag | `vX.Y.Z` |
+| default `webui` image digest | candidate Docker Hub manifest digest |
 | chart package | `hami-webui-X.Y.Z.tgz` |
 
 Only `vX.Y.Z` is created. Do not create a second `hami-webui-X.Y.Z` tag or
@@ -59,7 +64,7 @@ stable tag remains a human-readable alias and must resolve to that same digest.
 Docker Hub and GHCR digests are recorded separately and are not assumed to be
 equal.
 
-## Phase 1: candidate images
+## Phase 1: candidate image
 
 Run **Verified Stable Release** with:
 
@@ -67,7 +72,7 @@ Run **Verified Stable Release** with:
 - `source_sha`: the full, current `main` commit SHA
 
 The workflow refuses a branch, abbreviated SHA, stale `main`, or fork. It builds
-the frontend and backend once for `linux/amd64` and `linux/arm64`, pushing only a
+the unified `webui` image for `linux/amd64` and `linux/arm64`, pushing only a
 unique candidate tag:
 
 ```text
@@ -78,7 +83,7 @@ Both Docker Hub and GHCR manifest digests are sealed into the
 `release-candidate-<run-id>` artifact. Keep that run ID.
 
 Create a small release-metadata PR that sets the next Chart version,
-`appVersion`, default tags, and the two Docker Hub digests from the candidate.
+`appVersion`, default image tag, and Docker Hub digest from the candidate.
 After the candidate source, only these paths may change:
 
 - `charts/hami-webui/Chart.yaml`
@@ -89,8 +94,8 @@ After the candidate source, only these paths may change:
 
 Any application, build, dependency, workflow, or template change invalidates
 the candidate; build a new one instead. Within `Chart.yaml`, only `version` and
-`appVersion` may differ. Within `values.yaml`, only the frontend/backend `tag`
-and `digest` fields may differ; the controller compares the remaining YAML
+`appVersion` may differ. Within `values.yaml`, only the `image.tag` and
+`image.digest` fields may differ; the controller compares the remaining YAML
 structure to the candidate commit.
 
 ## Phase 2: canonical chart and protected publication
@@ -144,9 +149,10 @@ verification.
 After approval the controller:
 
 1. re-verifies the canonical bundle hashes and performs a read-only preflight
-   of all four image tags, the public and repository-linked OCI package/version,
-   workflow-built Pages site/package/index, Git tag, GitHub Release, and Release
-   assets; every stable object must be absent or an exact match;
+   of both registry image tags, the public and repository-linked OCI
+   package/version, workflow-built Pages site/package/index, Git tag, GitHub
+   Release, and Release assets; every stable object must be absent or an exact
+   match;
 2. creates or reuses a private GitHub draft targeting the verified commit and
    attaches the same archive, checksum, and manifest;
 3. create-only reserves `vX.Y.Z` at the verified commit; a retry accepts that
@@ -176,6 +182,16 @@ test.
 
 Before setting `STABLE_RELEASES_ENABLED=true`:
 
+- let the first `main` publication create `projecthami/hami-webui`; Docker Hub
+  [creates a missing destination on first push](https://docs.docker.com/docker-hub/repos/manage/hub-images/bulk-migrate/)
+  when the authenticated account has permission. If creation is denied, create
+  the public repository manually and re-run that failed job;
+- let the same publication create `ghcr.io/project-hami/hami-webui`, then make
+  that package public, confirm it is linked to this repository, and verify that
+  `:main` is anonymously pullable;
+- keep both image packages public. Candidate and stable phases independently
+  verify registry visibility and repository linkage and must not bypass this
+  gate;
 - observe the `pr-release-required` check on this controller PR, add that exact
   aggregate context to `main` protection, and require it before merging future
   controller changes;
@@ -199,7 +215,6 @@ Before setting `STABLE_RELEASES_ENABLED=true`:
   `DOCKERHUB_TOKEN` (username) and `DOCKERHUB_PASSWD` (access token/password);
 - allow the workflow's `GITHUB_TOKEN` `contents:write`, `packages:write`, and
   `actions:read` only in the jobs that declare them;
-- keep Docker Hub and GHCR image packages public;
 - run this workflow once with `phase=bootstrap-oci`. Its protected job publishes
   one `0.0.0-bootstrap.<run-id>` package from a retained artifact and then
   intentionally requires an anonymous pull. A first run may stop because GitHub

--- a/scripts/release/preflight-publication.sh
+++ b/scripts/release/preflight-publication.sh
@@ -29,6 +29,10 @@ release_validate_commit "${release_sha}"
 [[ "$(release_sha256_file "${chart_path}")" == "${chart_sha}" ]] || \
   release_die "canonical chart changed before destination preflight"
 
+# Stable publication requires both application-image destinations to remain
+# publicly readable, and the GHCR package to stay linked to this repository.
+bash "${script_dir}/verify-image-publication-targets.sh" "${repository}"
+
 # The first OCI push would create a private package by default. Require the
 # package to be bootstrapped, public, and linked to this repository before any
 # stable image or chart destination is touched.

--- a/scripts/release/record-candidate-image.sh
+++ b/scripts/release/record-candidate-image.sh
@@ -14,7 +14,7 @@ ghcr_repository="${5:?GHCR repository is required}"
 output_path="${6:?output path is required}"
 
 release_validate_commit "${source_sha}"
-[[ "${component}" == "frontend" || "${component}" == "backend" ]] || \
+[[ "${component}" == "webui" ]] || \
   release_die "unexpected image component: ${component}"
 [[ "${candidate_tag}" == candidate-* ]] || release_die "candidate tag must start with candidate-"
 

--- a/scripts/release/seal-candidate-manifest.sh
+++ b/scripts/release/seal-candidate-manifest.sh
@@ -21,10 +21,10 @@ release_validate_commit "${source_sha}"
 expected_tag="candidate-${source_sha:0:12}-${run_id}-${run_attempt}"
 [[ "${candidate_tag}" == "${expected_tag}" ]] || \
   release_die "candidate tag does not bind the source, run, and attempt"
-[[ -f "${parts_dir}/frontend.json" && -f "${parts_dir}/backend.json" ]] || \
-  release_die "frontend and backend candidate metadata are both required"
-[[ "$(find "${parts_dir}" -maxdepth 1 -name '*.json' -type f | wc -l | tr -d ' ')" == "2" ]] || \
-  release_die "candidate metadata must contain exactly two JSON parts"
+[[ -f "${parts_dir}/webui.json" ]] || \
+  release_die "unified webui candidate metadata is required"
+[[ "$(find "${parts_dir}" -maxdepth 1 -name '*.json' -type f | wc -l | tr -d ' ')" == "1" ]] || \
+  release_die "candidate metadata must contain exactly one JSON part"
 
 jq -e -s \
   --arg repository "${repository}" \
@@ -32,13 +32,13 @@ jq -e -s \
   --arg candidate_tag "${candidate_tag}" \
   --arg run_id "${run_id}" \
   --arg run_attempt "${run_attempt}" '
-    if length != 2 or
+    if length != 1 or
        any(.[]; .sourceSha != $source_sha or .candidateTag != $candidate_tag) or
-       ([.[].component] | sort != ["backend", "frontend"]) or
+       [.[].component] != ["webui"] or
        any(.[]; (.registries | keys | sort) != ["dockerhub", "ghcr"])
     then error("candidate image metadata is incomplete or inconsistent")
     else {
-      schemaVersion: 1,
+      schemaVersion: 2,
       repository: $repository,
       workflow: ".github/workflows/release.yaml",
       sourceSha: $source_sha,
@@ -49,7 +49,7 @@ jq -e -s \
         .[$image.component] = $image.registries))
     }
     end
-  ' "${parts_dir}/frontend.json" "${parts_dir}/backend.json" >"${output_path}"
+  ' "${parts_dir}/webui.json" >"${output_path}"
 
 jq -e . "${output_path}" >/dev/null
-echo "Candidate manifest sealed from exactly two image records."
+echo "Candidate manifest sealed from exactly one image record."

--- a/scripts/release/tests/fixtures/Chart.yaml
+++ b/scripts/release/tests/fixtures/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hami-webui
 description: Release contract fixture
 type: application
-version: 1.2.0
-appVersion: "1.2.0"
+version: 2.0.0
+appVersion: "2.0.0"
 dependencies:
   - name: fixture
     version: 1.0.0

--- a/scripts/release/tests/fixtures/values.yaml
+++ b/scripts/release/tests/fixtures/values.yaml
@@ -2,11 +2,6 @@ replicaCount: 1
 vendorNodeSelectors:
   NVIDIA: gpu=on
 image:
-  frontend:
-    repository: projecthami/hami-webui-fe-oss
-    tag: "v1.2.0"
-    digest: ""
-  backend:
-    repository: projecthami/hami-webui-be-oss
-    tag: "v1.2.0"
-    digest: ""
+  repository: projecthami/hami-webui
+  tag: "v2.0.0"
+  digest: ""

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -44,6 +44,27 @@ yq -e '
   length == 1
 ' .github/workflows/release.yaml >/dev/null
 
+# Development and candidate publication must build the same unified target and
+# publish only the two canonical registry references.
+yq -e '
+  [.jobs."publish-development-image".steps[] |
+    select(.uses == "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a") |
+    select(.with.context == "." and .with.target == "unified") |
+    select((.with.tags | split("\n") | map(select(. != "")) | sort | join(",")) ==
+      "ghcr.io/project-hami/hami-webui:main,projecthami/hami-webui:main")] |
+  length == 1
+' .github/workflows/ci.yaml >/dev/null
+
+# shellcheck disable=SC2016
+yq -e '
+  [.jobs."candidate-images".steps[] |
+    select(.uses == "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a") |
+    select(.with.context == "." and .with.target == "unified") |
+    select((.with.tags | split("\n") | map(select(. != "")) | sort | join(",")) ==
+      "ghcr.io/project-hami/hami-webui:${{ needs.candidate-preflight.outputs.candidate_tag }},projecthami/hami-webui:${{ needs.candidate-preflight.outputs.candidate_tag }}")] |
+  length == 1
+' .github/workflows/release.yaml >/dev/null
+
 # Build a minimal two-commit repository so the contract test exercises the
 # candidate-to-release comparison rather than relying on this checkout's history.
 contract_repo="${work_dir}/contract-repo"
@@ -61,7 +82,7 @@ jq -n \
   --arg source_sha "${candidate_sha}" \
   --arg digest "${digest_a}" '
     {
-      schemaVersion: 1,
+      schemaVersion: 2,
       repository: "Project-HAMi/HAMi-WebUI",
       workflow: ".github/workflows/release.yaml",
       sourceSha: $source_sha,
@@ -69,13 +90,9 @@ jq -n \
       runId: "42",
       runAttempt: "1",
       images: {
-        frontend: {
-          dockerhub: {repository: "projecthami/hami-webui-fe-oss", ref: ("projecthami/hami-webui-fe-oss:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest},
-          ghcr: {repository: "ghcr.io/project-hami/hami-webui-fe-oss", ref: ("ghcr.io/project-hami/hami-webui-fe-oss:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest}
-        },
-        backend: {
-          dockerhub: {repository: "projecthami/hami-webui-be-oss", ref: ("projecthami/hami-webui-be-oss:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest},
-          ghcr: {repository: "ghcr.io/project-hami/hami-webui-be-oss", ref: ("ghcr.io/project-hami/hami-webui-be-oss:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest}
+        webui: {
+          dockerhub: {repository: "projecthami/hami-webui", ref: ("projecthami/hami-webui:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest},
+          ghcr: {repository: "ghcr.io/project-hami/hami-webui", ref: ("ghcr.io/project-hami/hami-webui:candidate-" + $source_sha[0:12] + "-42-1"), digest: $digest}
         }
       }
     }
@@ -86,17 +103,11 @@ jq -n \
 candidate_parts="${work_dir}/candidate-parts"
 mkdir -p "${candidate_parts}"
 jq '{
-  component: "frontend",
+  component: "webui",
   sourceSha,
   candidateTag,
-  registries: .images.frontend
-}' "${contract_repo}/candidate.json" >"${candidate_parts}/frontend.json"
-jq '{
-  component: "backend",
-  sourceSha,
-  candidateTag,
-  registries: .images.backend
-}' "${contract_repo}/candidate.json" >"${candidate_parts}/backend.json"
+  registries: .images.webui
+}' "${contract_repo}/candidate.json" >"${candidate_parts}/webui.json"
 bash "${release_dir}/seal-candidate-manifest.sh" \
   "${candidate_parts}" "${work_dir}/sealed-candidate.json" \
   Project-HAMi/HAMi-WebUI "${candidate_sha}" \
@@ -107,23 +118,21 @@ cmp "${work_dir}/expected-candidate.json" "${work_dir}/actual-candidate.json"
 
 cp -R "${candidate_parts}" "${work_dir}/bad-candidate-parts"
 jq '.sourceSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' \
-  "${work_dir}/bad-candidate-parts/backend.json" >"${work_dir}/bad-backend.json"
-mv "${work_dir}/bad-backend.json" "${work_dir}/bad-candidate-parts/backend.json"
+  "${work_dir}/bad-candidate-parts/webui.json" >"${work_dir}/bad-webui.json"
+mv "${work_dir}/bad-webui.json" "${work_dir}/bad-candidate-parts/webui.json"
 require_failure "inconsistent candidate image metadata" \
   bash "${release_dir}/seal-candidate-manifest.sh" \
     "${work_dir}/bad-candidate-parts" "${work_dir}/bad-candidate.json" \
     Project-HAMi/HAMi-WebUI "${candidate_sha}" \
     "candidate-${candidate_sha:0:12}-42-1" 42 1
 
-VERSION=1.2.1 DIGEST="${digest_a}" yq -i '
+VERSION=2.0.1 DIGEST="${digest_a}" yq -i '
   .version = strenv(VERSION) |
   .appVersion = strenv(VERSION)
 ' "${contract_repo}/charts/hami-webui/Chart.yaml"
-VERSION=1.2.1 DIGEST="${digest_a}" yq -i '
-  .image.frontend.tag = "v" + strenv(VERSION) |
-  .image.backend.tag = "v" + strenv(VERSION) |
-  .image.frontend.digest = strenv(DIGEST) |
-  .image.backend.digest = strenv(DIGEST)
+VERSION=2.0.1 DIGEST="${digest_a}" yq -i '
+  .image.tag = "v" + strenv(VERSION) |
+  .image.digest = strenv(DIGEST)
 ' "${contract_repo}/charts/hami-webui/values.yaml"
 git -C "${contract_repo}" add charts
 git -C "${contract_repo}" commit -qm 'allowed release metadata'
@@ -134,6 +143,53 @@ release_sha="$(git -C "${contract_repo}" rev-parse HEAD)"
   GITHUB_REPOSITORY=Project-HAMi/HAMi-WebUI \
     bash "${release_dir}/verify-release-contract.sh" candidate.json 42 "${release_sha}"
 )
+
+# The single-image manifest is a new contract. A legacy schema must fail closed
+# instead of being interpreted with missing or ambiguous image identities.
+jq '.schemaVersion = 1' "${contract_repo}/candidate.json" \
+  >"${contract_repo}/legacy-candidate.json"
+(
+  cd "${contract_repo}"
+  require_failure "legacy candidate manifest schema" \
+    env GITHUB_REPOSITORY=Project-HAMi/HAMi-WebUI \
+    bash "${release_dir}/verify-release-contract.sh" legacy-candidate.json 42 "${release_sha}"
+)
+
+# The controller must not reinterpret a Chart 1.x two-container values shape as
+# a partially populated unified image contract.
+cp -R "${contract_repo}" "${work_dir}/legacy-chart-values"
+yq -i '
+  .image = {
+    "frontend": {
+      "repository": "projecthami/hami-webui-fe-oss",
+      "tag": "v1.3.0",
+      "digest": .image.digest
+    },
+    "backend": {
+      "repository": "projecthami/hami-webui-be-oss",
+      "tag": "v1.3.0",
+      "digest": .image.digest
+    }
+  }
+' "${work_dir}/legacy-chart-values/charts/hami-webui/values.yaml"
+git -C "${work_dir}/legacy-chart-values" add charts/hami-webui/values.yaml
+git -C "${work_dir}/legacy-chart-values" commit -qm 'legacy two-image values'
+legacy_chart_sha="$(git -C "${work_dir}/legacy-chart-values" rev-parse HEAD)"
+require_failure "Chart 1.x two-image values" \
+  verify_contract_in_repo "${work_dir}/legacy-chart-values" "${legacy_chart_sha}"
+
+# A root image object alone is not enough to hide a breaking Chart migration
+# under a 1.x version number.
+cp -R "${contract_repo}" "${work_dir}/legacy-chart-major"
+VERSION=1.9.0 yq -i '
+  .version = strenv(VERSION) |
+  .appVersion = strenv(VERSION)
+' "${work_dir}/legacy-chart-major/charts/hami-webui/Chart.yaml"
+git -C "${work_dir}/legacy-chart-major" add charts/hami-webui/Chart.yaml
+git -C "${work_dir}/legacy-chart-major" commit -qm 'legacy chart major'
+legacy_major_sha="$(git -C "${work_dir}/legacy-chart-major" rev-parse HEAD)"
+require_failure "Chart major version below 2" \
+  verify_contract_in_repo "${work_dir}/legacy-chart-major" "${legacy_major_sha}"
 
 # A non-release default under an allowed file path must still invalidate the
 # already-built candidate.
@@ -178,7 +234,7 @@ require_failure "tampered canonical bundle" \
   bash "${release_dir}/verify-bundle.sh" "${work_dir}/tampered-bundle"
 
 # Exercise the all-destination preflight without any network writes. Command
-# fixtures model four available candidates and entirely absent stable targets.
+# fixtures model two available registry manifests and absent stable targets.
 preflight_bundle="${work_dir}/preflight-bundle"
 pages="${work_dir}/pages"
 mock_bin="${work_dir}/mock-bin"
@@ -199,13 +255,9 @@ jq -n \
         chart: {file: "hami-webui-9.9.9.tgz", sha256: $chart_sha}
       },
       images: {
-        frontend: {
-          dockerhub: {repository: "docker.example/frontend", digest: $digest},
-          ghcr: {repository: "ghcr.example/frontend", digest: $digest}
-        },
-        backend: {
-          dockerhub: {repository: "docker.example/backend", digest: $digest},
-          ghcr: {repository: "ghcr.example/backend", digest: $digest}
+        webui: {
+          dockerhub: {repository: "projecthami/hami-webui", digest: $digest},
+          ghcr: {repository: "ghcr.io/project-hami/hami-webui", digest: $digest}
         }
       }
     }
@@ -236,6 +288,25 @@ else
   exit 1
 fi
 MOCK_DOCKER
+cat >"${mock_bin}/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"${MOCK_LOG}"
+if [[ "${MOCK_DOCKERHUB_MISSING:-false}" == "true" ]]; then
+  echo 'curl: (22) The requested URL returned error: 404' >&2
+  exit 22
+fi
+is_private=false
+[[ "${MOCK_DOCKERHUB_PRIVATE:-false}" != "true" ]] || is_private=true
+jq -n --argjson is_private "${is_private}" '
+  {
+    namespace: "projecthami",
+    name: "hami-webui",
+    is_private: $is_private,
+    status: 1
+  }
+'
+MOCK_CURL
 cat >"${mock_bin}/helm" <<'MOCK_HELM'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -260,7 +331,26 @@ cat >"${mock_bin}/gh" <<'MOCK_GH'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "$*" >>"${MOCK_LOG}"
-if [[ "$*" == *'/packages/container/charts%2Fhami-webui'* ]]; then
+if [[ "$*" == *'/packages/container/hami-webui'* ]]; then
+  [[ "${MOCK_WEBUI_PACKAGE_MISSING:-false}" != "true" ]] || {
+    echo 'HTTP 404: not found' >&2
+    exit 1
+  }
+  visibility="public"
+  repository="Project-HAMi/HAMi-WebUI"
+  [[ "${MOCK_WEBUI_PACKAGE_PRIVATE:-false}" != "true" ]] || visibility="private"
+  [[ "${MOCK_WEBUI_PACKAGE_UNLINKED:-false}" != "true" ]] || repository=""
+  jq -n \
+    --arg visibility "${visibility}" \
+    --arg repository "${repository}" '
+      {
+        name: "hami-webui",
+        package_type: "container",
+        visibility: $visibility,
+        repository: {full_name: $repository}
+      }
+    '
+elif [[ "$*" == *'/packages/container/charts%2Fhami-webui'* ]]; then
   visibility="public"
   repository="Project-HAMi/HAMi-WebUI"
   [[ "${MOCK_OCI_PACKAGE_PRIVATE:-false}" != "true" ]] || visibility="private"
@@ -340,14 +430,43 @@ else
   printf '[]\n'
 fi
 MOCK_GH
-chmod +x "${mock_bin}/docker" "${mock_bin}/helm" "${mock_bin}/gh"
+chmod +x "${mock_bin}/docker" "${mock_bin}/curl" "${mock_bin}/helm" "${mock_bin}/gh"
+
+PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
+
+require_failure "missing Docker Hub publication target" \
+  env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_DOCKERHUB_MISSING=true \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
+
+require_failure "private Docker Hub publication target" \
+  env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_DOCKERHUB_PRIVATE=true \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
+
+require_failure "missing GHCR publication target" \
+  env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_WEBUI_PACKAGE_MISSING=true \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
+
+require_failure "private GHCR publication target" \
+  env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_WEBUI_PACKAGE_PRIVATE=true \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
+
+require_failure "unlinked GHCR publication target" \
+  env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_WEBUI_PACKAGE_UNLINKED=true \
+  bash "${release_dir}/verify-image-publication-targets.sh" \
+    Project-HAMi/HAMi-WebUI projecthami/hami-webui hami-webui
 
 PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
   bash "${release_dir}/preflight-publication.sh" \
     "${preflight_bundle}" Project-HAMi/HAMi-WebUI "${pages}" \
     https://project-hami.github.io/HAMi-WebUI
-[[ "$(grep -c '@sha256:' "${mock_log}")" == "4" ]]
-[[ "$(grep -c ':v9.9.9' "${mock_log}")" == "4" ]]
+[[ "$(grep -c '@sha256:' "${mock_log}")" == "2" ]]
+[[ "$(grep -c ':v9.9.9' "${mock_log}")" == "2" ]]
 
 require_failure "private OCI parent package" \
   env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" MOCK_OCI_PACKAGE_PRIVATE=true \
@@ -496,7 +615,7 @@ rm -f "${tag_state}"
 PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
   MOCK_TAG_STATE="${tag_state}" MOCK_TAG_SHA="${release_sha}" \
   bash "${release_dir}/reserve-release-tag.sh" \
-    Project-HAMi/HAMi-WebUI v1.2.1 "${release_sha}"
+    Project-HAMi/HAMi-WebUI v2.0.1 "${release_sha}"
 [[ "$(cat "${tag_state}")" == "${release_sha}" ]]
 [[ "$(grep -c -- '--method POST' "${mock_log}")" == "1" ]]
 
@@ -504,7 +623,7 @@ PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
 PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
   MOCK_TAG_STATE="${tag_state}" MOCK_TAG_SHA="${release_sha}" \
   bash "${release_dir}/reserve-release-tag.sh" \
-    Project-HAMi/HAMi-WebUI v1.2.1 "${release_sha}"
+    Project-HAMi/HAMi-WebUI v2.0.1 "${release_sha}"
 if grep -q -- '--method POST' "${mock_log}"; then
   echo "existing exact release tag was created again" >&2
   exit 1
@@ -515,7 +634,7 @@ require_failure "conflicting release tag" \
   env PATH="${mock_bin}:${PATH}" MOCK_LOG="${mock_log}" \
   MOCK_TAG_STATE="${tag_state}" MOCK_TAG_SHA="${release_sha}" \
   bash "${release_dir}/reserve-release-tag.sh" \
-    Project-HAMi/HAMi-WebUI v1.2.1 "${release_sha}"
+    Project-HAMi/HAMi-WebUI v2.0.1 "${release_sha}"
 
 rm -f "${tag_state}"
 require_failure "release tag creation rejected by ruleset" \
@@ -523,7 +642,7 @@ require_failure "release tag creation rejected by ruleset" \
   MOCK_TAG_STATE="${tag_state}" MOCK_TAG_SHA="${release_sha}" \
   MOCK_TAG_CREATE_FAIL=true \
   bash "${release_dir}/reserve-release-tag.sh" \
-    Project-HAMi/HAMi-WebUI v1.2.1 "${release_sha}"
+    Project-HAMi/HAMi-WebUI v2.0.1 "${release_sha}"
 
 # Recheck the tag and exact draft asset set immediately before the final
 # publication mutation. A stale target_commitish is not sufficient when a tag

--- a/scripts/release/verify-image-publication-targets.sh
+++ b/scripts/release/verify-image-publication-targets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/lib.sh
+source "${script_dir}/lib.sh"
+
+repository="${1:-Project-HAMi/HAMi-WebUI}"
+dockerhub_repository="${2:-projecthami/hami-webui}"
+ghcr_package="${3:-hami-webui}"
+
+release_require_command curl
+release_require_command gh
+release_require_command jq
+
+dockerhub_namespace="${dockerhub_repository%%/*}"
+dockerhub_name="${dockerhub_repository#*/}"
+[[ -n "${dockerhub_namespace}" && -n "${dockerhub_name}" && \
+   "${dockerhub_repository}" == */* ]] || \
+  release_die "Docker Hub repository must be namespace/name: ${dockerhub_repository}"
+
+if ! dockerhub_record="$(curl --fail --silent --show-error \
+  "https://hub.docker.com/v2/repositories/${dockerhub_namespace}/${dockerhub_name}/")"; then
+  release_die "Docker Hub repository ${dockerhub_repository} is missing or unreadable"
+fi
+jq -e \
+  --arg namespace "${dockerhub_namespace}" \
+  --arg name "${dockerhub_name}" '
+    .namespace == $namespace and
+    .name == $name and
+    .is_private == false and
+    .status == 1
+  ' <<<"${dockerhub_record}" >/dev/null || \
+  release_die "Docker Hub repository ${dockerhub_repository} must be active and public"
+
+github_owner="${repository%%/*}"
+if ! ghcr_record="$(gh api "orgs/${github_owner}/packages/container/${ghcr_package}")"; then
+  release_die "GHCR package ${github_owner}/${ghcr_package} is missing or unreadable"
+fi
+jq -e \
+  --arg package "${ghcr_package}" \
+  --arg repository "${repository}" '
+    .name == $package and
+    .package_type == "container" and
+    .visibility == "public" and
+    .repository.full_name == $repository
+  ' <<<"${ghcr_record}" >/dev/null || \
+  release_die "GHCR package ${github_owner}/${ghcr_package} must be public and linked to ${repository}"
+
+echo "Unified image publication targets are public and correctly linked."

--- a/scripts/release/verify-release-contract.sh
+++ b/scripts/release/verify-release-contract.sh
@@ -26,7 +26,7 @@ manifest_run_attempt="$(jq -r '.runAttempt' "${candidate_manifest}")"
 candidate_sha="$(jq -r '.sourceSha' "${candidate_manifest}")"
 candidate_tag="$(jq -r '.candidateTag' "${candidate_manifest}")"
 
-[[ "${schema_version}" == "1" ]] || release_die "unsupported candidate manifest schema: ${schema_version}"
+[[ "${schema_version}" == "2" ]] || release_die "unsupported candidate manifest schema: ${schema_version}"
 [[ "${repository}" == "${GITHUB_REPOSITORY:-Project-HAMi/HAMi-WebUI}" ]] || \
   release_die "candidate belongs to a different repository: ${repository}"
 [[ "${workflow}" == ".github/workflows/release.yaml" ]] || \
@@ -39,6 +39,11 @@ release_validate_commit "${candidate_sha}"
 expected_candidate_tag="candidate-${candidate_sha:0:12}-${candidate_run_id}-${manifest_run_attempt}"
 [[ "${candidate_tag}" == "${expected_candidate_tag}" ]] || \
   release_die "candidate tag does not bind the source, run, and attempt"
+jq -e '
+  (.images | keys) == ["webui"] and
+  ((.images.webui | keys | sort) == ["dockerhub", "ghcr"])
+' "${candidate_manifest}" >/dev/null || \
+  release_die "candidate manifest must contain exactly one webui image for Docker Hub and GHCR"
 
 git cat-file -e "${candidate_sha}^{commit}"
 git cat-file -e "${release_sha}^{commit}"
@@ -64,57 +69,53 @@ release_chart_contract="$(yq -o=json 'del(.version, .appVersion)' "${chart_dir}/
 [[ "${candidate_chart_contract}" == "${release_chart_contract}" ]] || \
   release_die "Chart.yaml changed beyond version/appVersion after the candidate build"
 
+if ! yq -e '
+  .image.repository != null and
+  .image.frontend == null and
+  .image.backend == null
+' "${chart_dir}/values.yaml" >/dev/null; then
+  release_die "Chart 1.x two-image values cannot be published by the unified-image controller"
+fi
+
 candidate_values_contract="$(git show "${candidate_sha}:charts/hami-webui/values.yaml" | \
-  yq -o=json 'del(.image.frontend.tag, .image.frontend.digest, .image.backend.tag, .image.backend.digest)' -)"
-release_values_contract="$(yq -o=json 'del(.image.frontend.tag, .image.frontend.digest, .image.backend.tag, .image.backend.digest)' "${chart_dir}/values.yaml")"
+  yq -o=json 'del(.image.tag, .image.digest)' -)"
+release_values_contract="$(yq -o=json 'del(.image.tag, .image.digest)' "${chart_dir}/values.yaml")"
 [[ "${candidate_values_contract}" == "${release_values_contract}" ]] || \
   release_die "values.yaml changed beyond release image identities after the candidate build"
 
 version="$(yq -r '.version' "${chart_dir}/Chart.yaml")"
 app_version="$(yq -r '.appVersion' "${chart_dir}/Chart.yaml")"
-frontend_repository="$(yq -r '.image.frontend.repository' "${chart_dir}/values.yaml")"
-backend_repository="$(yq -r '.image.backend.repository' "${chart_dir}/values.yaml")"
-frontend_tag="$(yq -r '.image.frontend.tag' "${chart_dir}/values.yaml")"
-backend_tag="$(yq -r '.image.backend.tag' "${chart_dir}/values.yaml")"
-frontend_digest="$(yq -r '.image.frontend.digest' "${chart_dir}/values.yaml")"
-backend_digest="$(yq -r '.image.backend.digest' "${chart_dir}/values.yaml")"
-expected_frontend_digest="$(jq -r '.images.frontend.dockerhub.digest' "${candidate_manifest}")"
-expected_backend_digest="$(jq -r '.images.backend.dockerhub.digest' "${candidate_manifest}")"
+image_repository="$(yq -r '.image.repository' "${chart_dir}/values.yaml")"
+image_tag="$(yq -r '.image.tag' "${chart_dir}/values.yaml")"
+image_digest="$(yq -r '.image.digest' "${chart_dir}/values.yaml")"
+expected_image_digest="$(jq -r '.images.webui.dockerhub.digest' "${candidate_manifest}")"
 
 [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
   release_die "stable chart version must be x.y.z: ${version}"
+[[ "${version%%.*}" -ge 2 ]] || \
+  release_die "the unified-image release contract requires Chart major version 2 or newer"
 [[ "${app_version}" == "${version}" ]] || \
   release_die "Chart.appVersion must equal Chart.version"
-[[ "${frontend_repository}" == "projecthami/hami-webui-fe-oss" ]] || \
-  release_die "unexpected default frontend repository: ${frontend_repository}"
-[[ "${backend_repository}" == "projecthami/hami-webui-be-oss" ]] || \
-  release_die "unexpected default backend repository: ${backend_repository}"
-[[ "${frontend_tag}" == "v${version}" ]] || release_die "frontend tag must be v${version}"
-[[ "${backend_tag}" == "v${version}" ]] || release_die "backend tag must be v${version}"
-release_validate_digest "${frontend_digest}"
-release_validate_digest "${backend_digest}"
-[[ "${frontend_digest}" == "${expected_frontend_digest}" ]] || \
-  release_die "frontend default digest does not match the candidate"
-[[ "${backend_digest}" == "${expected_backend_digest}" ]] || \
-  release_die "backend default digest does not match the candidate"
+[[ "${image_repository}" == "projecthami/hami-webui" ]] || \
+  release_die "unexpected default image repository: ${image_repository}"
+[[ "${image_tag}" == "v${version}" ]] || release_die "image tag must be v${version}"
+release_validate_digest "${image_digest}"
+[[ "${image_digest}" == "${expected_image_digest}" ]] || \
+  release_die "default image digest does not match the candidate"
 
-for component in frontend backend; do
-  for registry in dockerhub ghcr; do
-    image_repository="$(jq -r ".images.${component}.${registry}.repository" "${candidate_manifest}")"
-    image_reference="$(jq -r ".images.${component}.${registry}.ref" "${candidate_manifest}")"
-    image_digest="$(jq -r ".images.${component}.${registry}.digest" "${candidate_manifest}")"
-    case "${component}/${registry}" in
-      frontend/dockerhub) expected_repository="projecthami/hami-webui-fe-oss" ;;
-      frontend/ghcr) expected_repository="ghcr.io/project-hami/hami-webui-fe-oss" ;;
-      backend/dockerhub) expected_repository="projecthami/hami-webui-be-oss" ;;
-      backend/ghcr) expected_repository="ghcr.io/project-hami/hami-webui-be-oss" ;;
-    esac
-    [[ "${image_repository}" == "${expected_repository}" ]] || \
-      release_die "unexpected ${component}/${registry} repository: ${image_repository}"
-    [[ "${image_reference}" == "${image_repository}:${candidate_tag}" ]] || \
-      release_die "${component}/${registry} does not use the sealed candidate tag"
-    release_validate_digest "${image_digest}"
-  done
+for registry in dockerhub ghcr; do
+  registry_repository="$(jq -r ".images.webui.${registry}.repository" "${candidate_manifest}")"
+  image_reference="$(jq -r ".images.webui.${registry}.ref" "${candidate_manifest}")"
+  registry_digest="$(jq -r ".images.webui.${registry}.digest" "${candidate_manifest}")"
+  case "${registry}" in
+    dockerhub) expected_repository="projecthami/hami-webui" ;;
+    ghcr) expected_repository="ghcr.io/project-hami/hami-webui" ;;
+  esac
+  [[ "${registry_repository}" == "${expected_repository}" ]] || \
+    release_die "unexpected webui/${registry} repository: ${registry_repository}"
+  [[ "${image_reference}" == "${registry_repository}:${candidate_tag}" ]] || \
+    release_die "webui/${registry} does not use the sealed candidate tag"
+  release_validate_digest "${registry_digest}"
 done
 
 [[ -f "${chart_dir}/Chart.lock" ]] || release_die "Chart.lock is required"


### PR DESCRIPTION
## What changed

- publish one canonical multi-architecture hami-webui image from the unified Docker target
- seal one webui candidate in schema v2 while recording Docker Hub and GHCR digests separately
- require public registry destinations and keep Chart 1.x stable publication fail-closed
- retain legacy image PR smoke coverage until the separate Chart 2 migration

## Verification

- make verify
- actionlint on CI and release workflows
- ShellCheck on release scripts
- deterministic release-controller tests, including legacy schema/Chart rejection and registry visibility failures

## Rollout

The first merged main build creates the canonical Docker Hub and GHCR repositories. Before a release candidate can run, both must be public and the GHCR package must be linked to this repository; the controller enforces that gate. This PR does not change the production Chart or publish a stable release.

Tracks #209.