### PR TITLE
build: make the application image the default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,7 +55,7 @@ jest.config.*
 # Charts
 charts
 
-# Only the Web-asset build helper is part of the frontend image context.
+# Only the Web-asset build helper is part of the application image context.
 scripts/*
 !scripts/precompress-web-assets.mjs
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Build Development Images
+name: Build HAMi-WebUI Image
 
 on:
   push:
@@ -40,140 +40,8 @@ jobs:
               - 'server/**'
               - 'test/unified-image/**'
 
-  validate-images:
-    name: Build ${{ matrix.name }} image
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: frontend
-            context: .
-            repository: hami-webui-fe-oss
-          - name: backend
-            context: ./server
-            repository: hami-webui-be-oss
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Build image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ${{ matrix.context }}
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: projecthami/${{ matrix.repository }}:pr-${{ github.event.pull_request.number }}
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
-
-  frontend-runtime-smoke:
-    name: Smoke frontend image runtime (${{ matrix.arch }})
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            platform: linux/amd64
-          - arch: arm64
-            platform: linux/arm64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up QEMU
-        if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Build frontend image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          load: true
-          tags: hami-webui-frontend:runtime-smoke-${{ matrix.arch }}
-          cache-from: type=gha,scope=frontend-runtime-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=frontend-runtime-${{ matrix.arch }}
-
-      - name: Verify non-root read-only runtime
-        shell: bash
-        run: |
-          set -euo pipefail
-          image=hami-webui-frontend:runtime-smoke-${{ matrix.arch }}
-          container=hami-webui-frontend-runtime-smoke-${{ matrix.arch }}
-          curl_local=(curl --noproxy '*')
-          trap 'docker rm --force "${container}" >/dev/null 2>&1 || true' EXIT
-
-          [[ "$(docker image inspect --format '{{.Config.User}}' "${image}")" == "65532:65532" ]]
-          docker run --detach \
-            --platform '${{ matrix.platform }}' \
-            --name "${container}" \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges \
-            --publish 127.0.0.1::3000 \
-            "${image}"
-
-          port="$(docker port "${container}" 3000/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
-          for _ in {1..30}; do
-            if "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/health_check" >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-          "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/health_check" >/dev/null
-          "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/" | grep -Fq '<div id="app"></div>'
-          [[ "$("${curl_local[@]}" --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}/static/contract-missing.js")" == "404" ]]
-
-          docker stop --time 5 "${container}" >/dev/null
-          [[ "$(docker inspect --format '{{.State.ExitCode}}' "${container}")" == "0" ]]
-
-          docker rm "${container}" >/dev/null
-          container="${container}-base-path"
-          docker run --detach \
-            --platform '${{ matrix.platform }}' \
-            --name "${container}" \
-            --read-only \
-            --cap-drop ALL \
-            --security-opt no-new-privileges \
-            --env 'HAMI_WEBUI_BASE_PATH=/gpu-ui/' \
-            --env "HAMI_WEBUI_FRAME_ANCESTORS_JSON=[\"'self'\",\"https://portal.example.com\"]" \
-            --publish 127.0.0.1::3000 \
-            "${image}"
-
-          port="$(docker port "${container}" 3000/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
-          for _ in {1..30}; do
-            if "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/health_check" >/dev/null; then
-              break
-            fi
-            sleep 1
-          done
-          "${curl_local[@]}" --fail --silent --show-error "http://127.0.0.1:${port}/gpu-ui/" | grep -Fq '<base data-hami-webui-base href="/gpu-ui/">'
-          "${curl_local[@]}" --silent --show-error --head "http://127.0.0.1:${port}/gpu-ui/" | tr -d '\r' | \
-            grep -Fq "Content-Security-Policy: frame-ancestors 'self' https://portal.example.com"
-          [[ "$("${curl_local[@]}" --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}/")" == "404" ]]
-
-          docker stop --time 5 "${container}" >/dev/null
-          [[ "$(docker inspect --format '{{.State.ExitCode}}' "${container}")" == "0" ]]
-
   unified-runtime-smoke:
-    name: Smoke unified image runtime
+    name: Smoke application image runtime
     if: needs.unified-image-changes.outputs.unified == 'true'
     needs: unified-image-changes
     runs-on: ubuntu-latest
@@ -193,22 +61,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - name: Build unified image (amd64)
+      - name: Build application image (amd64)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          target: unified
           platforms: linux/amd64
           load: true
           tags: hami-webui:unified-runtime-smoke-amd64
           cache-from: type=gha,scope=unified-runtime
           cache-to: type=gha,mode=max,scope=unified-runtime
 
-      - name: Build unified image (arm64)
+      - name: Build application image (arm64)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          target: unified
           platforms: linux/arm64
           load: true
           tags: hami-webui:unified-runtime-smoke-arm64
@@ -268,21 +134,11 @@ jobs:
     if: github.event_name == 'pull_request' && always()
     needs:
       - unified-image-changes
-      - validate-images
-      - frontend-runtime-smoke
       - unified-runtime-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate image build results
         run: |
-          if [[ "${{ needs.validate-images.result }}" != "success" ]]; then
-            echo "Image builds did not complete successfully: ${{ needs.validate-images.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.frontend-runtime-smoke.result }}" != "success" ]]; then
-            echo "Frontend runtime smoke did not complete successfully: ${{ needs.frontend-runtime-smoke.result }}"
-            exit 1
-          fi
           if [[ "${{ needs.unified-image-changes.result }}" != "success" ]]; then
             echo "Unified image change detection did not complete successfully: ${{ needs.unified-image-changes.result }}"
             exit 1
@@ -292,7 +148,7 @@ jobs:
             echo "Unified image runtime smoke did not complete successfully: ${{ needs.unified-runtime-smoke.result }}"
             exit 1
           fi
-          echo "All image builds passed."
+          echo "Application image checks passed."
 
   publish-development-image:
     name: Publish unified development image

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["/apps/web-entry"]
 
+# Preserve an explicit standalone Web-entry target for focused development and
+# reproducing the old frontend runtime. The application image remains the
+# final, implicit build target below.
+FROM frontend-runtime AS frontend
+
 FROM go-base AS unified-builder
 
 ARG BUILDARCH
@@ -71,7 +76,7 @@ ARG PROTOC_SHA256_ARM64=1de522032a8b194002fe35cab86d747848238b5e4de4f99648372079
 ARG DEBIAN_SNAPSHOT=20260824T000000Z
 ARG UNZIP_VERSION=6.0-28
 
-# Match the pinned backend toolchain while the released backend image remains
+# Match the pinned backend toolchain while the standalone backend image remains
 # independently buildable from server/Dockerfile.
 RUN sed -i -E \
       -e "s|https?://deb.debian.org/debian-security|https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}|g" \
@@ -122,7 +127,3 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 ENTRYPOINT ["/apps/hami-webui"]
 CMD ["--conf", "/apps/config/config.yaml"]
-
-# Keep the released frontend image as the implicit Docker build target until
-# the Chart and release controller migrate atomically in their own PRs.
-FROM frontend-runtime AS frontend

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 PNPM ?= pnpm
 DOCKER ?= docker
-DOCKER_IMAGE ?= hami-webui-frontend
-UNIFIED_DOCKER_IMAGE ?= hami-webui
+DOCKER_IMAGE ?= hami-webui
 VERSION ?= dev
 PLATFORM ?=
 DOCKER_PLATFORM_FLAG := $(if $(strip $(PLATFORM)),--platform $(PLATFORM),)
@@ -20,8 +19,7 @@ help:
 		'  make verify-vite-env        Check the Vite environment boundary' \
 		'  make build-web-entry        Build the production Go Web entry' \
 		'  make verify                 Run all frontend and Web-entry checks' \
-		'  make build-image            Build a local frontend image' \
-		'  make build-unified-image    Build the candidate single-process image' \
+		'  make build-image            Build the application image' \
 		'' \
 		'Use PLATFORM=linux/amd64 (or linux/arm64) for an explicit image platform.'
 
@@ -73,9 +71,3 @@ verify: lint test verify-vite-env build build-web-entry
 .PHONY: build-image
 build-image:
 	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) -t $(DOCKER_IMAGE):$(VERSION) .
-
-# The unified image remains an explicit development target until the Chart and
-# release controller migrate to the single-image contract.
-.PHONY: build-unified-image
-build-unified-image:
-	$(DOCKER) build $(DOCKER_PLATFORM_FLAG) --target unified -t $(UNIFIED_DOCKER_IMAGE):$(VERSION) .

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -160,20 +160,20 @@ bootstrap from the ongoing ability to serve the Web entry.
 
 ## Build a Docker image
 
-Build the same unified target used by development publication and release
-candidates:
+Build the same application image used by development publication, Chart 2, and
+release candidates:
 
 ```bash
-make build-unified-image
+make build-image
 ```
 
-The resulting image is tagged `hami-webui:dev`. Override
-`UNIFIED_DOCKER_IMAGE`, `VERSION`, or `PLATFORM` when a local integration
-environment needs another tag or architecture:
+The resulting image is tagged `hami-webui:dev`. Override `DOCKER_IMAGE`,
+`VERSION`, or `PLATFORM` when a local integration environment needs another tag
+or architecture:
 
 ```bash
-make build-unified-image \
-  UNIFIED_DOCKER_IMAGE=my-registry/hami-webui \
+make build-image \
+  DOCKER_IMAGE=my-registry/hami-webui \
   VERSION=test \
   PLATFORM=linux/amd64
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,11 +10,6 @@ publishing: the protected `release` environment must exist and its
 `STABLE_RELEASES_ENABLED` variable must be set to `true` after the repository,
 registry, and release acceptance gates below are configured.
 
-The unified image contract lands before the Chart 2 migration by design. Until
-that follow-up changes the production chart from `image.frontend` and
-`image.backend` to the single `image` value, release-contract verification
-fails closed and no stable release can be published.
-
 ## What “atomic” means here
 
 Docker Hub, GHCR, GitHub Pages, and GitHub Releases do not share a transaction.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**

Chart 2, development publication, and stable releases now use the single
`hami-webui` application image, but the repository defaults still produced the
standalone frontend image. A plain `docker build .` could therefore pass its
health check while returning 502 for every API request.

This change:

- makes the unified application the default Docker target and `make build-image`;
- keeps the standalone `frontend` target available explicitly;
- replaces unconditional frontend/backend image jobs with the existing
  dual-architecture application runtime smoke;
- keeps the required `pr-images-required` check name unchanged;
- updates the developer and release documentation.

**Verification**

- `actionlint` passes for `.github/workflows/ci.yaml`;
- `make verify` passes;
- `docker buildx build --call=targets .` reports `unified (default)`;
- `make build-image VERSION=default-contract PLATFORM=linux/amd64` succeeds;
- the default image passes the Kind runtime contract: non-root/read-only,
  Web and API listeners, SPA/base path, frame policy, metrics/readiness
  isolation, and graceful shutdown.

CI verifies the default image on both linux/amd64 and linux/arm64.

Progresses #209.
