### PR TITLE
fix(helm): prevent mixed-version installs

### DIFF
--- a/.github/workflows/pr-chart.yaml
+++ b/.github/workflows/pr-chart.yaml
@@ -29,6 +29,7 @@ jobs:
               - 'charts/**'
               - 'scripts/chart/**'
               - 'scripts/verify-chart*.sh'
+              - 'scripts/verify-install-docs.sh'
               - '.github/workflows/pr-chart.yaml'
 
   verify:

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -29,6 +29,10 @@ jobs:
             release:
               - '.github/workflows/release.yaml'
               - '.github/workflows/pr-release.yaml'
+              - 'charts/hami-webui/Chart.yaml'
+              - 'charts/hami-webui/README.md'
+              - 'docs/installation/helm/index.md'
+              - 'scripts/verify-install-docs.sh'
               - 'scripts/release/**'
               - 'docs/releasing.md'
 
@@ -55,7 +59,10 @@ jobs:
         run: actionlint .github/workflows/release.yaml .github/workflows/pr-release.yaml
 
       - name: Check release shell scripts
-        run: shellcheck scripts/release/*.sh scripts/release/tests/*.sh
+        run: shellcheck scripts/verify-install-docs.sh scripts/release/*.sh scripts/release/tests/*.sh
+
+      - name: Verify version-matched installation documentation
+        run: bash scripts/verify-install-docs.sh
 
       - name: Run deterministic release contract tests
         run: bash scripts/release/tests/release-controller.sh

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -13,17 +13,29 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 
 ## Installing the Chart
 
-Before deploying, ensure that you configure the `values.yaml` file to match your cluster’s requirements. For detailed instructions, refer to the [Configuration Guide for HAMi-WebUI Helm Chart](#configuration-guide-for-hamiwebui-helm-chart)
-> _**Important**_: You must adjust the values.yaml before proceeding with the deployment.
-
-Download the `values.yaml` file from the Helm Charts repository:
-
-https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml
-
+Choose a released Chart version first. This README follows the Chart source in
+its branch, while the published Helm repository may contain an older release.
+Never combine `values.yaml` from `main` with a different Chart version.
 
 ```console
-helm install my-hami-webui hami-webui/hami-webui --create-namespace --namespace hami -f values.yaml
+helm search repo hami-webui/hami-webui --versions
+# Replace X.Y.Z with the version you want to install.
+CHART_VERSION="X.Y.Z"
+helm show values hami-webui/hami-webui \
+  --version "${CHART_VERSION}" > values.yaml
+# Review and edit values.yaml for your cluster before installing it.
+helm install my-hami-webui hami-webui/hami-webui \
+  --version "${CHART_VERSION}" \
+  --create-namespace \
+  --namespace hami \
+  --values values.yaml
 ```
+
+Using `helm show values` and `helm install` with the same explicit version keeps
+the configuration schema and the installed templates together. For the selected
+release, treat the comments in the retrieved values file as authoritative. The
+[configuration guide below](#configuration-guide-for-hamiwebui-helm-chart)
+describes the Chart version shown at the top of this README.
 
 Chart 2 deploys one `projecthami/hami-webui` image and one container. When
 upgrading from Chart 1.3, create a fresh Chart 2 values file and use

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -10,6 +10,11 @@ The examples below use `kubectl port-forward` for local access. Configure
 The HAMi-WebUI community publishes a Helm chart for Kubernetes. Report problems
 in the [HAMi-WebUI repository](https://github.com/Project-HAMi/HAMi-WebUI/issues).
 
+> This page follows the Chart source in the current Git branch. The published
+> Helm repository may contain an older release. Always select a Chart version
+> explicitly and use the values packaged with that same version;
+> `values.yaml` from `main` is not compatible with every released Chart.
+
 ## Prerequisites
 
 To install HAMi-WebUI using Helm, ensure you meet these requirements:
@@ -41,17 +46,35 @@ To set up the HAMi-WebUI Helm repository so that you download the correct HAMi-W
 
    ```bash
    helm repo add hami-webui https://project-hami.github.io/HAMi-WebUI
+   helm repo update
+   helm search repo hami-webui/hami-webui --versions
    ```
 
-2. Deploy HAMi-WebUI using following command:
+2. Select the release you want to install, set its version, and retrieve the
+   defaults from that exact package:
 
    ```bash
-   helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
+   # Replace X.Y.Z with a version listed by helm search.
+   CHART_VERSION="X.Y.Z"
+   helm show values hami-webui/hami-webui \
+     --version "${CHART_VERSION}" > values.yaml
    ```
 
-   > _**Important**_: You need to replace the value of 'externalPrometheus.address' to your prometheus address inside cluster
+   Review and edit `values.yaml` for your cluster, then install the same version:
 
-   You can set other fields in [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation according to configuration [document](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values)
+   ```bash
+   : "${CHART_VERSION:?Set CHART_VERSION to the version used to generate values.yaml}"
+   helm install my-hami-webui hami-webui/hami-webui \
+     --version "${CHART_VERSION}" \
+     --namespace kube-system \
+     --values values.yaml \
+     --set externalPrometheus.enabled=true \
+     --set-string externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
+   ```
+
+   This example uses an existing Prometheus. Replace
+   `externalPrometheus.address` with its in-cluster HTTP API address. Do not copy
+   the `main` values file into an installation of an older release.
 
 3. Run the following command to verify the installation:
 

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -18,6 +18,28 @@ require_failure() {
   fi
 }
 
+write_chart_readme_fixture() {
+  local version="$1"
+  local output="$2"
+  local badge_version="${version//-/--}"
+
+  cat >"${output}" <<EOF
+# HAMi-WebUI release fixture
+
+![Version: ${version}](https://img.shields.io/badge/Version-${badge_version}-informational?style=flat-square)
+![AppVersion: ${version}](https://img.shields.io/badge/AppVersion-${badge_version}-informational?style=flat-square)
+
+\`\`\`console
+CHART_VERSION="X.Y.Z"
+helm show values hami-webui/hami-webui \\
+  --version "\${CHART_VERSION}" > values.yaml
+helm install fixture hami-webui/hami-webui \\
+  --version "\${CHART_VERSION}" \\
+  --values values.yaml
+\`\`\`
+EOF
+}
+
 verify_contract_in_repo() {
   local repository_dir="$1"
   local release_sha="$2"
@@ -134,6 +156,8 @@ VERSION=2.0.1 DIGEST="${digest_a}" yq -i '
   .image.tag = "v" + strenv(VERSION) |
   .image.digest = strenv(DIGEST)
 ' "${contract_repo}/charts/hami-webui/values.yaml"
+write_chart_readme_fixture 2.0.1 \
+  "${contract_repo}/charts/hami-webui/README.md"
 git -C "${contract_repo}" add charts
 git -C "${contract_repo}" commit -qm 'allowed release metadata'
 release_sha="$(git -C "${contract_repo}" rev-parse HEAD)"
@@ -185,7 +209,11 @@ VERSION=1.9.0 yq -i '
   .version = strenv(VERSION) |
   .appVersion = strenv(VERSION)
 ' "${work_dir}/legacy-chart-major/charts/hami-webui/Chart.yaml"
-git -C "${work_dir}/legacy-chart-major" add charts/hami-webui/Chart.yaml
+write_chart_readme_fixture 1.9.0 \
+  "${work_dir}/legacy-chart-major/charts/hami-webui/README.md"
+git -C "${work_dir}/legacy-chart-major" add \
+  charts/hami-webui/Chart.yaml \
+  charts/hami-webui/README.md
 git -C "${work_dir}/legacy-chart-major" commit -qm 'legacy chart major'
 legacy_major_sha="$(git -C "${work_dir}/legacy-chart-major" rev-parse HEAD)"
 require_failure "Chart major version below 2" \

--- a/scripts/release/verify-release-contract.sh
+++ b/scripts/release/verify-release-contract.sh
@@ -14,6 +14,9 @@ chart_dir="${4:-charts/hami-webui}"
 release_require_command git
 release_require_command jq
 release_require_command yq
+bash "${script_dir}/../verify-install-docs.sh" \
+  "${chart_dir}" \
+  "${script_dir}/../../docs/installation/helm/index.md"
 release_validate_commit "${release_sha}"
 [[ "${candidate_run_id}" =~ ^[0-9]+$ ]] || release_die "candidate run id must be numeric"
 jq -e . "${candidate_manifest}" >/dev/null

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -10,6 +10,8 @@ export HELM_CONFIG_HOME="${work_dir}/helm/config"
 export HELM_CACHE_HOME="${work_dir}/helm/cache"
 export HELM_DATA_HOME="${work_dir}/helm/data"
 
+bash "${repo_root}/scripts/verify-install-docs.sh"
+
 helm repo add nvidia-dcgm https://nvidia.github.io/dcgm-exporter/helm-charts
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 

--- a/scripts/verify-install-docs.sh
+++ b/scripts/verify-install-docs.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart_dir="${1:-${repo_root}/charts/hami-webui}"
+install_guide="${2:-${repo_root}/docs/installation/helm/index.md}"
+chart_readme="${chart_dir}/README.md"
+
+for required_file in "${chart_dir}/Chart.yaml" "${chart_readme}" "${install_guide}"; do
+  if [[ ! -f "${required_file}" ]]; then
+    echo "Required installation document is missing: ${required_file}" >&2
+    exit 1
+  fi
+done
+
+chart_version="$(awk '$1 == "version:" { value = $2; gsub(/"/, "", value); print value; exit }' "${chart_dir}/Chart.yaml")"
+app_version="$(awk '$1 == "appVersion:" { value = $2; gsub(/"/, "", value); print value; exit }' "${chart_dir}/Chart.yaml")"
+badge_version="${chart_version//-/--}"
+badge_app_version="${app_version//-/--}"
+
+if ! grep -F "![Version: ${chart_version}]" "${chart_readme}" | \
+  grep -Fq "https://img.shields.io/badge/Version-${badge_version}-"; then
+  echo "Chart README version badge does not match Chart.yaml: ${chart_version}" >&2
+  exit 1
+fi
+if ! grep -F "![AppVersion: ${app_version}]" "${chart_readme}" | \
+  grep -Fq "https://img.shields.io/badge/AppVersion-${badge_app_version}-"; then
+  echo "Chart README appVersion badge does not match Chart.yaml: ${app_version}" >&2
+  exit 1
+fi
+
+for install_doc in "${chart_readme}" "${install_guide}"; do
+  if grep -Eq 'github\.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/(README\.md|values\.yaml)|raw\.githubusercontent\.com/Project-HAMi/HAMi-WebUI/main/charts/hami-webui/(README\.md|values\.yaml)' "${install_doc}"; then
+    echo "Installation documentation must not pair main Chart files with a released Chart: ${install_doc}" >&2
+    exit 1
+  fi
+
+  awk -v document="${install_doc}" '
+    /^[[:space:]]*```(bash|console|sh)[[:space:]]*$/ {
+      in_block = 1
+      block = ""
+      next
+    }
+    in_block && /^[[:space:]]*```[[:space:]]*$/ {
+      if (index(block, "helm show values hami-webui/hami-webui") > 0) {
+        saw_values = 1
+        if (index(block, "--version \"${CHART_VERSION}\"") == 0) {
+          printf "helm show values must use CHART_VERSION in %s\n", document > "/dev/stderr"
+          failed = 1
+        }
+      }
+      if (index(block, "helm install ") > 0 && index(block, "hami-webui/hami-webui") > 0) {
+        saw_install = 1
+        if (index(block, "--version \"${CHART_VERSION}\"") == 0) {
+          printf "helm install must use CHART_VERSION in %s\n", document > "/dev/stderr"
+          failed = 1
+        }
+        if (index(block, "CHART_VERSION=") == 0 && index(block, "${CHART_VERSION:?") == 0) {
+          printf "helm install must define or require CHART_VERSION in the same code block: %s\n", document > "/dev/stderr"
+          failed = 1
+        }
+      }
+      in_block = 0
+      next
+    }
+    in_block {
+      block = block "\n" $0
+    }
+    END {
+      if (!saw_values) {
+        printf "Installation documentation must retrieve version-matched values: %s\n", document > "/dev/stderr"
+        failed = 1
+      }
+      if (!saw_install) {
+        printf "Installation documentation must contain the versioned install command: %s\n", document > "/dev/stderr"
+        failed = 1
+      }
+      exit failed
+    }
+  ' "${install_doc}"
+done
+
+echo "Version-matched Helm installation documentation is valid."


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

The public Helm repository currently serves Chart 1.3.0 while `main` contains the Chart 2 release candidate. The installation docs linked `main` values and then installed an unpinned repository Chart; following that path fails with `.Values.env.frontend: can\'t evaluate field frontend in type interface {}`.

This change makes the Chart and values one explicit versioned contract:

- choose `CHART_VERSION` from the published versions;
- retrieve defaults with `helm show values --version`;
- install with the same `--version`;
- fail closed if the variable is lost between the two steps.

The existing external Prometheus example is preserved. A lightweight verifier protects the commands and Chart metadata in the existing required release check and again during stable release validation.

**Verification**

- released Chart 1.3.0 renders with values from the same package
- `bash scripts/verify-install-docs.sh`
- `bash scripts/verify-chart.sh`
- `bash scripts/release/tests/release-controller.sh`
- ShellCheck and actionlint

Part of #209. This does not publish Chart 2.0.