### PR TITLE
fix(helm): require explicit Prometheus setup

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,8 +73,13 @@ jobs:
           lock_before="$(sha256sum charts/hami-webui/Chart.lock | awk '{print $1}')"
           helm dependency build charts/hami-webui --skip-refresh
           [[ "$(sha256sum charts/hami-webui/Chart.lock | awk '{print $1}')" == "${lock_before}" ]]
-          helm lint charts/hami-webui
-          helm template oci-bootstrap charts/hami-webui >/dev/null
+          prometheus_verification_args=(
+            --set 'externalPrometheus.enabled=true'
+            --set-string 'externalPrometheus.address=http://prometheus.oci-bootstrap.svc.cluster.local:9090'
+          )
+          helm lint charts/hami-webui "${prometheus_verification_args[@]}"
+          helm template oci-bootstrap charts/hami-webui \
+            "${prometheus_verification_args[@]}" >/dev/null
           mkdir bootstrap-bundle
           helm package charts/hami-webui \
             --version "${version}" \

--- a/charts/hami-webui/Chart.yaml
+++ b/charts/hami-webui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-rc.0
+version: 2.0.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -1,6 +1,6 @@
 # HAMi-WebUI
 
-![Version: 2.0.0-rc.0](https://img.shields.io/badge/Version-2.0.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 2.0.0-rc.1](https://img.shields.io/badge/Version-2.0.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 ## Get Repo Info
 
@@ -24,11 +24,14 @@ CHART_VERSION="X.Y.Z"
 helm show values hami-webui/hami-webui \
   --version "${CHART_VERSION}" > values.yaml
 # Review and edit values.yaml for your cluster before installing it.
+PROMETHEUS_ADDRESS="http://prometheus.monitoring.svc.cluster.local:9090"
 helm install my-hami-webui hami-webui/hami-webui \
   --version "${CHART_VERSION}" \
   --create-namespace \
   --namespace hami \
-  --values values.yaml
+  --values values.yaml \
+  --set externalPrometheus.enabled=true \
+  --set-string externalPrometheus.address="${PROMETHEUS_ADDRESS}"
 ```
 
 Using `helm show values` and `helm install` with the same explicit version keeps
@@ -36,6 +39,11 @@ the configuration schema and the installed templates together. For the selected
 release, treat the comments in the retrieved values file as authoritative. The
 [configuration guide below](#configuration-guide-for-hamiwebui-helm-chart)
 describes the Chart version shown at the top of this README.
+
+The command above assumes an existing Prometheus and Prometheus Operator. Its
+Prometheus resource must select the ServiceMonitors created by this Chart. See
+[Prometheus modes](#2-about-prometheus) before installing into a new cluster or
+one that uses raw scrape configuration.
 
 Chart 2 deploys one `projecthami/hami-webui` image and one container. When
 upgrading from Chart 1.3, create a fresh Chart 2 values file and use
@@ -68,13 +76,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | dcgm-exporter.enabled | bool | `true`                                                                             |  |
 | dcgm-exporter.nodeSelector.gpu | string | `"on"`                                                                             |  |
 | dcgm-exporter.serviceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
-| dcgm-exporter.serviceMonitor.enabled | bool | `true`                                                                             |  |
+| dcgm-exporter.serviceMonitor.enabled | bool | `true`                                                                             | Create a DCGM ServiceMonitor; disable in raw/manual scrape mode. |
 | dcgm-exporter.serviceMonitor.honorLabels | bool | `false`                                                                            |  |
 | dcgm-exporter.serviceMonitor.interval | string | `"15s"`                                                                            |  |
 | env[0].name | string | `"TZ"` | Default environment variable name for the single application container. Replace the list to add other variables. |
 | env[0].value | string | `"Asia/Shanghai"` | Default timezone value. |
-| externalPrometheus.address | string | `"http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"` | Prometheus or VictoriaMetrics HTTP API address. |
-| externalPrometheus.enabled | bool | `false`                                                                            | Use an existing metrics backend instead of the bundled address. |
+| externalPrometheus.address | string | `""` | Required Prometheus or VictoriaMetrics HTTP API address when external mode is enabled. |
+| externalPrometheus.enabled | bool | `false`                                                                            | Use an existing metrics backend. Exactly one of this value and `kube-prometheus-stack.enabled` must be true. |
 | externalPrometheus.timeout | string | `"1m"` | Timeout sent with each upstream PromQL request. |
 | externalPrometheus.tls.insecureSkipVerify | bool | `false` | Disable HTTPS certificate verification. Use only as a temporary break-glass setting. |
 | externalPrometheus.tls.serverName | string | `""` | Optional certificate name override for the HTTPS endpoint. |
@@ -86,7 +94,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.frameAncestors | list or null | `null` | CSP framing allowlist. `null` preserves existing behavior, `[]` blocks framing, and a list allows explicit parents. |
 | fullnameOverride | string | `""`                                                                               |  |
 | hamiServiceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
-| hamiServiceMonitor.enabled | bool | `true`                                                                             |  |
+| hamiServiceMonitor.enabled | bool | `true`                                                                             | Preferred HAMi device-plugin monitor. Disable only when another selected monitor preserves workload labels with `honorLabels: true`, or in raw/manual mode. |
 | hamiServiceMonitor.honorLabels | bool | `true`                                                                            | Keep HAMi's workload namespace/pod/container labels when they collide with Prometheus scrape-target labels. |
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
@@ -106,7 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | kube-prometheus-stack.alertmanager.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.crds.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.defaultRules.create | bool | `false`                                                                            |  |
-| kube-prometheus-stack.enabled | bool | `false`                                                                            |  |
+| kube-prometheus-stack.enabled | bool | `false`                                                                            | Create a dedicated Prometheus through the dependency Chart. Mutually exclusive with `externalPrometheus.enabled`. |
 | kube-prometheus-stack.grafana.enabled | bool | `false`                                                                            |  |
 | kube-prometheus-stack.kube-state-metrics.prometheus.monitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          | Allow the bundled Prometheus to scrape kube-state-metrics for cluster CPU and memory totals. |
 | kube-prometheus-stack.kubernetesServiceMonitors.enabled | bool | `false`                                                                            |  |
@@ -147,7 +155,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.create | bool | `true`                                                                             |  |
 | serviceAccount.name | string | `""`                                                                               |  |
 | serviceMonitor.additionalLabels.jobRelease | string | `"hami-webui-prometheus"`                                                          |  |
-| serviceMonitor.enabled | bool | `true`                                                                             |  |
+| serviceMonitor.enabled | bool | `true`                                                                             | Create a ServiceMonitor for HAMi-WebUI metrics; requires Prometheus Operator CRDs. |
 | serviceMonitor.honorLabels | bool | `false`                                                                            |  |
 | serviceMonitor.interval | string | `"15s"`                                                                            |  |
 | serviceMonitor.relabelings | list | `[]`                                                                               |  |
@@ -178,9 +186,10 @@ This ensures that the existing `dcgm-exporter` instance is used, preventing conf
 
 ### 2. About `Prometheus`
 
-#### Scenario 1: If an existing Prometheus is available in your cluster
+HAMi-WebUI does not guess a Prometheus release name or namespace. Select exactly
+one mode; rendering fails when neither or both are enabled.
 
-If your cluster already has a working Prometheus instance, you can enable the external Prometheus configuration and provide the correct address:
+For the recommended existing-Prometheus path, provide its real HTTP API address:
 
 ```yaml
 externalPrometheus:
@@ -188,73 +197,20 @@ externalPrometheus:
   address: "<your-prometheus-address>"
 ```
 
-Here, replace <your-prometheus-address> with the actual domain or internal Ingress address for your Prometheus instance.
-
-HTTPS certificates are verified by default. For an endpoint signed by a private
-CA, create a Secret and reference its data key instead of placing PEM material
-in values:
-
-```yaml
-externalPrometheus:
-  enabled: true
-  address: "https://prometheus.example.com"
-  tls:
-    existingSecret: "prometheus-ca"
-    caKey: "ca.crt"
-```
-
-See the [installation guide](../../docs/installation/helm/index.md#https-external-prometheus)
-for Secret creation, mTLS, and the upgrade boundary.
-
-#### Scenario 2: If no Prometheus or Operator is installed in the cluster
-
-If there is no existing Prometheus or Prometheus Operator in your cluster, you can enable the kube-prometheus-stack to deploy Prometheus:
+For a self-contained evaluation cluster, enable the dependency together with
+its Operator and CRDs:
 
 ```yaml
 kube-prometheus-stack:
   enabled: true
   crds:
     enabled: true
-  ...
   prometheusOperator:
     enabled: true
-  ...
 ```
 
-#### Scenario 3: If Prometheus and Operator already exist, but a separate Prometheus instance is needed
-If your cluster has Prometheus and Prometheus Operator, but you want to use a separate instance without affecting the existing setup, modify the configuration as follows:
-
-```yaml
-kube-prometheus-stack:
-  enabled: true
-  ...
-```
-This allows you to reuse the existing Operator and CRDs while deploying a new Prometheus instance.
-
-### 3. About `jobRelease` Labels
-
-If deploying a completely new Prometheus, you can leave the default `jobRelease: hami-webui-prometheus` unchanged.
-
-***However, if you are integrating with an existing Prometheus instance and modifying the `prometheusSpec.serviceMonitorSelector.matchLabels`, ensure that **all** corresponding `...ServiceMonitor.additionalLabels` are updated to reflect the correct label.***
-
-For example, if you modify:
-
-```yaml
-prometheus:
-  prometheusSpec:
-    serviceMonitorSelector:
-      matchLabels:
-        <jobRelease-label-key>: <jobRelease-label-value>
-```
-
-You must also modify all ...ServiceMonitor.additionalLabels in your values.yaml file to match:
-
-```yaml
-...ServiceMonitor:
-  additionalLabels:
-    <jobRelease-label-key>: <jobRelease-label-value>
-```
-
-This includes `kube-prometheus-stack.kube-state-metrics.prometheus.monitor.additionalLabels`.
-
-This ensures that Prometheus will correctly discover all the ServiceMonitor configurations based on the updated labels.
+The external path requires a running Prometheus Operator and matching
+ServiceMonitor label/namespace selectors. The self-contained path creates
+cluster-scoped resources. Raw scraping, reuse of an existing Operator, HTTPS
+trust, duplicate-target prevention, and verification queries are documented in
+the [installation guide](../../docs/installation/helm/index.md#select-a-prometheus-ownership-mode).

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -73,17 +73,53 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/*
-Resolve the Prometheus address. When the embedded stack is enabled, use the
-dependency chart's own helpers so its naming and override rules cannot drift.
+Require one explicit Prometheus ownership mode. A guessed in-cluster address
+can let the Pod become Ready while every metrics query points at a Service that
+does not exist, so an unconfigured or ambiguous mode must fail at render time.
+*/}}
+{{- define "hami-webui.validatePrometheusConfiguration" -}}
+{{- $external := default (dict) .Values.externalPrometheus -}}
+{{- $stack := default (dict) (index .Values "kube-prometheus-stack") -}}
+{{- $externalEnabled := default false (get $external "enabled") -}}
+{{- $stackEnabled := default false (get $stack "enabled") -}}
+{{- if and $externalEnabled $stackEnabled -}}
+{{- fail "externalPrometheus.enabled and kube-prometheus-stack.enabled are mutually exclusive; select exactly one Prometheus mode" -}}
+{{- end -}}
+{{- if not (or $externalEnabled $stackEnabled) -}}
+{{- fail "Prometheus is not configured; enable externalPrometheus with an explicit address or enable kube-prometheus-stack" -}}
+{{- end -}}
+{{- if $externalEnabled -}}
+{{- $address := trim (default "" (get $external "address")) -}}
+{{- if empty $address -}}
+{{- fail "externalPrometheus.address is required when externalPrometheus.enabled=true" -}}
+{{- end -}}
+{{- if not (regexMatch "^https?://[^[:space:]]+$" $address) -}}
+{{- fail "externalPrometheus.address must be an absolute http:// or https:// URL without whitespace" -}}
+{{- end -}}
+{{- $parsedAddress := urlParse $address -}}
+{{- if empty (get $parsedAddress "hostname") -}}
+{{- fail "externalPrometheus.address must include a hostname" -}}
+{{- end -}}
+{{- end -}}
+{{- if $stackEnabled -}}
+{{- $prometheus := default (dict) (get $stack "prometheus") -}}
+{{- if and (hasKey $prometheus "enabled") (not (get $prometheus "enabled")) -}}
+{{- fail "kube-prometheus-stack.prometheus.enabled must remain true when kube-prometheus-stack.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the Prometheus address. When the dependency stack is enabled, use its
+own helpers so release-name, namespace and port overrides cannot drift.
 */}}
 {{- define "hami-webui.prometheusAddress" -}}
+{{- include "hami-webui.validatePrometheusConfiguration" . -}}
 {{- if .Values.externalPrometheus.enabled -}}
 {{- .Values.externalPrometheus.address -}}
 {{- else if (index .Values "kube-prometheus-stack").enabled -}}
 {{- $stack := index .Subcharts "kube-prometheus-stack" -}}
 {{- printf "http://%s-prometheus.%s.svc.cluster.local:%v" (include "kube-prometheus-stack.fullname" $stack) (include "kube-prometheus-stack.namespace" $stack) $stack.Values.prometheus.service.port -}}
-{{- else -}}
-{{- printf "http://%s-kube-prometh-prometheus.%s.svc.cluster.local:9090" (include "hami-webui.fullname" .) (include "hami-webui.namespace" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/hami-webui/values.schema.json
+++ b/charts/hami-webui/values.schema.json
@@ -92,6 +92,16 @@
     "externalPrometheus": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "address": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string",
+          "minLength": 1
+        },
         "tls": {
           "type": "object",
           "additionalProperties": false,
@@ -113,6 +123,22 @@
             },
             "keyKey": {
               "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "kube-prometheus-stack": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "prometheus": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
             }
           }
         }

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -81,6 +81,9 @@ env:
   - name: TZ
     value: "Asia/Shanghai"
 
+# ServiceMonitor resources require Prometheus Operator CRDs. In raw/manual
+# scrape mode, disable this block, hamiServiceMonitor, and the dcgm-exporter
+# ServiceMonitor together, then configure equivalent scrape jobs yourself.
 serviceMonitor:
   enabled: true
   interval: 15s
@@ -90,6 +93,10 @@ serviceMonitor:
   relabelings: []
 
 hamiServiceMonitor:
+  # Keep this monitor by default and leave HAMi's prometheus.enabled=false. It
+  # preserves workload labels; disable it only when another selected monitor
+  # owns the same endpoint and is confirmed to set honorLabels: true, or when
+  # using raw/manual scrape configuration.
   enabled: true
   interval: 15s
   # Preserve HAMi's namespace/pod/container workload labels when they collide
@@ -117,6 +124,9 @@ dcgm-exporter:
   nodeSelector:
     gpu: "on"
 
+# Prometheus ownership is explicit: enable exactly one of this dependency and
+# externalPrometheus. The defaults intentionally enable neither so Helm fails
+# with an actionable message until the installer chooses a real backend.
 kube-prometheus-stack:
   enabled: false
   crds:
@@ -146,8 +156,10 @@ kube-prometheus-stack:
 
 externalPrometheus:
   enabled: false
-  # If externalPrometheus.enabled is true, this address will be used
-  address: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090"
+  # Required when enabled. Use the real in-cluster HTTP API address of an
+  # existing Prometheus or VictoriaMetrics instance; the Chart does not guess
+  # release names or namespaces.
+  address: ""
   # Single PromQL upstream timeout (sent to Prometheus / VictoriaMetrics as the &timeout= parameter).
   timeout: "1m"
   tls:

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -32,7 +32,11 @@ To install HAMi-WebUI using Helm, ensure you meet these requirements:
 | <= v1.1.0 | >= 2.4.0, < 2.9.0 | old labels: `deviceuuid`, `devicetype`, `podnamespace`, `podname`, `ctrname` | For existing HAMi deployments before the metrics rename |
 | v1.1.1+ | >= 2.9.0 | new labels: `device_uuid`, `device_type`, `namespace`, `pod`, `container` | Required after the HAMi 2.9.0 metrics rename |
 
-3. Prometheus > 2.8.0
+3. External mode requires a reachable Prometheus-compatible HTTP API
+   (Prometheus > 2.8.0 or VictoriaMetrics). Using the Chart's `ServiceMonitor`
+   resources also requires a running Prometheus Operator and its CRD; the raw
+   scrape path documented below does not. Self-contained mode provisions the
+   API, Operator, and CRDs together.
 
 4. Helm > 3.0
 
@@ -64,28 +68,40 @@ To set up the HAMi-WebUI Helm repository so that you download the correct HAMi-W
 
    ```bash
    : "${CHART_VERSION:?Set CHART_VERSION to the version used to generate values.yaml}"
+   PROMETHEUS_ADDRESS="http://<prometheus-service>.<namespace>.svc.cluster.local:9090"
+   PROMETHEUS_RELEASE="<kube-prometheus-stack-release>"
    helm install my-hami-webui hami-webui/hami-webui \
      --version "${CHART_VERSION}" \
      --namespace kube-system \
      --values values.yaml \
      --set externalPrometheus.enabled=true \
-     --set-string externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
+     --set-string externalPrometheus.address="${PROMETHEUS_ADDRESS}" \
+     --set-string serviceMonitor.additionalLabels.release="${PROMETHEUS_RELEASE}" \
+     --set-string hamiServiceMonitor.additionalLabels.release="${PROMETHEUS_RELEASE}" \
+     --set-string dcgm-exporter.serviceMonitor.additionalLabels.release="${PROMETHEUS_RELEASE}"
    ```
 
-   This example uses an existing Prometheus. Replace
-   `externalPrometheus.address` with its in-cluster HTTP API address. Do not copy
-   the `main` values file into an installation of an older release.
+   Replace both placeholders. This example uses an existing
+   kube-prometheus-stack release whose default selector is
+   `release=<Helm release>`. If your Prometheus uses another selector, apply its
+   labels to all three ServiceMonitors instead. Its
+   `serviceMonitorNamespaceSelector` must include the HAMi-WebUI namespace.
+   Do not copy the `main` values file into an older Chart release.
 
-3. Run the following command to verify the installation:
+3. Verify both the workload and the scrape contract:
 
    ```bash
    kubectl get pods -n kube-system | grep webui
+   kubectl get servicemonitor -n kube-system \
+     -l app.kubernetes.io/instance=my-hami-webui
    ```
 
-   By default, a successful Chart 2 installation has one Ready HAMi-WebUI Pod;
+   A successful Chart 2 installation has one Ready HAMi-WebUI Pod;
    every HAMi-WebUI Pod contains one application container. When the bundled
    dcgm-exporter is enabled, its DaemonSet schedules Pods on nodes matching its
-   node selector.
+   node selector. Pod readiness does not prove that an external Prometheus has
+   selected or scraped these ServiceMonitors; use the query checks in
+   [Prometheus scrape configuration](#prometheus-scrape-configuration).
 
 ### Upgrade from Chart 1.3 to 2.0
 
@@ -140,6 +156,45 @@ helm rollback my-hami-webui <CHART-1-REVISION> \
 That rollback restores the Chart 1.3 templates, values, and two-image runtime
 together. Use `--reset-values` again when moving forward to Chart 2.
 
+### Select a Prometheus ownership mode
+
+Chart 2 requires exactly one Prometheus mode. Helm rejects an installation when
+neither mode is configured, when both are enabled, or when external mode has no
+absolute HTTP(S) address. This prevents a healthy-looking Pod from querying a
+guessed Service that the Chart never created.
+
+The recommended production path is an independently managed Prometheus and
+Prometheus Operator. Enable `externalPrometheus` as shown in the installation
+command, then make the Operator's Prometheus resource select all three generated
+ServiceMonitors and their namespaces. Keep this Chart's `hamiServiceMonitor`
+enabled and leave the HAMi Chart's `prometheus.enabled=false` default: this
+monitor sets `honorLabels: true`. Disable it only when another selected monitor
+owns the same endpoint and is confirmed to preserve those workload labels.
+
+For a self-contained evaluation cluster with no existing Prometheus or
+Operator, use:
+
+```yaml
+externalPrometheus:
+  enabled: false
+kube-prometheus-stack:
+  enabled: true
+  crds:
+    enabled: true
+  prometheusOperator:
+    enabled: true
+```
+
+This mode installs cluster-scoped CRDs and an Operator as part of the WebUI
+release. Helm does not upgrade or delete CRDs as ordinary release resources, so
+manage the monitoring stack as a separate release for long-lived production
+clusters.
+
+If a compatible Operator and CRDs already exist but a separate Prometheus
+instance is desired, enable only `kube-prometheus-stack.enabled`; the Chart's
+defaults deliberately leave that dependency's CRDs and Operator disabled. The
+existing Operator must watch the HAMi-WebUI namespace.
+
 ### HTTPS external Prometheus
 
 HAMi-WebUI verifies HTTPS certificates with the container's system trust store
@@ -178,7 +233,14 @@ silently skipped it for every HTTPS Prometheus endpoint. Before upgrading an
 installation that relies on an untrusted self-signed certificate, configure its
 CA as shown above or explicitly opt into the temporary insecure setting.
 
-### Prometheus scrape labels
+### Prometheus scrape configuration
+
+ServiceMonitor objects are discovery requests, not proof of collection. The
+running Prometheus resource must select their labels through
+`serviceMonitorSelector` and must select the HAMi-WebUI namespace through
+`serviceMonitorNamespaceSelector`. A common kube-prometheus-stack installation
+selects `release=<its Helm release>`; the first-install command above applies
+that label to all three generated ServiceMonitors.
 
 HAMi's vgpu-monitor exposes workload identity as `namespace`, `pod`, and
 `container`. When Prometheus adds scrape-target labels with the same names and
@@ -201,9 +263,64 @@ scrape_configs:
 `Prometheus.spec.overrideHonorLabels: true` forces
 `honorLabels` off for every ServiceMonitor, including this one.
 
-If the same Prometheus selects both this chart's ServiceMonitor and HAMi's
-built-in device-plugin ServiceMonitor (`prometheus.enabled` in the HAMi chart),
-the endpoint is scraped twice. Configure that Prometheus to select only one.
+If the same Prometheus selects both this Chart's monitor and HAMi's built-in
+device-plugin ServiceMonitor, the endpoint is scraped twice. The HAMi monitor
+does not currently set `honorLabels: true`, so prefer this Chart's monitor and
+leave HAMi's `prometheus.enabled=false`. Use another owner only after confirming
+that its monitor preserves the workload labels, and select exactly one.
+
+For a Prometheus installation without the Operator, keep external mode enabled
+but turn off every Operator custom resource:
+
+```yaml
+externalPrometheus:
+  enabled: true
+  address: "http://<prometheus-address>:9090"
+serviceMonitor:
+  enabled: false
+hamiServiceMonitor:
+  enabled: false
+dcgm-exporter:
+  serviceMonitor:
+    enabled: false
+```
+
+The manually managed scrape configuration must collect all of these targets:
+
+- the generated `my-hami-webui-backend` Service on port `8000`, path `/metrics`;
+- HAMi's device-plugin monitor Service on `monitorport`, path `/metrics`, with
+  `honor_labels: true`;
+- kube-state-metrics for Kubernetes CPU and memory capacity; and
+- every vendor exporter or monitor used by the enabled hardware providers. The
+  consumed metric families include `DCGM_*` for NVIDIA, `npu_*` for Ascend,
+  `dcu_*`/`vdcu_*` for DCU, `mlu_*` for MLU, and `mx_*` for MetaX.
+
+Service names and discovery labels depend on the releases already installed in
+the cluster, so the Chart cannot safely write this external configuration. Raw
+scraping is therefore an advanced, user-managed path.
+
+After installation, query the selected Prometheus rather than relying only on
+Pod readiness. At minimum verify:
+
+```promql
+hami_vgpu_count or hami_core_size
+kube_node_status_allocatable
+```
+
+Then query a metric that matches the installed hardware:
+
+| Hardware | Example query |
+| --- | --- |
+| NVIDIA | `DCGM_FI_DEV_GPU_UTIL` |
+| Ascend | `npu_chip_info_utilization` |
+| DCU | `dcu_utilizationrate` |
+| MLU | `mlu_utilization` |
+| MetaX | `mx_gpu_usage` |
+
+For NVIDIA, also query `hami_container_device_utilization_ratio` while a HAMi
+workload is active. It is NVIDIA container telemetry, not a cross-vendor
+installation check. Missing applicable series means the address, selector,
+namespace selector, scrape ownership, or vendor exporter is still incomplete.
 
 ### Single-container service boundary
 

--- a/scripts/release/package-chart.sh
+++ b/scripts/release/package-chart.sh
@@ -28,8 +28,13 @@ lock_after="$(release_sha256_file "${work_dir}/hami-webui/Chart.lock")"
 [[ "${lock_before}" == "${lock_after}" ]] || \
   release_die "helm dependency build changed Chart.lock"
 
-helm lint "${work_dir}/hami-webui"
-helm template release-verification "${work_dir}/hami-webui" >/dev/null
+prometheus_verification_args=(
+  --set 'externalPrometheus.enabled=true'
+  --set-string 'externalPrometheus.address=http://prometheus.release-verification.svc.cluster.local:9090'
+)
+helm lint "${work_dir}/hami-webui" "${prometheus_verification_args[@]}"
+helm template release-verification "${work_dir}/hami-webui" \
+  "${prometheus_verification_args[@]}" >/dev/null
 helm package "${work_dir}/hami-webui" --destination "${output_dir}"
 
 version="$(yq -r '.version' "${work_dir}/hami-webui/Chart.yaml")"

--- a/scripts/release/tests/release-controller.sh
+++ b/scripts/release/tests/release-controller.sh
@@ -35,7 +35,9 @@ helm show values hami-webui/hami-webui \\
   --version "\${CHART_VERSION}" > values.yaml
 helm install fixture hami-webui/hami-webui \\
   --version "\${CHART_VERSION}" \\
-  --values values.yaml
+  --values values.yaml \\
+  --set externalPrometheus.enabled=true \\
+  --set-string externalPrometheus.address="http://prometheus.example.invalid:9090"
 \`\`\`
 EOF
 }
@@ -65,6 +67,19 @@ yq -e '
     select(.with."persist-credentials" == false)] |
   length == 1
 ' .github/workflows/release.yaml >/dev/null
+
+bootstrap_package_step="$(yq -r '
+  .jobs."bootstrap-oci-prepare".steps[] |
+  select(.name == "Package one auditable non-stable version") |
+  .run
+' .github/workflows/release.yaml)"
+verification_args_reference="\"\${prometheus_verification_args[@]}\""
+if ! grep -Fq 'externalPrometheus.enabled=true' <<<"${bootstrap_package_step}" ||
+  ! grep -Fq 'externalPrometheus.address=http://prometheus.oci-bootstrap.svc.cluster.local:9090' <<<"${bootstrap_package_step}" ||
+  [[ "$(grep -Fc "${verification_args_reference}" <<<"${bootstrap_package_step}")" -ne 2 ]]; then
+  echo "OCI bootstrap lint and render must use one explicit Prometheus verification mode" >&2
+  exit 1
+fi
 
 # Development and candidate publication must build the same unified target and
 # publish only the two canonical registry references.

--- a/scripts/verify-chart-upgrade.sh
+++ b/scripts/verify-chart-upgrade.sh
@@ -234,6 +234,8 @@ hamiServiceMonitor:
 kube-prometheus-stack:
   enabled: false
 externalPrometheus:
+  enabled: true
+  address: http://prometheus.invalid
   timeout: 1s
 metricsExporter:
   interval: 3600s

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -17,7 +17,37 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 
 cp -R "${repo_root}/charts/hami-webui" "${work_dir}/hami-webui"
 helm dependency build --skip-refresh "${work_dir}/hami-webui"
-helm lint --strict "${work_dir}/hami-webui"
+
+prometheus_test_address='http://prometheus.monitoring.svc.cluster.local:9090'
+if default_prometheus_output="$(helm template test "${work_dir}/hami-webui" 2>&1)"; then
+  echo "Chart defaults unexpectedly guessed a Prometheus backend" >&2
+  exit 1
+fi
+if ! grep -Fq 'Prometheus is not configured' <<<"${default_prometheus_output}"; then
+  echo "Unconfigured Prometheus mode did not return an actionable error" >&2
+  echo "${default_prometheus_output}" >&2
+  exit 1
+fi
+
+helm lint --strict "${work_dir}/hami-webui" \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=${prometheus_test_address}"
+
+# Most assertions below exercise unrelated Chart contracts. Give the temporary
+# test copy one explicit external Prometheus mode while leaving the shipped
+# defaults unconfigured and fail-closed.
+test_values_tmp="${work_dir}/values.yaml.tmp"
+awk -v address="${prometheus_test_address}" '
+  $0 == "externalPrometheus:" { in_external = 1; print; next }
+  in_external && $0 == "  enabled: false" { print "  enabled: true"; next }
+  in_external && $0 ~ /^  address:/ {
+    print "  address: \"" address "\""
+    in_external = 0
+    next
+  }
+  { print }
+' "${work_dir}/hami-webui/values.yaml" >"${test_values_tmp}"
+mv "${test_values_tmp}" "${work_dir}/hami-webui/values.yaml"
 
 render_template() {
   local template="$1"
@@ -40,6 +70,10 @@ service_port_names() {
 web_service_render="$(render_template templates/service.yaml)"
 backend_service_render="$(render_template templates/backend-service.yaml)"
 service_monitor_render="$(render_template templates/servicemonitor.yaml)"
+hami_service_monitor_render="$(render_template templates/hamiservicemonitor.yaml)"
+dcgm_service_monitor_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --show-only charts/dcgm-exporter/templates/service-monitor.yaml)"
 default_deployment_render="$(render_template templates/deployment.yaml)"
 default_config_render="$(render_template templates/configmap.yaml)"
 
@@ -165,6 +199,13 @@ if ! grep -Fq 'app.kubernetes.io/component: "backend"' <<<"${service_monitor_spe
   echo "ServiceMonitor must select only the internal backend Service" >&2
   exit 1
 fi
+if ! grep -Fq 'jobRelease: hami-webui-prometheus' <<<"${service_monitor_render}" ||
+  ! grep -Fq 'jobRelease: hami-webui-prometheus' <<<"${hami_service_monitor_render}" ||
+  ! grep -Fq 'jobRelease: hami-webui-prometheus' <<<"${dcgm_service_monitor_render}" ||
+  ! grep -Fq 'honorLabels: true' <<<"${hami_service_monitor_render}"; then
+  echo "Prometheus Operator mode did not render the aligned scrape labels and HAMi label contract" >&2
+  exit 1
+fi
 
 load_balancer_web_service="$(render_template templates/service.yaml \
   --set 'service.type=LoadBalancer')"
@@ -193,6 +234,7 @@ assert_internal_prometheus_address() {
 
   local -a render_args=(
     --namespace "${release_namespace}"
+    --set 'externalPrometheus.enabled=false'
     --set 'kube-prometheus-stack.enabled=true'
     --set 'kube-prometheus-stack.prometheus.enabled=true'
     "$@"
@@ -227,10 +269,12 @@ assert_internal_prometheus_address test hami-webui-test \
 
 prometheus_render="$(helm template test "${work_dir}/hami-webui" \
   --namespace hami-webui-test \
+  --set 'externalPrometheus.enabled=false' \
   --set 'kube-prometheus-stack.enabled=true' \
   --show-only charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml)"
 kube_state_metrics_render="$(helm template test "${work_dir}/hami-webui" \
   --namespace hami-webui-test \
+  --set 'externalPrometheus.enabled=false' \
   --set 'kube-prometheus-stack.enabled=true' \
   --show-only charts/kube-prometheus-stack/charts/kube-state-metrics/templates/servicemonitor.yaml)"
 selector_label='jobRelease: hami-webui-prometheus'
@@ -244,11 +288,104 @@ external_address='http://external-prometheus.observability.svc.cluster.local:909
 external_render="$(helm template test "${work_dir}/hami-webui" \
   --set 'externalPrometheus.enabled=true' \
   --set-string "externalPrometheus.address=${external_address}" \
-  --set 'kube-prometheus-stack.enabled=true' \
-  --set 'kube-prometheus-stack.prometheus.enabled=true' \
   --show-only templates/configmap.yaml)"
 grep -Fq "address: ${external_address}" <<<"${external_render}"
 grep -Fq 'insecure_skip_verify: false' <<<"${external_render}"
+
+assert_prometheus_mode_rejected() {
+  local expected_message="$1"
+  shift
+  local output
+
+  if output="$(helm template test "${work_dir}/hami-webui" "$@" 2>&1)"; then
+    echo "Invalid Prometheus mode was accepted: ${expected_message}" >&2
+    exit 1
+  fi
+  if ! grep -Fq "${expected_message}" <<<"${output}"; then
+    echo "Prometheus mode rejection did not explain: ${expected_message}" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+assert_prometheus_mode_rejected 'Prometheus is not configured' \
+  --set 'externalPrometheus.enabled=false' \
+  --set 'kube-prometheus-stack.enabled=false'
+assert_prometheus_mode_rejected 'mutually exclusive' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=${external_address}" \
+  --set 'kube-prometheus-stack.enabled=true'
+assert_prometheus_mode_rejected 'externalPrometheus.address is required' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address='
+assert_prometheus_mode_rejected 'absolute http:// or https:// URL' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=prometheus.monitoring.svc:9090'
+assert_prometheus_mode_rejected 'externalPrometheus.address must include a hostname' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=http:///api/v1'
+assert_prometheus_mode_rejected 'externalPrometheus.address must include a hostname' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=http://:9090'
+assert_prometheus_mode_rejected 'kube-prometheus-stack.prometheus.enabled must remain true' \
+  --set 'externalPrometheus.enabled=false' \
+  --set 'kube-prometheus-stack.enabled=true' \
+  --set 'kube-prometheus-stack.prometheus.enabled=false'
+
+raw_prometheus_render="$(helm template test "${work_dir}/hami-webui" \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=${external_address}" \
+  --set 'serviceMonitor.enabled=false' \
+  --set 'hamiServiceMonitor.enabled=false' \
+  --set 'dcgm-exporter.serviceMonitor.enabled=false')"
+if grep -Fq 'kind: ServiceMonitor' <<<"${raw_prometheus_render}" ||
+  ! grep -Fq 'kind: DaemonSet' <<<"${raw_prometheus_render}" ||
+  ! grep -Fq "address: ${external_address}" <<<"${raw_prometheus_render}"; then
+  echo "Manual-scrape mode did not remove only the Operator custom resources" >&2
+  exit 1
+fi
+
+existing_operator_args=(
+  --namespace hami-webui-test
+  --include-crds
+  --set 'externalPrometheus.enabled=false'
+  --set 'kube-prometheus-stack.enabled=true'
+)
+existing_operator_render="$(helm template test "${work_dir}/hami-webui" \
+  "${existing_operator_args[@]}")"
+if ! grep -Eq '^kind: Prometheus$' <<<"${existing_operator_render}" ||
+  grep -Eq '^kind: CustomResourceDefinition$' <<<"${existing_operator_render}" ||
+  helm template test "${work_dir}/hami-webui" \
+    "${existing_operator_args[@]}" \
+    --show-only charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml \
+    >/dev/null 2>&1; then
+  echo "Existing-Operator mode rendered the wrong Prometheus ownership resources" >&2
+  exit 1
+fi
+
+self_contained_args=(
+  --namespace hami-webui-test
+  --include-crds
+  --set 'externalPrometheus.enabled=false'
+  --set 'kube-prometheus-stack.enabled=true'
+  --set 'kube-prometheus-stack.crds.enabled=true'
+  --set 'kube-prometheus-stack.prometheusOperator.enabled=true'
+)
+self_contained_render="$(helm template test "${work_dir}/hami-webui" \
+  "${self_contained_args[@]}")"
+self_contained_prometheus_render="$(helm template test "${work_dir}/hami-webui" \
+  "${self_contained_args[@]}" \
+  --show-only charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml)"
+self_contained_operator_render="$(helm template test "${work_dir}/hami-webui" \
+  "${self_contained_args[@]}" \
+  --show-only charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml)"
+if ! grep -Eq '^kind: CustomResourceDefinition$' <<<"${self_contained_render}" ||
+  ! grep -Eq '^kind: Prometheus$' <<<"${self_contained_prometheus_render}" ||
+  ! grep -Eq '^kind: Deployment$' <<<"${self_contained_operator_render}" ||
+  ! grep -Fq 'app: kube-prometheus-stack-operator' <<<"${self_contained_operator_render}"; then
+  echo "Self-contained Prometheus mode omitted CRDs, Operator, or Prometheus" >&2
+  exit 1
+fi
 
 external_deployment_render="$(render_template templates/deployment.yaml \
   --set 'externalPrometheus.enabled=true' \
@@ -311,8 +448,10 @@ grep -Fq 'insecure_skip_verify: true' <<<"${prometheus_insecure_render}"
 
 disabled_tls_render="$(helm template test "${work_dir}/hami-webui" \
   --namespace hami-webui-test \
+  --set 'externalPrometheus.enabled=false' \
   --set-string 'externalPrometheus.tls.existingSecret=unused-tls' \
   --set-string 'externalPrometheus.tls.caKey=ca.pem' \
+  --set 'kube-prometheus-stack.enabled=true' \
   --show-only templates/configmap.yaml \
   --show-only templates/deployment.yaml)"
 if grep -Eq 'prometheus-tls|insecure_skip_verify|unused-tls|ca\.pem' <<<"${disabled_tls_render}"; then

--- a/scripts/verify-install-docs.sh
+++ b/scripts/verify-install-docs.sh
@@ -60,6 +60,13 @@ for install_doc in "${chart_readme}" "${install_guide}"; do
           printf "helm install must define or require CHART_VERSION in the same code block: %s\n", document > "/dev/stderr"
           failed = 1
         }
+        external_mode = index(block, "--set externalPrometheus.enabled=true") > 0 && \
+          index(block, "--set-string externalPrometheus.address=") > 0
+        managed_mode = index(block, "--set kube-prometheus-stack.enabled=true") > 0
+        if (external_mode == managed_mode) {
+          printf "helm install must select exactly one explicit Prometheus mode in %s\n", document > "/dev/stderr"
+          failed = 1
+        }
       }
       in_block = 0
       next
@@ -81,4 +88,4 @@ for install_doc in "${chart_readme}" "${install_guide}"; do
   ' "${install_doc}"
 done
 
-echo "Version-matched Helm installation documentation is valid."
+echo "Version-matched Helm installation and Prometheus mode documentation is valid."


### PR DESCRIPTION
/kind bug

## Why

The Chart could render a Ready HAMi-WebUI Pod while its backend queried a guessed Prometheus Service that did not exist. It also rendered ServiceMonitors without making their ownership and selector contract explicit, so a clean install could silently have no usable metrics.

## What changed

- require exactly one explicit Prometheus mode: an existing HTTP API or the optional managed stack
- reject missing, conflicting, or malformed configuration instead of guessing a Service DNS name
- document existing-Operator, self-contained, raw-scrape, TLS, selector, `honorLabels`, and vendor-exporter requirements
- keep chart packaging and OCI bootstrap verification on an explicit non-production Prometheus fixture
- cover the four ownership modes and the release path with deterministic checks

## Verification

- Helm 3.18.4 and Helm 4.2.4: `bash scripts/verify-chart.sh`
- clean Kind clusters: raw mode without ServiceMonitor CRDs; self-contained CRD/Operator/Prometheus mode with selected targets
- live Chart 1.3 install -> Chart 2 upgrade -> rollback -> forward upgrade
- `bash scripts/verify-install-docs.sh`
- `bash scripts/release/tests/release-controller.sh`
- actionlint 1.7.7 and ShellCheck

Related to #209. This does not publish 2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit Prometheus configuration modes for external or bundled Prometheus deployments.
  * Added validation requiring exactly one mode and a valid external Prometheus address.
  * Expanded Helm installation guidance, monitoring configuration, and verification steps.
* **Documentation**
  * Updated chart examples, configuration references, and release version to 2.0.0-rc.1.
* **Bug Fixes**
  * Prevented deployments from using an invalid or guessed Prometheus service address.
* **Tests**
  * Expanded chart, installation, upgrade, and release validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->