### PR TITLE
refactor(chart)!: deploy one application container

### DIFF
--- a/.github/workflows/pr-chart.yaml
+++ b/.github/workflows/pr-chart.yaml
@@ -27,7 +27,8 @@ jobs:
           filters: |
             chart:
               - 'charts/**'
-              - 'scripts/verify-chart.sh'
+              - 'scripts/chart/**'
+              - 'scripts/verify-chart*.sh'
               - '.github/workflows/pr-chart.yaml'
 
   verify:
@@ -51,11 +52,54 @@ jobs:
       - name: Verify chart
         run: bash scripts/verify-chart.sh
 
+  upgrade:
+    name: Chart 1.3 upgrade and rollback
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    needs: changes
+    if: needs.changes.outputs.chart == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.21.4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build current unified image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: unified
+          platforms: linux/amd64
+          load: true
+          tags: hami-webui:chart-upgrade-smoke
+          cache-from: type=gha,scope=chart-upgrade
+          cache-to: type=gha,mode=max,scope=chart-upgrade
+      - name: Install pinned Kind
+        shell: bash
+        run: |
+          set -euo pipefail
+          kind_version=v0.27.0
+          kind_sha256=a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b
+          kind_bin="${RUNNER_TEMP}/bin/kind"
+          mkdir -p "$(dirname "${kind_bin}")"
+          curl --fail --silent --show-error --location \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64" \
+            --output "${kind_bin}"
+          echo "${kind_sha256}  ${kind_bin}" | sha256sum --check
+          chmod 0755 "${kind_bin}"
+          dirname "${kind_bin}" >>"${GITHUB_PATH}"
+      - name: Verify upgrade and rollback contract
+        run: bash scripts/verify-chart-upgrade.sh hami-webui chart-upgrade-smoke
+
   pr-chart-required:
     runs-on: ubuntu-latest
     needs:
       - changes
       - verify
+      - upgrade
     if: always()
     steps:
       - name: Aggregate chart check results
@@ -70,6 +114,10 @@ jobs:
           fi
           if [[ "${{ needs.verify.result }}" != "success" ]]; then
             echo "Chart checks did not complete successfully: ${{ needs.verify.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.upgrade.result }}" != "success" ]]; then
+            echo "Chart upgrade checks did not complete successfully: ${{ needs.upgrade.result }}"
             exit 1
           fi
           echo "All chart checks passed."

--- a/charts/hami-webui/Chart.yaml
+++ b/charts/hami-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hami-webui
-description: A Helm chart for Kubernetes
+description: A Web interface for monitoring HAMi-managed heterogeneous devices
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 2.0.0-rc.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "main"
 
 dependencies:
   - condition: dcgm-exporter.enabled

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -1,6 +1,6 @@
 # HAMi-WebUI
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 2.0.0-rc.0](https://img.shields.io/badge/Version-2.0.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 ## Get Repo Info
 
@@ -25,12 +25,17 @@ https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.ya
 helm install my-hami-webui hami-webui/hami-webui --create-namespace --namespace hami -f values.yaml
 ```
 
+Chart 2 deploys one `projecthami/hami-webui` image and one container. When
+upgrading from Chart 1.3, create a fresh Chart 2 values file and use
+`--reset-values`; do not reuse the nested frontend/backend values. See the
+[upgrade and rollback procedure](../../docs/installation/helm/index.md#upgrade-from-chart-13-to-20).
+
 ## Uninstalling the Chart
 
-To uninstall/delete the my-release deployment:
+To uninstall the release:
 
 ```console
-helm delete my-hami-webui
+helm uninstall my-hami-webui --namespace hami
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -47,12 +52,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default                                                                            | Description |
 |-----|------|------------------------------------------------------------------------------------|-------------|
 | affinity | object | `{}`                                                                               |  |
+| backend.http.timeout | string | `"60s"` | Timeout applied to each incoming API request context. |
 | dcgm-exporter.enabled | bool | `true`                                                                             |  |
 | dcgm-exporter.nodeSelector.gpu | string | `"on"`                                                                             |  |
 | dcgm-exporter.serviceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
 | dcgm-exporter.serviceMonitor.enabled | bool | `true`                                                                             |  |
 | dcgm-exporter.serviceMonitor.honorLabels | bool | `false`                                                                            |  |
 | dcgm-exporter.serviceMonitor.interval | string | `"15s"`                                                                            |  |
+| env[0].name | string | `"TZ"` | Default environment variable name for the single application container. Replace the list to add other variables. |
+| env[0].value | string | `"Asia/Shanghai"` | Default timezone value. |
 | externalPrometheus.address | string | `"http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"` | Prometheus or VictoriaMetrics HTTP API address. |
 | externalPrometheus.enabled | bool | `false`                                                                            | Use an existing metrics backend instead of the bundled address. |
 | externalPrometheus.timeout | string | `"1m"` | Timeout sent with each upstream PromQL request. |
@@ -64,17 +72,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | externalPrometheus.tls.keyKey | string | `""` | Secret data key containing the client private key; configure with `certKey`. |
 | frontend.basePath | string | `"/"` | Public URL prefix served by the official Go Web entry; use the same non-stripped Ingress path. |
 | frontend.frameAncestors | list or null | `null` | CSP framing allowlist. `null` preserves existing behavior, `[]` blocks framing, and a list allows explicit parents. |
-| frontend.livenessProbe.enabled | bool | `true` | Enable the Web-entry liveness probe. |
-| frontend.livenessProbe.failureThreshold | int | `6` |  |
-| frontend.livenessProbe.initialDelaySeconds | int | `5` |  |
-| frontend.livenessProbe.periodSeconds | int | `10` |  |
-| frontend.livenessProbe.timeoutSeconds | int | `3` |  |
-| frontend.proxyTimeout | string | `"65s"` | End-to-end backend proxy timeout; keep this longer than `backend.http.timeout`. |
-| frontend.readinessProbe.enabled | bool | `true` | Enable the Web-entry readiness probe. |
-| frontend.readinessProbe.failureThreshold | int | `3` |  |
-| frontend.readinessProbe.initialDelaySeconds | int | `1` |  |
-| frontend.readinessProbe.periodSeconds | int | `5` |  |
-| frontend.readinessProbe.timeoutSeconds | int | `3` |  |
 | fullnameOverride | string | `""`                                                                               |  |
 | hamiServiceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
 | hamiServiceMonitor.enabled | bool | `true`                                                                             |  |
@@ -82,15 +79,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.backend.digest | string | `"sha256:7057047c7c2f7838cd190b3dc7263d503bbcf5d8e52642bc703227d137bc029d"`                | Immutable manifest digest; takes precedence over `image.backend.tag` when set. |
-| image.backend.pullPolicy | string | `"IfNotPresent"`                                                                  |  |
-| image.backend.repository | string | `"projecthami/hami-webui-be-oss"`                                                  |  |
-| image.backend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.backend.digest` is empty. |
-| image.frontend.digest | string | `"sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e"`               | Immutable manifest digest; takes precedence over `image.frontend.tag` when set. |
-| image.frontend.pullPolicy | string | `"IfNotPresent"`                                                                   |  |
-| image.frontend.repository | string | `"projecthami/hami-webui-fe-oss"`                                                  |  |
-| image.frontend.tag | string | `"v1.3.0"`                                                                         | Used only when `image.frontend.digest` is empty. |
-| imagePullSecrets | list | `[]`                                                                               | Image pull secrets used by both containers in the WebUI Pod. |
+| image.digest | string | `""` | Immutable manifest digest; takes precedence over `image.tag` when set. |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the application image. |
+| image.repository | string | `"projecthami/hami-webui"` | Unified HAMi-WebUI image repository. |
+| image.tag | string | `"main"` | Used only when `image.digest` is empty. Release packaging replaces development defaults with the released version. |
+| imagePullSecrets | list | `[]` | Image pull secrets used by the WebUI Pod. |
 | ingress.annotations | object | `{}`                                                                               |  |
 | ingress.className | string | `""`                                                                               |  |
 | ingress.enabled | bool | `false`                                                                            |  |
@@ -108,23 +101,35 @@ The command removes all the Kubernetes components associated with the chart and 
 | kube-prometheus-stack.nodeExporter.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelector.matchLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
 | kube-prometheus-stack.prometheusOperator.enabled | bool | `false`                                                                            |  |
+| metricsExporter.interval | string | `"30s"` | Interval between background metric refreshes. |
+| metricsExporter.timeout | string | `"60s"` | Hard timeout for one background metric refresh. |
 | nameOverride | string | `""`                                                                               |  |
 | namespaceOverride | string | `""`                                                                               |  |
 | nodeSelector | object | `{}`                                                                               |  |
 | podAnnotations | object | `{}`                                                                               |  |
 | podSecurityContext | object | `{}`                                                                               |  |
+| probes.liveness.enabled | bool | `true` | Probe the public `/health_check` endpoint after startup. |
+| probes.liveness.failureThreshold | int | `6` |  |
+| probes.liveness.initialDelaySeconds | int | `0` |  |
+| probes.liveness.periodSeconds | int | `10` |  |
+| probes.liveness.timeoutSeconds | int | `3` |  |
+| probes.readiness.enabled | bool | `true` | Probe the public `/health_check` endpoint after startup. |
+| probes.readiness.failureThreshold | int | `3` |  |
+| probes.readiness.initialDelaySeconds | int | `0` |  |
+| probes.readiness.periodSeconds | int | `5` |  |
+| probes.readiness.timeoutSeconds | int | `3` |  |
+| probes.startup.enabled | bool | `true` | Wait for internal `/readyz` and informer synchronization before other probes begin. |
+| probes.startup.failureThreshold | int | `60` | Combined with the five-second period, allows up to five minutes for startup. |
+| probes.startup.initialDelaySeconds | int | `0` |  |
+| probes.startup.periodSeconds | int | `5` |  |
+| probes.startup.timeoutSeconds | int | `3` |  |
 | replicaCount | int | `1`                                                                                |  |
-| resources.backend.limits.cpu | string | `"50m"`                                                                            |  |
-| resources.backend.limits.memory | string | `"250Mi"`                                                                          |  |
-| resources.backend.requests.cpu | string | `"50m"`                                                                            |  |
-| resources.backend.requests.memory | string | `"250Mi"`                                                                          |  |
-| resources.frontend.limits.cpu | string | `"200m"`                                                                           |  |
-| resources.frontend.limits.memory | string | `"500Mi"`                                                                          |  |
-| resources.frontend.requests.cpu | string | `"200m"`                                                                           |  |
-| resources.frontend.requests.memory | string | `"500Mi"`                                                                          |  |
+| resources.limits.cpu | string | `"250m"` | CPU limit for the single application container. |
+| resources.limits.memory | string | `"750Mi"` | Memory limit for the single application container. |
+| resources.requests.cpu | string | `"250m"` | CPU request for the single application container. |
+| resources.requests.memory | string | `"750Mi"` | Memory request for the single application container. |
 | securityContext | object | `{}`                                                                               |  |
-| service.legacyBackendPort | bool | `true`                                                                        | Deprecated Chart 1.x compatibility port for direct access to the raw backend on the primary Service. Set to `false` to expose only the supported Web entry; removed in Chart 2.0.0. |
-| service.port | int | `3000`                                                                             |  |
+| service.port | int | `3000` | Public SPA and browser API Service port. The internal metrics Service keeps port 8000 separate. |
 | service.type | string | `"ClusterIP"`                                                                      |  |
 | serviceAccount.annotations | object | `{}`                                                                               |  |
 | serviceAccount.create | bool | `true`                                                                             |  |
@@ -135,6 +140,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceMonitor.interval | string | `"15s"`                                                                            |  |
 | serviceMonitor.relabelings | list | `[]`                                                                               |  |
 | tolerations | list | `[]`                                                                               |  |
+| vendorNodeSelectors.Ascend | string | `"ascend=on"` | Node-label selector used for Ascend device discovery. |
+| vendorNodeSelectors.DCU | string | `"dcu=on"` | Node-label selector used for DCU device discovery. |
+| vendorNodeSelectors.MLU | string | `"mlu=on"` | Node-label selector used for MLU device discovery. |
+| vendorNodeSelectors.Metax | string | `"metax-tech.com/gpu.installed=true"` | Node-label selector used for Metax device discovery. |
+| vendorNodeSelectors.NVIDIA | string | `"gpu=on"` | Node-label selector used for NVIDIA device discovery. |
 
 ## Configuration Guide for HAMi-WebUI Helm Chart
 

--- a/charts/hami-webui/templates/NOTES.txt
+++ b/charts/hami-webui/templates/NOTES.txt
@@ -1,9 +1,4 @@
-{{- $legacyBackendPort := eq (include "hami-webui.legacyBackendPortEnabled" .) "true" -}}
-{{- if and $legacyBackendPort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
-WARNING: The primary Service exposes the deprecated raw backend port 8000 because
-service.legacyBackendPort is true. Set it to false unless an existing integration
-still connects directly to the backend.
-{{ end }}
+{{- include "hami-webui.validateChart2Values" . -}}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -7,20 +7,23 @@ Expand the name of the chart.
 
 {{/*
 Render an image reference. A verified manifest digest takes precedence over a
-mutable tag; tag remains the backwards-compatible default for normal installs.
+mutable tag.
 */}}
 {{- define "hami-webui.image" -}}
-{{- $repository := required (printf "image.%s.repository is required" .name) .image.repository -}}
+{{- $repository := required "image.repository is required" .image.repository -}}
 {{- $digest := default "" .image.digest -}}
 {{- if $digest -}}
 {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) -}}
-{{- fail (printf "image.%s.digest must be a sha256 digest" .name) -}}
+{{- fail "image.digest must be a sha256 digest" -}}
 {{- end -}}
 {{- printf "%s@%s" $repository $digest -}}
 {{- else -}}
 {{- $appVersion := required "Chart.appVersion is required when an image digest is not set" .appVersion -}}
-{{- $defaultTag := ternary $appVersion (printf "v%s" $appVersion) (hasPrefix "v" $appVersion) -}}
-{{- $tag := default $defaultTag .image.tag -}}
+{{- $fallbackTag := $appVersion -}}
+{{- if regexMatch "^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$" $appVersion -}}
+{{- $fallbackTag = printf "v%s" (replace "+" "_" $appVersion) -}}
+{{- end -}}
+{{- $tag := default $fallbackTag .image.tag -}}
 {{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 {{- end -}}
@@ -154,20 +157,35 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Keep the Chart 1.x backend port when the value is absent from reused values.
-Do not use Helm's default function here: an explicit false is considered empty.
+Reject Chart 1.x split-container values as one actionable migration error.
+The schema intentionally permits these shapes so Helm does not mask this
+message before template evaluation.
 */}}
-{{- define "hami-webui.legacyBackendPortEnabled" -}}
-{{- $serviceSettings := default (dict) .Values.service -}}
-{{- $legacyBackendPort := true -}}
-{{- if hasKey $serviceSettings "legacyBackendPort" -}}
-{{- $configuredLegacyBackendPort := get $serviceSettings "legacyBackendPort" -}}
-{{- if not (kindIs "bool" $configuredLegacyBackendPort) -}}
-{{- fail "service.legacyBackendPort must be a boolean" -}}
+{{- define "hami-webui.validateChart2Values" -}}
+{{- $legacy := list -}}
+{{- $sections := dict
+      "image" (list "frontend" "backend")
+      "resources" (list "frontend" "backend")
+      "env" (list "frontend" "backend")
+      "frontend" (list "proxyTimeout" "livenessProbe" "readinessProbe")
+      "backend" (list "grpc" "readinessProbe")
+      "service" (list "legacyBackendPort") -}}
+{{- range $sectionName, $keys := $sections -}}
+{{- $section := get $.Values $sectionName -}}
+{{- if kindIs "map" $section -}}
+{{- range $key := $keys -}}
+{{- if hasKey $section $key -}}
+{{- $legacy = append $legacy (printf "%s.%s" $sectionName $key) -}}
 {{- end -}}
-{{- $legacyBackendPort = $configuredLegacyBackendPort -}}
 {{- end -}}
-{{- $legacyBackendPort -}}
+{{- end -}}
+{{- end -}}
+{{- if $legacy -}}
+{{- fail (printf "HAMi-WebUI Chart 2.0 no longer accepts Chart 1.x split-container values: %s. Migrate to the flat image, resources, env, and probes settings; when upgrading from Chart 1.x, create a fresh Chart 2 values file and pass it together with --reset-values" (join ", " (sortAlpha $legacy))) -}}
+{{- end -}}
+{{- if not (kindIs "slice" .Values.env) -}}
+{{- fail "env must be a list of Kubernetes environment variables" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/hami-webui/templates/configmap.yaml
+++ b/charts/hami-webui/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "hami-webui.validateChart2Values" . -}}
 {{- include "hami-webui.validatePrometheusTLS" . -}}
 {{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
 {{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
@@ -15,9 +16,6 @@ data:
       http:
         addr: 0.0.0.0:8000
         timeout: {{ .Values.backend.http.timeout | default "60s" }}
-      grpc:
-        addr: 0.0.0.0:9000
-        timeout: {{ .Values.backend.grpc.timeout | default "60s" }}
     prometheus:
       address: {{ include "hami-webui.prometheusAddress" . }}
       timeout: {{ .Values.externalPrometheus.timeout | default "1m" }}

--- a/charts/hami-webui/templates/deployment.yaml
+++ b/charts/hami-webui/templates/deployment.yaml
@@ -1,42 +1,29 @@
+{{- include "hami-webui.validateChart2Values" . -}}
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.podAnnotations) (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)) -}}
-{{- $frontendEnv := default (list) .Values.env.frontend -}}
+{{- $env := default (list) .Values.env -}}
 {{- $frontendSettings := default (dict) .Values.frontend -}}
 {{- include "hami-webui.validatePrometheusTLS" . -}}
 {{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
 {{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
 {{- $prometheusTLSSecret := default "" (get $prometheusTLS "existingSecret") -}}
 {{- $mountPrometheusTLS := and (get $externalPrometheus "enabled") (ne $prometheusTLSSecret "") -}}
-{{- $frontendProxyTimeoutOverridden := false -}}
-{{- $frontendBasePathOverridden := false -}}
-{{- $frontendFrameAncestorsOverridden := false -}}
-{{- range $frontendEnv -}}
-{{- if eq (get . "name") "HAMI_WEBUI_PROXY_TIMEOUT" -}}
-{{- $frontendProxyTimeoutOverridden = true -}}
-{{- end -}}
+{{- $basePathOverridden := false -}}
+{{- $frameAncestorsOverridden := false -}}
+{{- range $env -}}
 {{- if eq (get . "name") "HAMI_WEBUI_BASE_PATH" -}}
-{{- $frontendBasePathOverridden = true -}}
+{{- $basePathOverridden = true -}}
 {{- end -}}
 {{- if eq (get . "name") "HAMI_WEBUI_FRAME_ANCESTORS_JSON" -}}
-{{- $frontendFrameAncestorsOverridden = true -}}
+{{- $frameAncestorsOverridden = true -}}
 {{- end -}}
 {{- end -}}
-{{- $basePathConfigured := hasKey $frontendSettings "basePath" -}}
-{{- $basePath := get $frontendSettings "basePath" -}}
-{{- if and (not $frontendBasePathOverridden) $basePathConfigured (ne (toJson $basePath) "null") (not (kindIs "string" $basePath)) -}}
-{{- fail "frontend.basePath must be a string" -}}
-{{- end -}}
+{{- $basePath := default "/" (get $frontendSettings "basePath") -}}
 {{- $frameAncestorsConfigured := hasKey $frontendSettings "frameAncestors" -}}
 {{- $frameAncestors := get $frontendSettings "frameAncestors" -}}
-{{- if and (not $frontendFrameAncestorsOverridden) $frameAncestorsConfigured (ne (toJson $frameAncestors) "null") (not (kindIs "slice" $frameAncestors)) -}}
-{{- fail "frontend.frameAncestors must be null or a list" -}}
-{{- end -}}
-{{- if and (not $frontendFrameAncestorsOverridden) (kindIs "slice" $frameAncestors) -}}
-{{- range $source := $frameAncestors -}}
-{{- if not (kindIs "string" $source) -}}
-{{- fail "frontend.frameAncestors entries must be strings" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- $probes := default (dict) .Values.probes -}}
+{{- $startupProbe := default (dict) (get $probes "startup") -}}
+{{- $readinessProbe := default (dict) (get $probes "readiness") -}}
+{{- $livenessProbe := default (dict) (get $probes "liveness") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,87 +54,62 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-fe-oss
+        - name: hami-webui
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "hami-webui.image" (dict "name" "frontend" "image" .Values.image.frontend "appVersion" .Chart.AppVersion) | quote }}
-          imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
+          image: {{ include "hami-webui.image" (dict "image" .Values.image "appVersion" .Chart.AppVersion) | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if not $frontendProxyTimeoutOverridden }}
-            - name: HAMI_WEBUI_PROXY_TIMEOUT
-              value: {{ default "65s" (get (default (dict) .Values.frontend) "proxyTimeout") | quote }}
-            {{- end }}
-            {{- if not $frontendBasePathOverridden }}
+            {{- if not $basePathOverridden }}
             - name: HAMI_WEBUI_BASE_PATH
-              value: {{ default "/" $basePath | quote }}
+              value: {{ $basePath | quote }}
             {{- end }}
-            {{- if and (not $frontendFrameAncestorsOverridden) $frameAncestorsConfigured (ne (toJson $frameAncestors) "null") }}
+            {{- if and (not $frameAncestorsOverridden) $frameAncestorsConfigured (ne (toJson $frameAncestors) "null") }}
             - name: HAMI_WEBUI_FRAME_ANCESTORS_JSON
               value: {{ toJson $frameAncestors | quote }}
             {{- end }}
-            {{- with $frontendEnv }}
+            {{- with $env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
-          {{- with .Values.frontend }}
-          {{- with .livenessProbe }}
-          {{- if .enabled }}
+            - name: metrics
+              containerPort: 8000
+              protocol: TCP
+          {{- if (get $startupProbe "enabled") }}
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: {{ default 0 (get $startupProbe "initialDelaySeconds") }}
+            periodSeconds: {{ default 5 (get $startupProbe "periodSeconds") }}
+            timeoutSeconds: {{ default 3 (get $startupProbe "timeoutSeconds") }}
+            failureThreshold: {{ default 60 (get $startupProbe "failureThreshold") }}
+          {{- end }}
+          {{- if (get $readinessProbe "enabled") }}
+          readinessProbe:
+            httpGet:
+              path: /health_check
+              port: http
+            initialDelaySeconds: {{ default 0 (get $readinessProbe "initialDelaySeconds") }}
+            periodSeconds: {{ default 5 (get $readinessProbe "periodSeconds") }}
+            timeoutSeconds: {{ default 3 (get $readinessProbe "timeoutSeconds") }}
+            failureThreshold: {{ default 3 (get $readinessProbe "failureThreshold") }}
+          {{- end }}
+          {{- if (get $livenessProbe "enabled") }}
           livenessProbe:
             httpGet:
               path: /health_check
               port: http
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            timeoutSeconds: {{ .timeoutSeconds }}
-            failureThreshold: {{ .failureThreshold }}
-          {{- end }}
-          {{- end }}
-          {{- with .readinessProbe }}
-          {{- if .enabled }}
-          readinessProbe:
-            httpGet:
-              path: /health_check
-              port: http
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            timeoutSeconds: {{ .timeoutSeconds }}
-            failureThreshold: {{ .failureThreshold }}
-          {{- end }}
-          {{- end }}
+            initialDelaySeconds: {{ default 0 (get $livenessProbe "initialDelaySeconds") }}
+            periodSeconds: {{ default 10 (get $livenessProbe "periodSeconds") }}
+            timeoutSeconds: {{ default 3 (get $livenessProbe "timeoutSeconds") }}
+            failureThreshold: {{ default 6 (get $livenessProbe "failureThreshold") }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.frontend | nindent 12 }}
-        - name: {{ .Chart.Name }}-be-oss
-          securityContext:
-                  {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "hami-webui.image" (dict "name" "backend" "image" .Values.image.backend "appVersion" .Chart.AppVersion) | quote }}
-          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
-          env:
-            {{- toYaml .Values.env.backend | nindent 12 }}
-          ports:
-            - name: metrics
-              containerPort: 8000
-              protocol: TCP
-          command:
-            - "/apps/server"
-          args:
-            - "--conf"
-            - "/apps/config/config.yaml"
-          {{- if .Values.backend.readinessProbe.enabled }}
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: metrics
-            initialDelaySeconds: {{ .Values.backend.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.backend.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.backend.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.backend.readinessProbe.failureThreshold }}
-          {{- end }}
-          resources:
-            {{- toYaml .Values.resources.backend | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /apps/config/

--- a/charts/hami-webui/templates/service.yaml
+++ b/charts/hami-webui/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- $legacyBackendPort := eq (include "hami-webui.legacyBackendPortEnabled" .) "true" -}}
+{{- include "hami-webui.validateChart2Values" . -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,12 +14,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if $legacyBackendPort }}
-    - port: 8000
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
-    {{- end }}
   selector:
     {{- include "hami-webui.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "hami-webui"

--- a/charts/hami-webui/values.schema.json
+++ b/charts/hami-webui/values.schema.json
@@ -2,6 +2,93 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string",
+          "pattern": "^(|[A-Za-z0-9_][A-Za-z0-9._-]{0,127})$"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^(|sha256:[a-f0-9]{64})$"
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "env": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "frontend": {
+      "type": "object",
+      "properties": {
+        "basePath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "frameAncestors": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "backend": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "object",
+          "properties": {
+            "timeout": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": {
+          "$ref": "#/definitions/probe"
+        },
+        "readiness": {
+          "$ref": "#/definitions/probe"
+        },
+        "liveness": {
+          "$ref": "#/definitions/probe"
+        }
+      }
+    },
     "externalPrometheus": {
       "type": "object",
       "properties": {
@@ -28,6 +115,32 @@
               "type": "string"
             }
           }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     }

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -12,21 +12,16 @@ vendorNodeSelectors:
   Metax: metax-tech.com/gpu.installed=true
 
 image:
-  frontend:
-    repository: projecthami/hami-webui-fe-oss
-    pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion (CI uses the git tag name).
-    tag: "v1.3.0"
-    # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e"
-  backend:
-    repository: projecthami/hami-webui-be-oss
-    pullPolicy: IfNotPresent
-    tag: "v1.3.0"
-    # When set, digest takes precedence over tag and renders repository@digest.
-    digest: "sha256:7057047c7c2f7838cd190b3dc7263d503bbcf5d8e52642bc703227d137bc029d"
+  repository: projecthami/hami-webui
+  pullPolicy: IfNotPresent
+  # Overrides the image tag. When empty, a semantic chart appVersion uses its
+  # matching v-prefixed release tag (with '+' mapped to '_', as OCI tags do not
+  # allow '+'); other appVersions are used unchanged.
+  tag: "main"
+  # When set, digest takes precedence over tag and renders repository@digest.
+  digest: ""
 
-# Image pull secrets used by both containers in the WebUI Pod.
+# Image pull secrets used by the WebUI Pod.
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -57,11 +52,6 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 3000
-  # Chart 1.x compatibility only. Port 8000 exposes the raw backend API,
-  # readiness, metrics, and Swagger endpoints through the primary Service.
-  # Disable it when only the supported Web entry should be reachable.
-  # This option is deprecated and will be removed in Chart 2.0.0.
-  legacyBackendPort: true
 
 ingress:
   enabled: false
@@ -80,38 +70,16 @@ ingress:
   #      - chart-example.local
 
 resources:
-  frontend:
-    limits:
-      cpu: 200m
-      memory: 500Mi
-    requests:
-      cpu: 200m
-      memory: 500Mi
-  backend:
-    limits:
-      cpu: 50m
-      memory: 250Mi
-    requests:
-      cpu: 50m
-      memory: 250Mi
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 750Mi
+  requests:
+    cpu: 250m
+    memory: 750Mi
 
 env:
-  frontend:
-    - name: TZ
-      value: "Asia/Shanghai"
-  backend:
-    - name: TZ
-      value: "Asia/Shanghai"
+  - name: TZ
+    value: "Asia/Shanghai"
 
 serviceMonitor:
   enabled: true
@@ -195,8 +163,7 @@ externalPrometheus:
     certKey: ""
     keyKey: ""
 
-# Web-entry runtime settings and health probes. The probes report the frontend
-# container's own health; backend readiness is gated separately below.
+# Public Web-entry runtime settings.
 frontend:
   # Public URL prefix served by the official Go Web entry. Keep the Ingress
   # path identical and do not configure the proxy to strip this prefix.
@@ -206,46 +173,35 @@ frontend:
   # non-empty list allows only the listed origins. The first release accepts
   # only "'self'" and exact http(s) origins.
   frameAncestors: null
-  # Keep this longer than backend.http.timeout so the backend owns normal API
-  # deadline responses. The previous Node frontend safely ignores this value.
-  proxyTimeout: "65s"
-  # /health_check reports whether the Web entry itself can serve traffic. It is
-  # intentionally independent from backend readiness; the backend probe below
-  # still keeps the Pod out of Service endpoints until informer caches sync.
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 3
-    failureThreshold: 6
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 1
-    periodSeconds: 5
-    timeoutSeconds: 3
-    failureThreshold: 3
 
-# Kratos server timeouts. These bound the deadline placed on each incoming HTTP/gRPC
-# request context. They no longer affect /metrics generation (which runs in the background),
-# but they still gate the page-side APIs, some of which legitimately take a few seconds
-# against a large Prometheus / VictoriaMetrics cluster.
+# Kratos API timeout. This bounds each incoming API request context without
+# affecting background metric collection.
 backend:
   http:
     timeout: "60s"
-  grpc:
-    timeout: "60s"
-  # Readiness probe on the backend's /readyz. The backend only starts listening
-  # after its k8s informer caches have synced, so gating the pod on /readyz keeps
-  # it out of the Service until the backend can serve — this prevents the Web entry
-  # from hitting "connection refused" against the not-yet-listening backend
-  # during startup. failureThreshold * periodSeconds should comfortably exceed the
-  # worst-case informer sync time on a large cluster.
-  readinessProbe:
+
+# The unified process starts both listeners only after Kubernetes informer
+# caches have synced. The startup budget allows five minutes for that initial
+# sync; subsequent probes verify the public Web entry.
+probes:
+  startup:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 0
     periodSeconds: 5
     timeoutSeconds: 3
     failureThreshold: 60
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 6
 
 # Background /metrics collector. The collector runs independently of Prometheus scrape;
 # scrapes only serialize the in-memory registry, so they are O(1) and immune to scrape
@@ -256,9 +212,6 @@ metricsExporter:
   # Hard cap on a single refresh cycle. Should be >= externalPrometheus.timeout and < interval * 2.
   timeout: "60s"
 
-# The frontend axios client timeout (default 60000ms) is compiled into the JS
-# bundle at image build time from the VITE_APP_REQUEST_TIMEOUT env var. To
-# change it for a deployed cluster you need to rebuild packages/web with a
-# different VITE_APP_REQUEST_TIMEOUT
-# (set in packages/web/.env.production before building the frontend image). It
-# cannot be tuned through this values.yaml.
+# The browser API timeout (default 60000ms) is compiled into the JavaScript
+# bundle from VITE_APP_REQUEST_TIMEOUT. Changing it requires rebuilding the
+# unified image; it cannot be tuned through this values file.

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -55,19 +55,17 @@ dependency or tool versions change. On Linux, use
 `pnpm exec playwright install --with-deps chromium` when Chromium's system
 libraries are not already installed.
 
-## Build HAMi-WebUI
+## Build and run HAMi-WebUI
 
-The Chart 1.x deployment consists of two containers:
+Chart 2 deploys one application image and one container. Its Go process serves
+the built Vue application on port `3000`, invokes the versioned API handler
+in-process, and exposes readiness, metrics, and diagnostics on the internal port
+`8000`.
 
-- the Go API and metrics backend; and
-- the Web entry, which serves the built Vue application and proxies
-  `/api/vgpu/v1/*` to the backend.
+Node.js and pnpm remain build and test dependencies for the Vue application.
+They are not present in the production image.
 
-Node.js is required to build the Vue application. The frontend image built from
-this revision uses Go at runtime; the previous official Node image remains
-supported for Chart 1.x rollback.
-
-### Backend
+### Backend development
 
 Generate the API code and start the backend from the repository root:
 
@@ -75,19 +73,17 @@ Generate the API code and start the backend from the repository root:
 make -C server run
 ```
 
-By default, you can access the web-ui-server-swagger at `http://localhost:8000/q/swagger-ui`.
+Swagger is available at `http://localhost:8000/q/swagger-ui`.
 
-### Frontend
+### Frontend development
 
-Start the backend first, then run `make dev` in the repository root. This
-starts the Vite development server; NestJS is not part of the browser
-development path. Vite forwards browser requests below `/api/vgpu/v1/*`
-directly to the backend at `http://127.0.0.1:8000` and removes the
+Start the backend first, then run `make dev` in the repository root. This starts
+the Vite development server; NestJS is not part of the browser development
+path. Vite forwards `/api/vgpu/v1/*` to `http://127.0.0.1:8000` and removes the
 `/api/vgpu` prefix.
 
-By default, you can access the web-ui at `http://localhost:3000/`.
-
-Set `HAMI_WEBUI_BACKEND_URL` when the backend uses a different origin:
+Open `http://localhost:3000/`. Set `HAMI_WEBUI_BACKEND_URL` when the backend
+uses another origin:
 
 ```bash
 HAMI_WEBUI_BACKEND_URL=http://127.0.0.1:18000 make dev
@@ -106,104 +102,86 @@ build, the Go Web entry, and its HTTP and Chromium contracts. The server target
 generates code before building, vetting, and testing every Go package. CI calls
 the same granular Make targets so local and pull-request behavior stay aligned.
 
-To exercise the production Web entry locally:
+To exercise the standalone Web entry while changing its static-serving
+contract:
 
 ```bash
 make build build-web-entry
 server/build/web-entry --static-dir ./public
 ```
 
-The backend must be available at `http://127.0.0.1:8000` for API requests.
+The backend must be available at `http://127.0.0.1:8000` for API requests in
+this standalone mode.
 
-### Chart 1.x frontend image contract
+### Chart 2 application contract
 
-The frontend image owns its OCI entrypoint; the Chart does not inject a
-Node-specific command. A compatible custom image must:
+The official image owns its OCI entrypoint; the Chart does not inject an
+implementation-specific command. The image runs as a numeric non-root user and
+is verified on amd64 and arm64 with a read-only root filesystem.
 
-- listen on port `3000`;
-- return HTTP 200 from `/health_check` without depending on backend readiness;
-- serve the SPA and its static assets;
-- forward `/api/vgpu/v1/*` to the backend while preserving HTTP status codes;
-  and
-- terminate cleanly on `SIGTERM`.
+The public listener exposes the SPA and only the versioned HAMi Web API below
+`/api/vgpu/v1/*`. Backend-only `/metrics`, `/readyz`, and `/q` endpoints remain
+on port `8000` for internal diagnostics and scraping. The browser API calls the
+backend handler directly in-process; there is no loopback reverse proxy.
 
-The new official Go image additionally runs as a numeric non-root user and is
-verified with a read-only root filesystem in CI. Those are official-image
-security gates, not new requirements retroactively imposed on the previous
-official image.
-
-The new official Go Web entry exposes only the versioned HAMi Web API through
-the same-origin entry. Backend-only `/metrics`, `/readyz`, and `/q` endpoints
-remain available only on the backend listener for internal diagnostics and
-scraping. Pinning the previous Node-based official image restores its legacy
-wildcard `/api/vgpu/*` proxy and HTTP 200 / `code: 599` proxy-error behavior;
-that rollback path does not provide the new routing or error guarantees. The
-legacy process may also require forced termination when the Pod's termination
-grace period expires.
-
-The official Go Web entry also accepts these optional environment variables:
+The unified application accepts these optional environment variables:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `HAMI_WEBUI_LISTEN_ADDRESS` | `:3000` | Standalone Web listener; Chart 1.x requires `:3000` |
-| `HAMI_WEBUI_BACKEND_URL` | `http://127.0.0.1:8000` | Backend origin |
+| `HAMI_WEBUI_LISTEN_ADDRESS` | `:3000` | Public Web listener; the Chart requires `:3000` |
 | `HAMI_WEBUI_STATIC_DIR` | `/apps/public` | Built Vue asset directory |
-| `HAMI_WEBUI_PROXY_TIMEOUT` | `65s` | End-to-end backend request timeout; keep it longer than `backend.http.timeout` |
 | `HAMI_WEBUI_BASE_PATH` | `/` | Public URL prefix; the reverse proxy must preserve it |
 | `HAMI_WEBUI_FRAME_ANCESTORS_JSON` | unset | JSON framing allowlist; `[]` blocks all parents |
 | `HAMI_WEBUI_HEALTHCHECK_URL` | `http://127.0.0.1:3000/health_check` | Target used only by `--healthcheck` |
 
-The public port, health endpoint, and versioned API prefix are compatibility
-contracts.
-Filesystem paths and executable names inside the image are not.
+`HAMI_WEBUI_BACKEND_URL` and `HAMI_WEBUI_PROXY_TIMEOUT` apply only to the
+standalone Web-entry development binary. They are intentionally absent from the
+Chart 2 in-process runtime. The public port, health endpoint, and versioned API
+prefix are compatibility contracts; filesystem paths and executable names are
+not.
 
-The official Go frontend can serve the SPA below a configured base path and
-emit a validated CSP `frame-ancestors` policy. These settings are runtime
-configuration, not Vite build variables. The unprefixed `/health_check`
-endpoint remains stable for Chart probes.
+The application can serve the SPA below a configured base path and emit a
+validated CSP `frame-ancestors` policy. These are runtime settings, not Vite
+build variables. The unprefixed `/health_check` remains stable for Chart probes.
 
-### Chart 1.x Service topology
+### Chart 2 Service and probe topology
 
-The primary Service routes browser traffic to the Web entry on port `3000`.
-An independently labelled `*-backend` ClusterIP Service routes port `8000` to
-the backend container and is the only Service selected by the included
-ServiceMonitor. The Deployment keeps `component: hami-webui` because both
-containers share one Pod; the backend component label belongs to the Service
-used for discovery, not to a separate backend workload.
+The primary Service routes browser traffic to port `3000`. An independently
+labelled `*-backend` ClusterIP Service routes port `8000` to the same container
+and is the only Service selected by the included ServiceMonitor. The `backend`
+component label belongs to this discovery Service, not to a separate workload
+or authorization boundary. The primary Service never exposes port `8000` in
+Chart 2.
 
-The primary Service retains a deprecated port `8000` only when
-`service.legacyBackendPort` is enabled for Chart 1.x compatibility. Do not
-widen the ServiceMonitor selector to include both Services: that would create
-duplicate scrape targets. The ClusterIP split also does not create an
-authorization boundary; cluster-internal access policy remains a deployment
-concern.
+The startup probe waits for `/readyz` on port `8000` for up to 300 seconds so
+Kubernetes informer caches can synchronize. After startup, readiness and
+liveness probe `/health_check` on port `3000`. This separates slow initial data
+bootstrap from the ongoing ability to serve the Web entry.
 
 ## Build a Docker image
 
-To build a frontend development image for the local Docker platform, run:
+Build the same unified target used by development publication and release
+candidates:
 
 ```bash
-make build-image
+make build-unified-image
 ```
 
-The resulting image is tagged as `hami-webui-frontend:dev`. It
-contains the Go Web entry and built Vue assets, but no production Node.js
-runtime.
-
-Build the backend development image from the repository root:
+The resulting image is tagged `hami-webui:dev`. Override
+`UNIFIED_DOCKER_IMAGE`, `VERSION`, or `PLATFORM` when a local integration
+environment needs another tag or architecture:
 
 ```bash
-make -C server build-image
+make build-unified-image \
+  UNIFIED_DOCKER_IMAGE=my-registry/hami-webui \
+  VERSION=test \
+  PLATFORM=linux/amd64
 ```
 
-The resulting image is tagged as `hami-webui-backend:dev`. Override
-`DOCKER_IMAGE`, `VERSION`, or `PLATFORM` when a local integration environment
-needs a different tag or architecture, for example:
+This target builds one local image and never pushes it. Stable multi-platform
+images, the Helm chart, release tag, and release notes are published only
+through the [verified release process](../releasing.md).
 
-```bash
-make build-image DOCKER_IMAGE=my-registry/hami-webui-frontend VERSION=test PLATFORM=linux/amd64
-```
-
-These targets build one local development image and never push it. Stable
-multi-platform images, the Helm chart, release tag, and release notes are
-published only through the [verified release process](../releasing.md).
+Chart 1.3 rollback restores its complete two-image deployment. Do not combine a
+Chart 1.x frontend or backend image with the Chart 2 templates; see the
+[Helm migration guide](../installation/helm/index.md#upgrade-from-chart-13-to-20).

--- a/docs/installation/embedding.md
+++ b/docs/installation/embedding.md
@@ -2,7 +2,7 @@
 
 HAMi-WebUI can be served below a URL prefix such as `/hami/` and embedded as a
 whole application in an internal platform. The prefix and framing policy are
-runtime settings: the frontend image does not need to be rebuilt.
+runtime settings: the application image does not need to be rebuilt.
 
 HAMi-WebUI remains a single-cluster, read-only UI. It does not provide login,
 RBAC, or a multi-cluster gateway. Put an authenticated Ingress or identity-aware
@@ -29,7 +29,7 @@ ingress:
           pathType: Prefix
 ```
 
-The official Go frontend accepts `/hami/`, its SPA deep links, static assets,
+The official Go application accepts `/hami/`, its SPA deep links, static assets,
 and `/hami/api/vgpu/v1/*`. The unprefixed `/health_check` endpoint remains
 available for Kubernetes probes. HAMi-WebUI deliberately does not trust
 `X-Forwarded-Prefix`; configure a non-stripping proxy instead.
@@ -84,15 +84,20 @@ HAMi-WebUI.
 
 ## Upgrade and rollback boundary
 
-Runtime base paths and application-managed framing require an official Go
-frontend image from a release that documents these values. Released Chart
-versions through v1.3.0 used the previous Node image; that image and arbitrary
-custom frontend images may ignore these environment variables and are supported
-only at `/` unless they implement the same contract.
+Chart 2 keeps `frontend.basePath` and `frontend.frameAncestors`, but replaces the
+Chart 1.x frontend/backend image pair with one application image. Do not reuse a
+Chart 1.x values file during this major upgrade. Create a fresh Chart 2 values
+file and follow the [Helm upgrade procedure](helm/index.md#upgrade-from-chart-13-to-20).
+
+Released Chart versions through v1.3.0 used the previous Node frontend image.
+That image and arbitrary custom frontend images may ignore these runtime
+settings and are supported only at `/` unless they implement the same contract.
+Rollback to Chart 1.3 must therefore restore the complete Helm revision, not
+only an old frontend image inside the Chart 2 single-image deployment.
 
 If a deployment relies on the application framing policy, configure an
 equivalent policy at the authenticated proxy before rolling back to an older
-frontend image.
+Chart release.
 
 For the underlying browser behavior, see the W3C
 [Content Security Policy specification](https://www.w3.org/TR/CSP3/#directive-frame-ancestors).

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -2,11 +2,13 @@
 
 This topic includes instructions for installing and running HAMi-WebUI on Kubernetes using Helm Charts.
 
-The WebUI can only be accessed by your localhost, so you need to connect your localhost to the cluster by configuring `~/.kube/config` 
+The examples below use `kubectl port-forward` for local access. Configure
+`~/.kube/config` so `kubectl` and Helm can reach the target cluster.
 
 [Helm](https://helm.sh/) is an open-source command line tool used for managing Kubernetes applications. It is a graduate project in the [CNCF Landscape](https://www.cncf.io/projects/helm/).
 
-The HAMi-WebUI open-source community offers Helm Charts for running it on Kubernetes. Please be aware that the code is provided without any warranties. If you encounter any problems, you can report them to the [Official GitHub repository](https://github.com/hami-webui/helm-charts/).
+The HAMi-WebUI community publishes a Helm chart for Kubernetes. Report problems
+in the [HAMi-WebUI repository](https://github.com/Project-HAMi/HAMi-WebUI/issues).
 
 ## Prerequisites
 
@@ -57,7 +59,63 @@ To set up the HAMi-WebUI Helm repository so that you download the correct HAMi-W
    kubectl get pods -n kube-system | grep webui
    ```
 
-   You should get the expected both 'hami-webui' and 'hami-webui-dcgm-exporter' in running state if installation is successful.
+   By default, a successful Chart 2 installation has one Ready HAMi-WebUI Pod;
+   every HAMi-WebUI Pod contains one application container. When the bundled
+   dcgm-exporter is enabled, its DaemonSet schedules Pods on nodes matching its
+   node selector.
+
+### Upgrade from Chart 1.3 to 2.0
+
+Chart 2 replaces the Chart 1.x frontend/backend image pair with one application
+image and one container. This is an intentional major-version boundary: do not
+pass a Chart 1.x values file to Chart 2 and do not use `--reuse-values`.
+
+First save the values and revision used by the current release:
+
+```bash
+helm get values my-hami-webui --namespace kube-system --output yaml > values-v1-backup.yaml
+helm history my-hami-webui --namespace kube-system
+```
+
+Create a new `values-v2.yaml` from the Chart 2 defaults, then copy only the
+settings you still need. Chart 2 supports external Prometheus and TLS settings,
+ServiceMonitor labels, Ingress, scheduling, security contexts,
+`frontend.basePath`, and `frontend.frameAncestors`; copy only settings that are
+actually present in your deployment.
+
+Do not copy these Chart 1.x settings:
+
+- `image.frontend` or `image.backend`; configure the flat `image` value;
+- `resources.frontend` or `resources.backend`; choose one `resources` budget;
+- `env.frontend` or `env.backend`; use the single `env` list;
+- container-specific probes; use the top-level `probes` settings; or
+- `frontend.proxyTimeout`, `backend.grpc`, or `service.legacyBackendPort`, which
+  no longer apply to the in-process API and single-container Service topology.
+
+After Chart 2.0.0 is published, upgrade with Helm defaults reset so removed
+values cannot leak from release history:
+
+```bash
+helm upgrade my-hami-webui hami-webui/hami-webui \
+  --namespace kube-system \
+  --version 2.0.0 \
+  --reset-values \
+  --values values-v2.yaml \
+  --wait
+```
+
+Chart 2 rejects known Chart 1.x value shapes instead of silently ignoring them.
+If rollback is needed, restore the complete previous Helm revision—not an old
+frontend or backend image inside the Chart 2 Pod:
+
+```bash
+helm rollback my-hami-webui <CHART-1-REVISION> \
+  --namespace kube-system \
+  --wait
+```
+
+That rollback restores the Chart 1.3 templates, values, and two-image runtime
+together. Use `--reset-values` again when moving forward to Chart 2.
 
 ### HTTPS external Prometheus
 
@@ -85,8 +143,8 @@ externalPrometheus:
 When Prometheus requires mutual TLS, add the client certificate and key to the
 same Secret and configure `certKey` and `keyKey` together. `serverName` is
 available when certificate verification must use a name different from the URL
-host. Secret contents are mounted only into the backend container; they are not
-copied into the rendered ConfigMap.
+host. Secret contents are mounted only into the HAMi-WebUI application
+container; they are not copied into the rendered ConfigMap.
 
 `insecureSkipVerify: true` remains available only as an explicit temporary
 escape hatch. It disables certificate-chain and host-name verification and
@@ -124,48 +182,40 @@ If the same Prometheus selects both this chart's ServiceMonitor and HAMi's
 built-in device-plugin ServiceMonitor (`prometheus.enabled` in the HAMi chart),
 the endpoint is scraped twice. Configure that Prometheus to select only one.
 
-### Backend service boundary
+### Single-container service boundary
 
-HAMi-WebUI exposes the supported browser API through the same-origin Web entry
-on the primary Service. The backend listener on port `8000` also serves raw API,
-`/readyz`, `/metrics`, and Swagger endpoints, so the chart creates a separate
-ClusterIP Service with a generated `*-backend` name (for example,
-`my-hami-webui-backend`) for backend discovery and Prometheus scraping.
+Chart 2 runs the SPA, browser API, metrics collector, and Kubernetes providers
+in one Go process and one container. The process keeps two listeners:
 
-For Chart 1.x upgrade compatibility, the primary Service still includes port
-`8000` by default. The port is deprecated and can be removed from the primary
-Service without affecting WebUI traffic or the included ServiceMonitor:
+- port `3000` is exposed by the primary Service and is the supported browser
+  entry for the SPA and `/api/vgpu/v1/*`;
+- port `8000` is exposed only through the generated internal `*-backend`
+  ClusterIP Service for `/readyz`, `/metrics`, and diagnostics.
 
-```yaml
-service:
-  legacyBackendPort: false
-```
+The port `8000` listener also contains implementation-level API and Swagger
+routes. It is not a public compatibility contract or an authorization boundary.
+The primary Service no longer exposes it, and Chart 2 removes
+`service.legacyBackendPort`.
 
-Set this to `false` for `NodePort` and `LoadBalancer` Services unless an existing
-integration still connects directly to the raw backend. Move in-cluster clients
-to the generated backend Service on port `8000`. For local diagnostics, forward
-that Service instead of changing the primary Service type:
+For local diagnostics, forward the internal Service instead of changing the
+primary Service type:
 
 ```bash
 kubectl port-forward service/my-hami-webui-backend 8000:8000 --namespace=kube-system
 ```
 
-Use NetworkPolicy or an equivalent cluster policy when backend access must also
-be restricted inside the cluster; a ClusterIP Service is a discovery boundary,
-not an authorization boundary.
+ClusterIP controls discovery and exposure through the primary Service; it does
+not by itself authorize callers inside the cluster.
 
-The included ServiceMonitor now selects only the backend Service, so retaining
-the compatibility port does not double-scrape Pods. It preserves the existing
-Prometheus `job` label through an explicit Service label; the generated `service`
-target label changes to the generated backend Service name. Update custom rules
-that match `service` before upgrading.
+The included ServiceMonitor selects only the internal Service and preserves the
+existing Prometheus `job` label through an explicit Service label. The generated
+`service` target label is the generated internal Service name. Update custom
+rules that match `service` before upgrading.
 
 Custom ServiceMonitors that still select the primary Service—whether by
 `component: hami-webui` or only the common name and instance labels—and port
-`metrics` must move to `component: backend` and port `backend-http`. Otherwise
-they can duplicate the included ServiceMonitor while the compatibility port is
-enabled, and stop finding a target when it is disabled. The compatibility port
-will be removed from the primary Service in Chart 2.0.0.
+`metrics` must move to `component: backend` and port `backend-http`; otherwise
+they no longer find a target in Chart 2.
 
 ### Access HAMi-WebUI
 
@@ -201,8 +251,7 @@ It is important to view the HAMi-WebUI server logs while troubleshooting any iss
 To check the HAMi-WebUI logs, run the following command:
 
 ```bash
-kubectl logs --namespace=hami deploy/my-hami-webui -c hami-webui-fe-oss
-kubectl logs --namespace=hami deploy/my-hami-webui -c hami-webui-be-oss
+kubectl logs --namespace=kube-system deployment/my-hami-webui
 ```
 
 For more information about accessing Kubernetes application logs, refer to [Pods](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#interacting-with-running-pods) and [Deployments](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#interacting-with-deployments-and-services).
@@ -212,16 +261,11 @@ For more information about accessing Kubernetes application logs, refer to [Pods
 
 To uninstall the HAMi-WebUI deployment, run the command:
 
-`helm uninstall <RELEASE-NAME> <NAMESPACE-NAME>`
+`helm uninstall <RELEASE-NAME> --namespace <NAMESPACE-NAME>`
 
 ```bash
-helm uninstall my-hami-webui -n hami
+helm uninstall my-hami-webui --namespace kube-system
 ```
 
-This deletes all of the objects from the given namespace hami.
-
-If you want to delete the namespace `hami`, then run the command:
-
-```bash
-kubectl delete namespace hami
-```
+This deletes the objects managed by that Helm release. It does not delete the
+namespace.

--- a/docs/proposals/chart-2-single-image.md
+++ b/docs/proposals/chart-2-single-image.md
@@ -1,0 +1,62 @@
+---
+title: Chart 2 Single-Image Runtime
+authors:
+- "@Nimbus318"
+approvers: []
+creation-date: 2026-08-31
+status: accepted
+---
+
+# Chart 2 Single-Image Runtime
+
+## Context
+
+Chart 1.x ran a Web entry and the HAMi API as two containers and published two
+images. They shared one Pod and release lifecycle, so the split did not provide
+independent scaling or isolation. It did add a second image, resource contract,
+upgrade surface, and production runtime to operate.
+
+The Go application can now serve the built Vue assets and invoke the API handler
+in-process. Node.js remains necessary to build and test the Vue application, but
+is not needed in the production image.
+
+## Decision
+
+Chart 2 deploys one `projecthami/hami-webui` image and one container. The process
+keeps two HTTP listeners with different exposure:
+
+- port `3000` is the supported browser entry for the SPA and
+  `/api/vgpu/v1/*`;
+- port `8000` is the internal readiness, metrics, and diagnostics listener. A
+  separate internal Service exposes it for metrics scraping; it is not an
+  authentication boundary or a public API contract.
+
+The primary Service exposes only port `3000`. The existing internal Service and
+ServiceMonitor topology remain so Prometheus continues to discover one target
+per Ready Pod.
+
+Chart 2 uses flat `image`, `resources`, and `env` values. It retains
+`frontend.basePath`, `frontend.frameAncestors`, external Prometheus TLS, and the
+existing Service, Ingress, ServiceMonitor, scheduling, and security-context
+extension points. This decision does not change RBAC, NetworkPolicy, external
+authentication, or the default iframe policy.
+
+## Migration and rollback
+
+Chart 1.x nested image, resource, environment, probe, proxy, gRPC, and legacy
+backend-port values are rejected instead of silently ignored. Operators must
+create a fresh Chart 2 values file and upgrade with `--reset-values`.
+
+The supported rollback is `helm rollback` to the previous Chart 1.3 revision,
+which restores its templates, values, and image pair together. Mixing a Chart
+1.x frontend or backend image into the Chart 2 Pod is not supported.
+
+## Consequences
+
+- The Web UI, API, and static assets are released and rolled back atomically.
+- Production has one image, one SBOM/CVE surface, and one container resource
+  budget.
+- Browser and internal listener semantics remain distinct even though they run
+  in one process.
+- The major Chart version and fail-closed value validation make the breaking
+  deployment contract explicit.

--- a/docs/proposals/web-entry-and-embedding.md
+++ b/docs/proposals/web-entry-and-embedding.md
@@ -4,7 +4,7 @@ authors:
 - "@Nimbus318"
 approvers: []
 creation-date: 2026-08-30
-status: proposed
+status: accepted
 ---
 
 # HAMi-WebUI Single-Cluster Web Entry and Embedding Architecture
@@ -16,12 +16,12 @@ be easy for platform teams to embed in an existing portal without rebuilding the
 frontend for each deployment.
 
 The same-origin Web entry remains part of the product contract, but it does not
-require a pass-through NestJS process. For HAMi-WebUI Chart package 1.x, the
-production NestJS runtime was replaced by a minimal static-file and
-reverse-proxy Gateway while preserving the public Helm and HTTP contracts.
-
-A single Go application image is deferred to Chart version 2.0.0 and will be
-considered only after compatibility and adoption conditions are met.
+require a pass-through NestJS process. After v1.3.0, the unreleased Chart 1.x
+main branch replaced the production NestJS runtime with a minimal static-file
+and reverse-proxy Gateway while preserving the public Helm and HTTP contracts.
+Chart 2 completes the transition with one Go application image and one
+container, as recorded in
+[`chart-2-single-image.md`](chart-2-single-image.md).
 
 This proposal supersedes the multi-cluster direction in
 `docs/proposals/webui-redesign.md`. Its goals around build consistency, metric
@@ -61,7 +61,8 @@ separate workstreams.
 - A central multi-cluster control plane or cluster registry.
 - Workload creation, mutation, or lifecycle management.
 - A widget SDK or micro-frontend framework in the first embedding iteration.
-- An immediate migration to one Go image.
+- A change to RBAC, NetworkPolicy, external authentication, or the default
+  iframe policy as part of runtime consolidation.
 - Metric correctness, dashboard aggregation, and exporter query optimization;
   those continue as independent workstreams.
 
@@ -124,11 +125,14 @@ support alone is not complete iframe support: framing policy, external
 authentication, cookies, navigation, and deep-link behavior must also be
 verified.
 
-### Chart 1.x Web Gateway
+### Post-v1.3 Web Gateway transition
 
-Chart 1.x continues to deploy separate frontend and backend containers. The
-frontend container uses the standard-library Go Web entry instead of a
-production NestJS runtime.
+This section records the compatibility bridge that preceded Chart 2; it is not
+the current deployment contract.
+
+The unreleased post-v1.3 transition retained separate frontend and backend
+containers. Its frontend container used the standard-library Go Web entry
+instead of a production NestJS runtime.
 
 The following public contracts remain stable:
 
@@ -183,21 +187,22 @@ probes so a failed Gateway cannot leave the Pod ready merely because the
 backend is healthy.
 
 Go port `8000` is a backend listener, not a metrics-only listener: it serves the
-API, `/readyz`, and `/metrics`. Chart 1.x provides a separately labelled internal
-backend ClusterIP Service, and ServiceMonitor selects only that Service. The
-primary Web Service's existing port `8000` remains a compatibility contract
-through the documented, deprecated `service.legacyBackendPort` option. It is
-enabled by default in Chart 1.x, can be disabled by security-sensitive
-deployments, and is removed only in Chart version 2.0.0. Distinct Service labels
-ensure that each Ready backend Pod has one scrape target and is not discovered
-again through the primary Service.
+API, `/readyz`, and `/metrics`. The post-v1.3 transition provided a separately
+labelled internal backend ClusterIP Service, and ServiceMonitor selected only
+that Service. The primary Web Service's existing port `8000` remained a
+compatibility contract through the documented, deprecated
+`service.legacyBackendPort` option. It was enabled by default during the
+transition, could be disabled by security-sensitive deployments, and is removed
+in Chart version 2.0.0. Distinct Service labels ensure that each Ready backend
+Pod has one scrape target and is not discovered again through the primary
+Service.
 
 The selected Web entry supports a non-root, read-only container; amd64 and
 arm64; deterministic proxy status codes; runtime base-path and framing
 configuration; and a small standard-library runtime surface. The default proxy
-timeout is explicit and longer than the default backend HTTP timeout. In Chart
-1.x it uses a reverse-proxy API adapter; Chart 2.0 can reuse the same static,
-routing, cache, compression, and framing handler with the in-process API
+timeout is explicit and longer than the default backend HTTP timeout. The
+post-v1.3 transition used a reverse-proxy API adapter; Chart 2 reuses the same
+static, routing, cache, compression, and framing handler with the in-process API
 handler. This keeps the compatibility bridge from becoming throwaway
 infrastructure.
 
@@ -207,9 +212,10 @@ frontend image was verified.
 
 ### Observable contract
 
-The target behavior below applies to the new official Go Web entry. The legacy
-frontend image is tested as a rollback path under its explicitly documented
-legacy semantics.
+The behavior below applies to the official Go Web entry in both the post-v1.3
+transition and the Chart 2 application unless a row is explicitly scoped to
+the reverse-proxy bridge. The v1.3.0 frontend image is a rollback path under its
+documented legacy semantics.
 
 | Scenario | Required result |
 | --- | --- |
@@ -218,51 +224,47 @@ legacy semantics.
 | Existing `/api/vgpu/v1/*` request | Preserve method, query, body, relevant headers, response body, and upstream status |
 | Unknown application request below `/api/vgpu/v1/*` | Preserve the backend's non-2xx JSON response |
 | Unsupported version or backend-only `/metrics`, `/readyz`, or `/q` path, directly or below `/api/vgpu` | Return HTTP 404 without proxying |
-| Backend connection refused / timed out | Return HTTP 502 / 504 with a non-success JSON response |
-| `/health_check` | Return HTTP 200 when the Gateway can serve, independent of backend readiness |
+| Post-v1.3 reverse-proxy bridge: backend connection refused / timed out | Return HTTP 502 / 504 with a non-success JSON response |
+| `/health_check` | Return HTTP 200 when the public Web entry can serve requests |
 | `index.html` / hashed asset | No long-lived cache / immutable cache with compression |
 | Iframe parent | Unset preserves the existing behavior; `[]` blocks all parents; explicit `'self'` and origin sources allow only those parents |
-| Primary Web / internal backend Services | Disabling the legacy backend port removes `8000` from Web exposure; ServiceMonitor discovers each Ready backend Pod exactly once |
-| Architecture | The new official Gateway frontend image passes non-root, read-only-filesystem, amd64, and arm64 smoke tests |
-| Migration | New Chart plus previous official frontend digest, and Helm rollback, both pass at the root base path |
+| Primary Web / internal backend Services | The primary Chart 2 Service exposes only `3000`; ServiceMonitor discovers each Ready Pod exactly once through the internal `8000` Service |
+| Architecture | The official application image passes non-root, read-only-filesystem, amd64, and arm64 smoke tests |
+| Migration | Chart 2 upgrade with fresh values and full Helm rollback to Chart 1.3 both pass at the root base path |
 
-### Chart version 2.0.0 gates
+### Chart version 2.0.0 follow-up
 
-A unified Go application image is an option, not a committed Chart 1.x
-deliverable. Exploration may begin when all of the following are true:
+The unified application and image passed the HTTP, browser, non-root,
+read-only-filesystem, and multi-architecture gates before becoming the Chart 2
+runtime. Keeping an unreleased two-image transition for another release would
+have preserved publication and operational complexity without an independent
+scaling boundary, so maintainers accepted the explicit major-version migration.
 
-1. The minimal Gateway has been stable for at least one release cycle.
-2. Maintainers have collected feedback on custom `image.frontend`, branding,
-   base-path, and iframe usage.
-3. There is a testable hypothesis for release or operational benefit.
-4. Maintainers accept a Chart major-version migration.
+Chart 2 exposes named `http` and `metrics` container ports from one Go
+application. The names describe traffic, not an authorization boundary. The
+primary Service exposes only port `3000`; a separate internal Service keeps
+port `8000` discoverable for readiness and metrics. Removed Chart 1.x values
+fail with a clear migration message rather than being silently ignored.
 
-The unified image may become the default only after its benefit is measured;
-upgrade, both rollback paths, multi-architecture, and read-only-filesystem tests
-pass; and the release controller is migrated from two components to one without
-weakening fail-closed digest or publication checks.
-
-If adopted, Chart version 2.0.0 may expose named `web` and `metrics` listeners
-from one Go application image. It must not call them `public` and `admin`,
-because those names imply an authorization boundary that does not exist.
-Removed Chart 1.x values must fail with a clear migration message rather than
-being silently ignored.
+The release remains gated on Helm upgrade and rollback verification plus final
+maintainer browser acceptance. The complete Chart 2 decision and migration
+boundary are recorded in [`chart-2-single-image.md`](chart-2-single-image.md).
 
 ## Consequences
 
 - Node.js remains a frontend build dependency, but the production runtime and
   checked-in NestJS dependency graph are removed.
-- Chart 1.x deliberately retains two containers, two images, and one same-Pod
-  proxy hop. Those costs are accepted to preserve upgrade and customization
-  contracts.
+- Chart 1.x retained two containers as a compatibility bridge. Chart 2 has one
+  image, one container resource budget, and no same-Pod proxy hop.
 - Leaving the framing allowlist empty preserves compatibility but leaves the
   existing clickjacking risk to the deployment boundary.
-- Custom frontend images are supported only through the documented container
-  contract; arbitrary internal layouts are not a compatibility promise.
-- A single Go image, Chart version 2.0.0, built-in authentication, and
-  multi-cluster control remain intentionally deferred.
+- Custom frontend-only images remain a Chart 1.x rollback concern. Chart 2
+  accepts a complete application image, not an independently replaceable
+  frontend container.
+- Built-in authentication and multi-cluster control remain intentionally
+  deferred.
 
-## Migration plan
+## Implementation sequence
 
 1. Add a Gateway-independent test harness and passing baseline tests for the
    current root SPA, deep-link refresh, API method/body/status forwarding,
@@ -278,9 +280,9 @@ being silently ignored.
 5. Verify Kubernetes install, upgrade, Helm rollback, image rollback, and
    backend failure recovery in an integration environment.
 6. Delete the unused NestJS runtime and dependencies after parity and rollback
-   are established, then publish and observe the Chart 1.x transition release.
-7. Treat a single Go image as separate Chart version 2.0.0 work after the
-   exploration gates are satisfied.
+   are established.
+7. Adopt the independently verified unified image through the explicit Chart 2
+   values and rollback boundary.
 
 Gateway pull requests do not require GPU hardware. Every stable release remains
 subject to the risk-based Kubernetes, GPU, and maintainer browser acceptance in
@@ -296,8 +298,8 @@ designed if a concrete client-specific or session-owning requirement appears.
 
 ### Move directly to Go static embedding in Chart 1.x
 
-Deferred. It would remove the public `image.frontend` customization and change
-Chart, release, and rollback contracts before their real usage is known.
+Rejected for the Chart 1.x compatibility bridge. The same consolidation was
+later adopted at the explicit Chart 2 major-version boundary.
 
 ### Add multi-cluster routing to the current Web process
 

--- a/scripts/chart/tests/values-chart1-transition.yaml
+++ b/scripts/chart/tests/values-chart1-transition.yaml
@@ -1,0 +1,183 @@
+# Complete values from the post-v1.3 Chart 1 transition immediately before the
+# Chart 2 migration. Keep this fixture intact: it exercises every removed
+# Chart 1 key and proves that reusing an old values set fails with one actionable
+# migration error instead of silently rendering a mixed Pod.
+
+replicaCount: 1
+
+vendorNodeSelectors:
+  NVIDIA: gpu=on
+  Ascend: ascend=on
+  DCU: dcu=on
+  MLU: mlu=on
+  Metax: metax-tech.com/gpu.installed=true
+
+image:
+  frontend:
+    repository: projecthami/hami-webui-fe-oss
+    pullPolicy: IfNotPresent
+    tag: "v1.3.0"
+    digest: "sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e"
+  backend:
+    repository: projecthami/hami-webui-be-oss
+    pullPolicy: IfNotPresent
+    tag: "v1.3.0"
+    digest: "sha256:7057047c7c2f7838cd190b3dc7263d503bbcf5d8e52642bc703227d137bc029d"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 3000
+  legacyBackendPort: true
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources:
+  frontend:
+    limits:
+      cpu: 200m
+      memory: 500Mi
+    requests:
+      cpu: 200m
+      memory: 500Mi
+  backend:
+    limits:
+      cpu: 50m
+      memory: 250Mi
+    requests:
+      cpu: 50m
+      memory: 250Mi
+
+env:
+  frontend:
+    - name: TZ
+      value: "Asia/Shanghai"
+  backend:
+    - name: TZ
+      value: "Asia/Shanghai"
+
+serviceMonitor:
+  enabled: true
+  interval: 15s
+  honorLabels: false
+  additionalLabels:
+    jobRelease: hami-webui-prometheus
+  relabelings: []
+
+hamiServiceMonitor:
+  enabled: true
+  interval: 15s
+  honorLabels: true
+  additionalLabels:
+    jobRelease: hami-webui-prometheus
+  svcNamespace: kube-system
+  relabelings: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+dcgm-exporter:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    honorLabels: false
+    additionalLabels:
+      jobRelease: hami-webui-prometheus
+  nodeSelector:
+    gpu: "on"
+
+kube-prometheus-stack:
+  enabled: false
+  crds:
+    enabled: false
+  defaultRules:
+    create: false
+  alertmanager:
+    enabled: false
+  grafana:
+    enabled: false
+  kubernetesServiceMonitors:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  kube-state-metrics:
+    prometheus:
+      monitor:
+        additionalLabels:
+          jobRelease: hami-webui-prometheus
+  prometheusOperator:
+    enabled: false
+  prometheus:
+    prometheusSpec:
+      serviceMonitorSelector:
+        matchLabels:
+          jobRelease: hami-webui-prometheus
+
+externalPrometheus:
+  enabled: false
+  address: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"
+  timeout: "1m"
+  tls:
+    insecureSkipVerify: false
+    serverName: ""
+    existingSecret: ""
+    caKey: ""
+    certKey: ""
+    keyKey: ""
+
+frontend:
+  basePath: "/"
+  frameAncestors: null
+  proxyTimeout: "65s"
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 6
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+backend:
+  http:
+    timeout: "60s"
+  grpc:
+    timeout: "60s"
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 60
+
+metricsExporter:
+  interval: "30s"
+  timeout: "60s"

--- a/scripts/verify-chart-upgrade.sh
+++ b/scripts/verify-chart-upgrade.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image_repository="${1:-projecthami/hami-webui}"
+image_tag="${2:-main}"
+cluster_name="${3:-hami-webui-chart-upgrade}"
+namespace="hami-webui-upgrade"
+release_name="upgrade-test"
+deployment_name="${release_name}-hami-webui"
+web_service_name="${release_name}-hami-webui"
+backend_service_name="${release_name}-hami-webui-backend"
+work_dir="$(mktemp -d)"
+cluster_created=false
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ "${cluster_created}" == "true" ]]; then
+    kind delete cluster --name "${cluster_name}" >/dev/null 2>&1
+  fi
+  rm -rf "${work_dir}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+for command in docker git helm jq kind kubectl tar; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "required command is unavailable: ${command}" >&2
+    exit 2
+  fi
+done
+
+if [[ ! "${image_repository}" =~ ^[a-z0-9._/-]+$ ]] ||
+  [[ ! "${image_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  echo "invalid test image reference: ${image_repository}:${image_tag}" >&2
+  exit 2
+fi
+
+legacy_chart="${work_dir}/legacy/charts/hami-webui"
+current_chart="${work_dir}/current/hami-webui"
+mkdir -p "${work_dir}/legacy" "${work_dir}/current"
+git -C "${repo_root}" archive v1.3.0 charts/hami-webui | tar -x -C "${work_dir}/legacy"
+cp -R "${repo_root}/charts/hami-webui" "${current_chart}"
+
+export HELM_CONFIG_HOME="${work_dir}/helm/config"
+export HELM_CACHE_HOME="${work_dir}/helm/cache"
+export HELM_DATA_HOME="${work_dir}/helm/data"
+helm repo add nvidia-dcgm https://nvidia.github.io/dcgm-exporter/helm-charts >/dev/null
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm dependency build --skip-refresh "${legacy_chart}" >/dev/null
+helm dependency build --skip-refresh "${current_chart}" >/dev/null
+
+legacy_overrides=(
+  # The released Chart renders multi-architecture index digests. Pull those
+  # immutable references below, retag the selected platform manifests, and load
+  # the tags into Kind so kubelet can use the locally imported images.
+  --set-string image.frontend.digest=
+  --set-string image.backend.digest=
+  --set dcgm-exporter.enabled=false
+  --set serviceMonitor.enabled=false
+  --set hamiServiceMonitor.enabled=false
+  --set kube-prometheus-stack.enabled=false
+)
+legacy_digest_images="$(helm template "${release_name}" "${legacy_chart}" \
+  --namespace "${namespace}" \
+  --set dcgm-exporter.enabled=false \
+  --set serviceMonitor.enabled=false \
+  --set hamiServiceMonitor.enabled=false \
+  --set kube-prometheus-stack.enabled=false \
+  --show-only templates/deployment.yaml | \
+  awk '$1 == "image:" { gsub(/"/, "", $2); print $2 }')"
+legacy_images="$(helm template "${release_name}" "${legacy_chart}" \
+  --namespace "${namespace}" \
+  "${legacy_overrides[@]}" \
+  --show-only templates/deployment.yaml | \
+  awk '$1 == "image:" { gsub(/\"/, "", $2); print $2 }')"
+if [[ "$(awk 'NF { count++ } END { print count + 0 }' <<<"${legacy_images}")" -ne 2 ]]; then
+  echo "expected exactly two Chart 1.3 application images" >&2
+  exit 1
+fi
+if [[ "$(awk 'NF { count++ } END { print count + 0 }' <<<"${legacy_digest_images}")" -ne 2 ]]; then
+  echo "expected exactly two pinned Chart 1.3 application images" >&2
+  exit 1
+fi
+
+paste <(printf '%s\n' "${legacy_digest_images}") <(printf '%s\n' "${legacy_images}") |
+  while IFS=$'\t' read -r digest_image runtime_image; do
+    docker pull "${digest_image}"
+    docker tag "${digest_image}" "${runtime_image}"
+  done
+
+image_reference="${image_repository}:${image_tag}"
+if ! docker image inspect "${image_reference}" >/dev/null 2>&1; then
+  docker pull "${image_reference}"
+fi
+all_images="${legacy_images}"$'\n'"${image_reference}"
+
+if kind get clusters | grep -Fxq "${cluster_name}"; then
+  echo "Kind cluster already exists; choose another name: ${cluster_name}" >&2
+  exit 2
+fi
+
+kind create cluster \
+  --name "${cluster_name}" \
+  --image kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507 \
+  --wait 120s
+cluster_created=true
+
+while IFS= read -r image; do
+  [[ -n "${image}" ]] || continue
+  if ! docker image inspect "${image}" >/dev/null 2>&1; then
+    echo "test image was not prepared locally: ${image}" >&2
+    exit 1
+  fi
+  kind load docker-image --name "${cluster_name}" "${image}"
+done <<<"${all_images}"
+
+helm install "${release_name}" "${legacy_chart}" \
+  --namespace "${namespace}" \
+  --create-namespace \
+  --values "${legacy_chart}/values.yaml" \
+  "${legacy_overrides[@]}" \
+  --wait \
+  --timeout 10m
+
+container_count() {
+  kubectl --namespace "${namespace}" get deployment "${deployment_name}" \
+    --output json | jq '.spec.template.spec.containers | length'
+}
+
+service_port_names() {
+  local service_name=$1
+  kubectl --namespace "${namespace}" get service "${service_name}" \
+    --output json | jq -r '.spec.ports[].name' | sort
+}
+
+service_proxy_get() {
+  local service_name=$1
+  local port_name=$2
+  local path=$3
+  kubectl get --raw \
+    "/api/v1/namespaces/${namespace}/services/http:${service_name}:${port_name}/proxy/${path}"
+}
+
+wait_for_service_path() {
+  local service_name=$1
+  local port_name=$2
+  local path=$3
+  for _ in {1..90}; do
+    if service_proxy_get "${service_name}" "${port_name}" "${path}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "service path did not become ready: ${service_name}:${port_name}/${path}" >&2
+  return 1
+}
+
+assert_equal() {
+  local description=$1
+  local expected=$2
+  local actual=$3
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'unexpected %s: expected %q, got %q\n' \
+      "${description}" "${expected}" "${actual}" >&2
+    return 1
+  fi
+}
+
+assert_legacy_contract() {
+  assert_equal "Chart 1.3 container count" "2" "$(container_count)"
+  assert_equal "Chart 1.3 Web Service ports" $'http\nmetrics' \
+    "$(service_port_names "${web_service_name}")"
+  if kubectl --namespace "${namespace}" get service "${backend_service_name}" >/dev/null 2>&1; then
+    echo "Chart 1.3 unexpectedly contains the Chart 2 backend discovery Service" >&2
+    return 1
+  fi
+  wait_for_service_path "${web_service_name}" http health_check
+  service_proxy_get "${web_service_name}" metrics metrics | grep -Fq '# HELP'
+}
+
+assert_current_contract() {
+  assert_equal "Chart 2 container count" "1" "$(container_count)"
+  assert_equal "Chart 2 Web Service ports" "http" \
+    "$(service_port_names "${web_service_name}")"
+  assert_equal "Chart 2 internal Service ports" "backend-http" \
+    "$(service_port_names "${backend_service_name}")"
+  wait_for_service_path "${web_service_name}" http health_check
+  service_proxy_get "${backend_service_name}" backend-http readyz | grep -Fq 'ok'
+  service_proxy_get "${backend_service_name}" backend-http metrics | grep -Fq '# HELP'
+  kubectl --namespace "${namespace}" exec deployment/"${deployment_name}" -- \
+    /apps/hami-webui --healthcheck
+}
+
+assert_legacy_contract
+
+assert_upgrade_rejected() {
+  local mode=$1
+  shift
+  local output
+  if output="$(helm upgrade "${release_name}" "${current_chart}" \
+    --namespace "${namespace}" "$@" 2>&1)"; then
+    echo "Chart 2 unexpectedly accepted Chart 1 values during ${mode}" >&2
+    return 1
+  fi
+  if ! grep -Fq 'HAMi-WebUI Chart 2.0 no longer accepts Chart 1.x split-container values' <<<"${output}"; then
+    echo "${mode} did not return the actionable Chart 2 migration error" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+  [[ "$(helm history "${release_name}" --namespace "${namespace}" --output json | jq 'length')" == "1" ]]
+  assert_legacy_contract
+}
+
+assert_upgrade_rejected "ordinary upgrade"
+assert_upgrade_rejected "--reuse-values upgrade" --reuse-values
+
+values_v2="${work_dir}/values-v2.yaml"
+cat >"${values_v2}" <<EOF
+image:
+  repository: "${image_repository}"
+  pullPolicy: IfNotPresent
+  tag: "${image_tag}"
+  digest: ""
+dcgm-exporter:
+  enabled: false
+serviceMonitor:
+  enabled: false
+hamiServiceMonitor:
+  enabled: false
+kube-prometheus-stack:
+  enabled: false
+externalPrometheus:
+  timeout: 1s
+metricsExporter:
+  interval: 3600s
+  timeout: 1s
+EOF
+
+helm upgrade "${release_name}" "${current_chart}" \
+  --namespace "${namespace}" \
+  --reset-values \
+  --values "${values_v2}" \
+  --wait \
+  --timeout 10m &
+upgrade_pid=$!
+availability_failures=0
+while kill -0 "${upgrade_pid}" >/dev/null 2>&1; do
+  if ! service_proxy_get "${web_service_name}" http health_check >/dev/null 2>&1; then
+    sleep 0.2
+    if ! service_proxy_get "${web_service_name}" http health_check >/dev/null 2>&1; then
+      availability_failures=$((availability_failures + 1))
+    fi
+  fi
+  sleep 1
+done
+wait "${upgrade_pid}"
+if [[ ${availability_failures} -ne 0 ]]; then
+  echo "Web Service was unavailable during the Chart 2 rolling upgrade" >&2
+  exit 1
+fi
+
+assert_current_contract
+
+helm rollback "${release_name}" 1 \
+  --namespace "${namespace}" \
+  --wait \
+  --timeout 10m
+assert_legacy_contract
+
+helm rollback "${release_name}" 2 \
+  --namespace "${namespace}" \
+  --wait \
+  --timeout 10m
+assert_current_contract
+
+echo "Chart 1.3 to Chart 2 upgrade and rollback checks passed."

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -15,7 +15,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 
 cp -R "${repo_root}/charts/hami-webui" "${work_dir}/hami-webui"
 helm dependency build --skip-refresh "${work_dir}/hami-webui"
-helm lint "${work_dir}/hami-webui"
+helm lint --strict "${work_dir}/hami-webui"
 
 render_template() {
   local template="$1"
@@ -39,6 +39,66 @@ web_service_render="$(render_template templates/service.yaml)"
 backend_service_render="$(render_template templates/backend-service.yaml)"
 service_monitor_render="$(render_template templates/servicemonitor.yaml)"
 default_deployment_render="$(render_template templates/deployment.yaml)"
+default_config_render="$(render_template templates/configmap.yaml)"
+
+deployment_containers="$(awk '
+  /^      containers:$/ { in_containers = 1; next }
+  in_containers && /^      [[:alpha:]][[:alnum:]]*:/ { exit }
+  in_containers && /^        - name:/ { print $3 }
+' <<<"${default_deployment_render}")"
+if [[ "$(awk 'NF { count++ } END { print count + 0 }' <<<"${deployment_containers}")" -ne 1 ]]; then
+  echo "Chart 2 must render exactly one application container" >&2
+  exit 1
+fi
+
+application_container="$(awk '
+  /^      containers:$/ { in_containers = 1; next }
+  in_containers && /^      [[:alpha:]][[:alnum:]]*:/ { exit }
+  in_containers { print }
+' <<<"${default_deployment_render}")"
+if [[ "$(grep -c 'containerPort:' <<<"${application_container}")" -ne 2 ]] ||
+  ! grep -B1 -A1 -F 'containerPort: 3000' <<<"${application_container}" | grep -Fq 'name: http' ||
+  ! grep -B1 -A1 -F 'containerPort: 8000' <<<"${application_container}" | grep -Fq 'name: metrics'; then
+  echo "The unified container must expose named http:3000 and metrics:8000 ports" >&2
+  exit 1
+fi
+if grep -Eq '^[[:space:]]+(command|args):' <<<"${application_container}"; then
+  echo "Chart must leave the unified image entrypoint and command untouched" >&2
+  exit 1
+fi
+
+probe_block() {
+  local probe_name="$1"
+  awk -v probe="${probe_name}" '
+    $0 == "          " probe ":" { in_probe = 1; print; next }
+    in_probe && /^          [[:alpha:]][[:alnum:]]*:/ { exit }
+    in_probe { print }
+  '
+}
+
+startup_probe="$(probe_block startupProbe <<<"${application_container}")"
+readiness_probe="$(probe_block readinessProbe <<<"${application_container}")"
+liveness_probe="$(probe_block livenessProbe <<<"${application_container}")"
+if ! grep -Fq 'path: /readyz' <<<"${startup_probe}" ||
+  ! grep -Fq 'port: metrics' <<<"${startup_probe}" ||
+  ! grep -Fq 'periodSeconds: 5' <<<"${startup_probe}" ||
+  ! grep -Fq 'failureThreshold: 60' <<<"${startup_probe}"; then
+  echo "Startup probe must allow five minutes for backend informer synchronization on /readyz:8000" >&2
+  exit 1
+fi
+for steady_probe in "${readiness_probe}" "${liveness_probe}"; do
+  if ! grep -Fq 'path: /health_check' <<<"${steady_probe}" ||
+    ! grep -Fq 'port: http' <<<"${steady_probe}"; then
+    echo "Steady-state readiness and liveness must check the public Web entry on /health_check:3000" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '^[[:space:]]+grpc:|0\.0\.0\.0:9000' <<<"${default_config_render}" ||
+  ! grep -Fq 'addr: 0.0.0.0:8000' <<<"${default_config_render}"; then
+  echo "Chart 2 configuration must keep HTTP :8000 and remove the unused gRPC listener" >&2
+  exit 1
+fi
 
 if grep -Fq '      imagePullSecrets:' <<<"${default_deployment_render}"; then
   echo "An empty imagePullSecrets value must not render a Pod field" >&2
@@ -59,14 +119,18 @@ if [[ "${image_pull_secrets_block}" != "${expected_image_pull_secrets_block}" ]]
   exit 1
 fi
 
-if [[ "$(service_port_names <<<"${web_service_render}")" != $'http\nmetrics' ]]; then
-  echo "Primary Service must preserve the Chart 1.x backend compatibility port by default" >&2
+if [[ "$(service_port_names <<<"${web_service_render}")" != "http" ]] ||
+  ! grep -Fq 'port: 3000' <<<"${web_service_render}" ||
+  ! grep -Fq 'targetPort: http' <<<"${web_service_render}" ||
+  grep -Fq 'targetPort: metrics' <<<"${web_service_render}"; then
+  echo "Primary Service must expose only the supported Web entry on port 3000" >&2
   exit 1
 fi
 if [[ "$(service_port_names <<<"${backend_service_render}")" != "backend-http" ]] ||
   ! grep -Fq 'name: test-hami-webui-backend' <<<"${backend_service_render}" ||
   ! grep -Fq 'type: ClusterIP' <<<"${backend_service_render}" ||
   ! grep -Fq 'monitoring.hami.io/job: "test-hami-webui"' <<<"${backend_service_render}" ||
+  ! grep -Fq 'port: 8000' <<<"${backend_service_render}" ||
   ! grep -Fq 'targetPort: metrics' <<<"${backend_service_render}"; then
   echo "Internal backend Service contract was not rendered" >&2
   exit 1
@@ -100,24 +164,6 @@ if ! grep -Fq 'app.kubernetes.io/component: "backend"' <<<"${service_monitor_spe
   exit 1
 fi
 
-web_only_service_render="$(render_template templates/service.yaml \
-  --set 'service.legacyBackendPort=false')"
-if [[ "$(service_port_names <<<"${web_only_service_render}")" != "http" ]] ||
-  grep -Fq 'targetPort: metrics' <<<"${web_only_service_render}"; then
-  echo "Disabling service.legacyBackendPort did not remove the raw backend port" >&2
-  exit 1
-fi
-
-for invalid_legacy_backend_port in \
-  --set-string=service.legacyBackendPort=false \
-  --set-json=service.legacyBackendPort=1; do
-  if helm template test "${work_dir}/hami-webui" \
-    "${invalid_legacy_backend_port}" >/dev/null 2>&1; then
-    echo "Invalid service.legacyBackendPort value was accepted: ${invalid_legacy_backend_port}" >&2
-    exit 1
-  fi
-done
-
 load_balancer_web_service="$(render_template templates/service.yaml \
   --set 'service.type=LoadBalancer')"
 load_balancer_backend_service="$(render_template templates/backend-service.yaml \
@@ -126,25 +172,6 @@ if ! grep -Fq 'type: LoadBalancer' <<<"${load_balancer_web_service}" ||
   ! grep -Fq 'type: ClusterIP' <<<"${load_balancer_backend_service}" ||
   grep -Fq 'type: LoadBalancer' <<<"${load_balancer_backend_service}"; then
   echo "Internal backend Service must not inherit the public Service type" >&2
-  exit 1
-fi
-
-legacy_values_chart="${work_dir}/hami-webui-legacy-values"
-cp -R "${work_dir}/hami-webui" "${legacy_values_chart}"
-awk '$1 != "legacyBackendPort:" { print }' \
-  "${legacy_values_chart}/values.yaml" >"${legacy_values_chart}/values.yaml.next"
-mv "${legacy_values_chart}/values.yaml.next" "${legacy_values_chart}/values.yaml"
-legacy_values_service_render="$(helm template test "${legacy_values_chart}" \
-  --show-only templates/service.yaml)"
-if [[ "$(service_port_names <<<"${legacy_values_service_render}")" != $'http\nmetrics' ]]; then
-  echo "Missing service.legacyBackendPort did not preserve the Chart 1.x upgrade contract" >&2
-  exit 1
-fi
-
-null_legacy_backend_port_render="$(render_template templates/service.yaml \
-  --set-json 'service.legacyBackendPort=null')"
-if [[ "$(service_port_names <<<"${null_legacy_backend_port_render}")" != $'http\nmetrics' ]]; then
-  echo "A null service.legacyBackendPort did not preserve the compatibility port" >&2
   exit 1
 fi
 
@@ -245,7 +272,7 @@ if ! grep -Fq 'ca_file: "/apps/prometheus-tls/ca.crt"' <<<"${prometheus_tls_ca_c
   ! grep -A1 -F 'key: "company-ca.pem"' <<<"${prometheus_tls_ca_deployment}" | grep -Fq 'path: ca.crt' ||
   [[ "$(grep -c 'name: prometheus-tls' <<<"${prometheus_tls_ca_deployment}")" -ne 2 ]] ||
   ! grep -A2 -F 'mountPath: /apps/prometheus-tls/' <<<"${prometheus_tls_ca_deployment}" | grep -Fq 'readOnly: true'; then
-  echo "Private-CA Secret was not rendered as a backend-only fixed-path mount" >&2
+  echo "Private-CA Secret was not rendered as a single unified-container fixed-path mount" >&2
   exit 1
 fi
 
@@ -330,48 +357,80 @@ if [[ ! "${checksum_a}" =~ ^[a-f0-9]{64}$ || ! "${checksum_b}" =~ ^[a-f0-9]{64}$
   exit 1
 fi
 
-app_version="$(helm show chart "${work_dir}/hami-webui" | awk -F': *' '$1 == "appVersion" {gsub(/\"/, "", $2); print $2}')"
-expected_tag="v${app_version#v}"
+# The development default is deliberately mutable. Stable release automation
+# replaces it with the verified candidate tag or digest before publication.
+grep -Fq 'image: "projecthami/hami-webui:main"' <<<"${default_deployment_render}"
 
-# Exercise the tag path independently of stable release defaults, which pin a
-# digest and therefore render repository@digest instead.
-tag_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string 'image.frontend.digest=' \
-  --set-string 'image.backend.digest=')"
-grep -Fq "image: \"projecthami/hami-webui-fe-oss:${expected_tag}\"" <<<"${tag_render}"
-grep -Fq "image: \"projecthami/hami-webui-be-oss:${expected_tag}\"" <<<"${tag_render}"
-frontend_container="$(awk '
-  /^        - name: .*fe-oss$/ { in_frontend = 1 }
-  in_frontend && /^        - name: .*be-oss$/ { exit }
-  in_frontend { print }
-' <<<"${tag_render}")"
-if [[ -z "${frontend_container}" ]] || grep -Eq '^[[:space:]]+(command|args):' <<<"${frontend_container}"; then
-  echo "Chart must leave the frontend image entrypoint and command untouched" >&2
+explicit_tag_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.tag=chart-contract' \
+  --set-string 'image.digest=' \
+  --show-only templates/deployment.yaml)"
+grep -Fq 'image: "projecthami/hami-webui:chart-contract"' <<<"${explicit_tag_render}"
+
+fallback_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.tag=' \
+  --set-string 'image.digest=' \
+  --show-only templates/deployment.yaml)"
+grep -Fq 'image: "projecthami/hami-webui:main"' <<<"${fallback_render}"
+
+assert_release_app_version_fallback() {
+  local app_version="$1"
+  local expected_tag="$2"
+  local release_chart
+  release_chart="$(mktemp -d "${work_dir}/release-XXXXXX")/hami-webui"
+  local chart_yaml_tmp="${release_chart}/Chart.yaml.tmp"
+
+  cp -R "${work_dir}/hami-webui" "${release_chart}"
+  awk -v app_version="${app_version}" '
+    $1 == "appVersion:" { print "appVersion: \"" app_version "\""; next }
+    { print }
+  ' "${release_chart}/Chart.yaml" >"${chart_yaml_tmp}"
+  mv "${chart_yaml_tmp}" "${release_chart}/Chart.yaml"
+
+  local release_fallback_render
+  release_fallback_render="$(helm template test "${release_chart}" \
+    --set-string 'image.tag=' \
+    --set-string 'image.digest=' \
+    --show-only templates/deployment.yaml)"
+  grep -Fq "image: \"projecthami/hami-webui:${expected_tag}\"" <<<"${release_fallback_render}"
+}
+
+assert_release_app_version_fallback '2.0.0' 'v2.0.0'
+assert_release_app_version_fallback 'v2.0.0' 'v2.0.0'
+assert_release_app_version_fallback '2.0.0-rc.1+build.7' 'v2.0.0-rc.1_build.7'
+
+if helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.tag=invalid+tag' >/dev/null 2>&1; then
+  echo "Invalid OCI image tag was accepted" >&2
   exit 1
 fi
-if [[ "$(grep -c 'path: /health_check' <<<"${tag_render}")" -ne 2 ]]; then
-  echo "Frontend liveness and readiness probes were not both rendered" >&2
+
+image_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+digest_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.tag=must-not-win' \
+  --set-string "image.digest=${image_digest}" \
+  --show-only templates/deployment.yaml)"
+grep -Fq "image: \"projecthami/hami-webui@${image_digest}\"" <<<"${digest_render}"
+if grep -Fq 'must-not-win' <<<"${digest_render}"; then
+  echo "Image tag took precedence over an immutable digest" >&2
   exit 1
 fi
-grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${tag_render}" | grep -Fq 'value: "65s"'
-grep -A1 -F 'name: HAMI_WEBUI_BASE_PATH' <<<"${tag_render}" | grep -Fq 'value: "/"'
-if grep -Fq 'name: HAMI_WEBUI_FRAME_ANCESTORS_JSON' <<<"${tag_render}"; then
+
+if helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.digest=not-a-digest' >/dev/null 2>&1; then
+  echo "Invalid image digest was accepted" >&2
+  exit 1
+fi
+
+grep -A1 -F 'name: HAMI_WEBUI_BASE_PATH' <<<"${default_deployment_render}" | grep -Fq 'value: "/"'
+if grep -Fq 'name: HAMI_WEBUI_FRAME_ANCESTORS_JSON' <<<"${default_deployment_render}"; then
   echo "Default framing policy must preserve the Chart 1.x no-header behavior" >&2
   exit 1
 fi
-
-proxy_timeout_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string 'frontend.proxyTimeout=125s')"
-grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_render}" | grep -Fq 'value: "125s"'
-
-proxy_timeout_env_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string 'env.frontend[0].name=HAMI_WEBUI_PROXY_TIMEOUT' \
-  --set-string 'env.frontend[0].value=75s')"
-if [[ "$(grep -c 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_env_render}")" -ne 1 ]]; then
-  echo "Explicit frontend proxy-timeout environment override was duplicated" >&2
+if grep -Fq 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${default_deployment_render}"; then
+  echo "Removed frontend proxy timeout leaked into the single-process Deployment" >&2
   exit 1
 fi
-grep -A1 -F 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${proxy_timeout_env_render}" | grep -Fq 'value: 75s'
 
 base_path_render="$(helm template test "${work_dir}/hami-webui" \
   --set-string 'frontend.basePath=/gpu-ui/')"
@@ -385,10 +444,10 @@ fi
 
 base_path_env_render="$(helm template test "${work_dir}/hami-webui" \
   --set-string 'frontend.basePath=/ignored/' \
-  --set-string 'env.frontend[0].name=HAMI_WEBUI_BASE_PATH' \
-  --set-string 'env.frontend[0].value=/from-env/')"
+  --set-string 'env[0].name=HAMI_WEBUI_BASE_PATH' \
+  --set-string 'env[0].value=/from-env/')"
 if [[ "$(grep -c 'name: HAMI_WEBUI_BASE_PATH' <<<"${base_path_env_render}")" -ne 1 ]]; then
-  echo "Explicit frontend base-path environment override was duplicated" >&2
+  echo "Explicit base-path environment override was duplicated" >&2
   exit 1
 fi
 grep -A1 -F 'name: HAMI_WEBUI_BASE_PATH' <<<"${base_path_env_render}" | grep -Fq 'value: /from-env/'
@@ -402,22 +461,12 @@ frame_allow_render="$(helm template test "${work_dir}/hami-webui" \
 grep -A1 -F 'name: HAMI_WEBUI_FRAME_ANCESTORS_JSON' <<<"${frame_allow_render}" | \
   grep -Fq 'value: "[\"'"'"'self'"'"'\",\"https://portal.example.com\"]"'
 
-# Helm upgrades with --reuse-values can reuse Chart 1.x values that do not
-# contain the frontend map. Missing configuration preserves the compatible
-# no-header behavior; it is distinct from an explicitly invalid scalar.
-legacy_frontend_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-json 'frontend=null')"
-if grep -Fq 'name: HAMI_WEBUI_FRAME_ANCESTORS_JSON' <<<"${legacy_frontend_render}"; then
-  echo "Missing frontend.frameAncestors unexpectedly emitted an environment variable" >&2
-  exit 1
-fi
-
 frame_env_render="$(helm template test "${work_dir}/hami-webui" \
   --set-json 'frontend.frameAncestors=[]' \
-  --set-string 'env.frontend[0].name=HAMI_WEBUI_FRAME_ANCESTORS_JSON' \
-  --set-string 'env.frontend[0].value=["https://portal.internal"]')"
+  --set-string 'env[0].name=HAMI_WEBUI_FRAME_ANCESTORS_JSON' \
+  --set-string 'env[0].value=["https://portal.internal"]')"
 if [[ "$(grep -c 'name: HAMI_WEBUI_FRAME_ANCESTORS_JSON' <<<"${frame_env_render}")" -ne 1 ]]; then
-  echo "Explicit frontend frame-ancestors environment override was duplicated" >&2
+  echo "Explicit frame-ancestors environment override was duplicated" >&2
   exit 1
 fi
 
@@ -432,65 +481,160 @@ if helm template test "${work_dir}/hami-webui" \
   exit 1
 fi
 
-for empty_frontend_env in '[]' 'null'; do
-  empty_frontend_env_render="$(helm template test "${work_dir}/hami-webui" \
-    --set-json "env.frontend=${empty_frontend_env}")"
-  if [[ "$(grep -c 'name: HAMI_WEBUI_PROXY_TIMEOUT' <<<"${empty_frontend_env_render}")" -ne 1 ]]; then
-    echo "Empty frontend env value did not render exactly one proxy-timeout variable" >&2
-    exit 1
-  fi
-  if [[ "$(grep -c 'name: HAMI_WEBUI_BASE_PATH' <<<"${empty_frontend_env_render}")" -ne 1 ]]; then
-    echo "Empty frontend env value did not render exactly one base-path variable" >&2
+empty_env_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-json 'env=[]')"
+if [[ "$(grep -c 'name: HAMI_WEBUI_BASE_PATH' <<<"${empty_env_render}")" -ne 1 ]]; then
+  echo "Empty env value did not render exactly one base-path variable" >&2
+  exit 1
+fi
+
+probes_disabled_render="$(helm template test "${work_dir}/hami-webui" \
+  --set 'probes.startup.enabled=false' \
+  --set 'probes.readiness.enabled=false' \
+  --set 'probes.liveness.enabled=false' \
+  --show-only templates/deployment.yaml)"
+if grep -Eq '^[[:space:]]+(startupProbe|readinessProbe|livenessProbe):' <<<"${probes_disabled_render}"; then
+  echo "Disabled unified-container probes were still rendered" >&2
+  exit 1
+fi
+
+clean_migration_render="$(helm template test "${work_dir}/hami-webui" \
+  --set-string 'image.repository=registry.example.com/platform/hami-webui' \
+  --set-string 'image.tag=migrated' \
+  --set-string 'image.digest=' \
+  --set-string 'resources.requests.cpu=125m' \
+  --set-string 'resources.requests.memory=384Mi' \
+  --set-string 'resources.limits.cpu=500m' \
+  --set-string 'resources.limits.memory=1Gi' \
+  --set-string 'env[0].name=TZ' \
+  --set-string 'env[0].value=UTC' \
+  --set-string 'frontend.basePath=/embedded/' \
+  --set-json "frontend.frameAncestors=[\"'self'\",\"https://portal.example.com\"]" \
+  --set-string 'backend.http.timeout=45s' \
+  --show-only templates/deployment.yaml \
+  --show-only templates/configmap.yaml)"
+for expected in \
+  'image: "registry.example.com/platform/hami-webui:migrated"' \
+  'cpu: 125m' \
+  'memory: 384Mi' \
+  'cpu: 500m' \
+  'memory: 1Gi' \
+  'name: TZ' \
+  'value: UTC' \
+  'value: "/embedded/"' \
+  'value: "[\"'"'"'self'"'"'\",\"https://portal.example.com\"]"' \
+  'timeout: 45s'; do
+  if ! grep -Fq "${expected}" <<<"${clean_migration_render}"; then
+    echo "Clean Chart 2 migration values did not render ${expected}" >&2
     exit 1
   fi
 done
 
-probes_disabled_render="$(helm template test "${work_dir}/hami-webui" \
-  --set 'frontend.livenessProbe.enabled=false' \
-  --set 'frontend.readinessProbe.enabled=false')"
-if grep -Fq 'path: /health_check' <<<"${probes_disabled_render}"; then
-  echo "Disabled frontend probes were still rendered" >&2
+legacy_values_fixture="${repo_root}/scripts/chart/tests/values-chart1-transition.yaml"
+if [[ ! -f "${legacy_values_fixture}" ]]; then
+  echo "Missing the complete Chart 1 migration regression fixture" >&2
   exit 1
 fi
 
-fallback_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string 'image.frontend.tag=' \
-  --set-string 'image.frontend.digest=' \
-  --set-string 'image.backend.tag=' \
-  --set-string 'image.backend.digest=')"
-grep -Fq "image: \"projecthami/hami-webui-fe-oss:${expected_tag}\"" <<<"${fallback_render}"
-grep -Fq "image: \"projecthami/hami-webui-be-oss:${expected_tag}\"" <<<"${fallback_render}"
-
-frontend_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-backend_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-digest_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string "image.frontend.digest=${frontend_digest}" \
-  --set-string "image.backend.digest=${backend_digest}")"
-grep -Fq "image: \"projecthami/hami-webui-fe-oss@${frontend_digest}\"" <<<"${digest_render}"
-grep -Fq "image: \"projecthami/hami-webui-be-oss@${backend_digest}\"" <<<"${digest_render}"
-
-# Chart 1.x must continue to accept the last Node-based frontend image. That
-# image owns `node dist/main` through its OCI entrypoint and command, so the
-# Deployment must not inject process-specific command or args.
-legacy_frontend_digest='sha256:b40bbec2b963932545a8b7ac15efef3ec087c76dce4da0ea4c3659fa2abd695e'
-legacy_render="$(helm template test "${work_dir}/hami-webui" \
-  --set-string "image.frontend.digest=${legacy_frontend_digest}" \
-  --set-string 'image.backend.digest=')"
-grep -Fq "image: \"projecthami/hami-webui-fe-oss@${legacy_frontend_digest}\"" <<<"${legacy_render}"
-legacy_frontend_container="$(awk '
-  /^        - name: .*fe-oss$/ { in_frontend = 1 }
-  in_frontend && /^        - name: .*be-oss$/ { exit }
-  in_frontend { print }
-' <<<"${legacy_render}")"
-if [[ -z "${legacy_frontend_container}" ]] || grep -Eq '^[[:space:]]+(command|args):' <<<"${legacy_frontend_container}"; then
-  echo "Legacy frontend image compatibility was broken by a process override" >&2
-  exit 1
+helm_supports_skip_schema=false
+if helm template --help | grep -Fq -- '--skip-schema-validation'; then
+  helm_supports_skip_schema=true
 fi
 
-if helm template test "${work_dir}/hami-webui" \
-  --set-string 'image.frontend.digest=not-a-digest' >/dev/null 2>&1; then
-  echo "invalid image digest was accepted" >&2
-  exit 1
-fi
+assert_legacy_values_rejected() {
+  local expected_field="$1"
+  shift
+  local mode output
 
-echo "Chart lint and image reference checks passed."
+  for mode in schema template; do
+    if [[ "${mode}" == template ]]; then
+      if [[ "${helm_supports_skip_schema}" != true ]]; then
+        continue
+      fi
+      if output="$(helm template test "${work_dir}/hami-webui" \
+        --namespace hami-webui-test \
+        --skip-schema-validation \
+        "$@" 2>&1)"; then
+        echo "Chart 1.x value ${expected_field} was accepted in ${mode} validation mode" >&2
+        exit 1
+      fi
+    elif output="$(helm template test "${work_dir}/hami-webui" \
+      --namespace hami-webui-test \
+      "$@" 2>&1)"; then
+      echo "Chart 1.x value ${expected_field} was accepted in ${mode} validation mode" >&2
+      exit 1
+    fi
+    if ! grep -Fq "${expected_field}" <<<"${output}"; then
+      echo "Chart 1.x value rejection did not identify ${expected_field} in ${mode} validation mode" >&2
+      echo "${output}" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_legacy_values_rejected 'image.frontend' \
+  --set-json 'image.frontend={"repository":"legacy/frontend"}'
+assert_legacy_values_rejected 'image.backend' \
+  --set-json 'image.backend={"repository":"legacy/backend"}'
+assert_legacy_values_rejected 'resources.frontend' \
+  --set-json 'resources.frontend={"requests":{"cpu":"100m"}}'
+assert_legacy_values_rejected 'resources.backend' \
+  --set-json 'resources.backend={"requests":{"cpu":"100m"}}'
+assert_legacy_values_rejected 'env.frontend' \
+  --set-json 'env={"frontend":[{"name":"TZ","value":"UTC"}]}'
+assert_legacy_values_rejected 'env.backend' \
+  --set-json 'env={"backend":[{"name":"TZ","value":"UTC"}]}'
+assert_legacy_values_rejected 'frontend.proxyTimeout' \
+  --set-string 'frontend.proxyTimeout=65s'
+assert_legacy_values_rejected 'frontend.livenessProbe' \
+  --set-json 'frontend.livenessProbe={"enabled":true}'
+assert_legacy_values_rejected 'frontend.readinessProbe' \
+  --set-json 'frontend.readinessProbe={"enabled":true}'
+assert_legacy_values_rejected 'backend.grpc' \
+  --set-json 'backend.grpc={"timeout":"60s"}'
+assert_legacy_values_rejected 'backend.readinessProbe' \
+  --set-json 'backend.readinessProbe={"enabled":true}'
+assert_legacy_values_rejected 'service.legacyBackendPort' \
+  --set 'service.legacyBackendPort=true'
+
+for validation_mode in schema template; do
+  if [[ "${validation_mode}" == template ]]; then
+    if [[ "${helm_supports_skip_schema}" != true ]]; then
+      continue
+    fi
+    if full_legacy_output="$(helm template test "${work_dir}/hami-webui" \
+      --namespace hami-webui-test \
+      --skip-schema-validation \
+      --values "${legacy_values_fixture}" 2>&1)"; then
+      echo "Complete Chart 1.3 values were accepted in ${validation_mode} validation mode" >&2
+      exit 1
+    fi
+  elif full_legacy_output="$(helm template test "${work_dir}/hami-webui" \
+    --namespace hami-webui-test \
+    --values "${legacy_values_fixture}" 2>&1)"; then
+    echo "Complete Chart 1.3 values were accepted in ${validation_mode} validation mode" >&2
+    exit 1
+  fi
+
+  for legacy_field in \
+    'image.frontend' \
+    'image.backend' \
+    'resources.frontend' \
+    'resources.backend' \
+    'env.frontend' \
+    'env.backend' \
+    'frontend.proxyTimeout' \
+    'frontend.livenessProbe' \
+    'frontend.readinessProbe' \
+    'backend.grpc' \
+    'backend.readinessProbe' \
+    'service.legacyBackendPort'; do
+    if ! grep -Fq "${legacy_field}" <<<"${full_legacy_output}"; then
+      echo "Complete Chart 1.3 rejection omitted ${legacy_field} in ${validation_mode} validation mode" >&2
+      echo "${full_legacy_output}" >&2
+      exit 1
+    fi
+  done
+done
+
+echo "Chart lint, single-container, migration, and image reference checks passed."


### PR DESCRIPTION
## What

Chart 1.x kept the Web entry and API in two containers and two images even though they shared one Pod and release lifecycle. Now that #228 publishes the unified application image, this PR completes the consolidation at an explicit Chart 2 boundary.

- deploy one `projecthami/hami-webui` image and one application container;
- keep public port `3000` separate from the internal readiness/metrics listener on `8000`;
- replace nested frontend/backend image, resource, environment, and probe values with one flat contract;
- reject known Chart 1 values with one actionable migration error instead of silently ignoring them; and
- document the fresh-values upgrade and complete Helm-revision rollback path.

This PR sets the development chart to `2.0.0-rc.0`; it does not publish 2.0.0.

## Migration boundary

Upgrading from Chart 1.3 requires a fresh Chart 2 values file together with `--reset-values`. `--reuse-values` and ordinary reuse of the old release values fail closed. Rollback restores the complete Chart 1.3 revision and its two-image runtime.

## Verification

- Helm lint and render contracts on Helm 3.21.4 and 4.2.4
- ShellCheck and actionlint
- full frontend/Web-entry and Go verification suites
- real Kind lifecycle using the released v1.3.0 image digests:
  - install the two-container Chart 1.3 runtime;
  - reject ordinary and `--reuse-values` upgrades without creating a revision;
  - upgrade with fresh values and `--reset-values` while keeping the Web Service available;
  - verify the single-container and `3000`/`8000` Service contracts; and
  - roll back to revision 1, then forward to revision 2 again.

Part of #209.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chart 2.0 introduces a unified single-container HAMi WebUI deployment with consolidated image, resource, environment, and probe settings.
  - Separate HTTP and metrics endpoints are supported, including startup, readiness, and liveness checks.
  - Added configurable HTTP timeout, metrics exporter, and vendor node selector settings.

- **Bug Fixes**
  - Improved chart validation detects unsupported Chart 1.x values and provides migration guidance.

- **Documentation**
  - Added installation, upgrade, rollback, and deployment guidance for Chart 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->