### PR TITLE
docs: align project entry points with current scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,16 @@ For more ways to contribute, check out the [Open Source Guides](https://opensour
 
 Before submitting a new issue, try to make sure someone hasn't already reported the problem. Look through the [existing issues](https://github.com/Project-HAMi/HAMi-WebUI/issues) for similar issues.
 
-Report a bug by [opening an issue](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=bug). Make sure that you provide as much information as possible on how to reproduce the bug.
+Report a bug by [opening an issue](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=kind%2Fbug). Make sure that you provide as much information as possible on how to reproduce the bug.
 
-For authentication and alerting HAMi-WebUI server logs are useful.
+Include the HAMi-WebUI version, installation mode, Kubernetes and HAMi
+versions, browser, reproduction steps, expected and actual behavior, and
+relevant browser console, network, or server logs. Remove credentials and
+private cluster data before sharing logs.
 
 ### Suggest enhancements
 
-If you have an idea of how to improve HAMi-WebUI, submit a [feature request](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=enhancement).
+If you have an idea of how to improve HAMi-WebUI, submit a [feature request](https://github.com/Project-HAMi/HAMi-WebUI/issues/new?labels=kind%2Fenhancement).
 
 We want to make HAMi-WebUI accessible to even more people. [Open an issue](https://github.com/Project-HAMi/HAMi-WebUI/issues/new) to help us understand what we can improve.
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 		'  make test                   Run Vue unit and contract tests' \
 		'  make build                  Build and pre-compress browser assets' \
 		'  make verify-vite-env        Check the Vite environment boundary' \
-		'  make build-web-entry        Build the production Go Web entry' \
+		'  make build-web-entry        Build the standalone Web-entry contract binary' \
 		'  make verify                 Run all frontend and Web-entry checks' \
 		'  make build-image            Build the application image' \
 		'' \

--- a/README.md
+++ b/README.md
@@ -2,16 +2,32 @@
 
 English | [简体中文](README_ZH.md) | [日本語](README_JA.md)
 
-An open-source platform for managing and observing GPU resources, based on the HAMi project
+An open-source, single-cluster observability UI for heterogeneous accelerators managed by [HAMi](https://github.com/Project-HAMi/HAMi)
 
-[![License](https://img.shields.io/github/license/Project-HAMi/HAMi)](LICENSE)
+[![License](https://img.shields.io/github/license/Project-HAMi/HAMi-WebUI)](LICENSE)
 
-HAMi-WebUI is built upon the [HAMi](https://github.com/Project-HAMi/HAMi) open-source project. It extends HAMi by providing an intuitive web interface for visualizing and managing GPU resource allocation and usage across nodes. The platform supports detailed views for tasks and GPUs, enabling teams to monitor resource consumption effectively.
+HAMi-WebUI visualizes accelerator inventory, allocation state, and available
+vendor telemetry across Kubernetes nodes. It provides:
 
-- **Resource Overview:** Provides a comprehensive view of all resources, including node and GPU usage. Quickly assess the status of all nodes and GPUs.
-- **Node Management:** Explore detailed node information, including node status, resource usage, and availability.
-- **GPU Management:** Visualize the GPU usage on each node, providing detailed insights into the allocation and usage of compute power and memory.
-- **Task Management:** Track tasks and their resource consumption. View task creation times, status, GPU allocations, and more.
+- **Cluster overview:** Review detected accelerator capacity, allocation, and
+  available utilization signals.
+- **Node inventory:** Inspect accelerator nodes, their devices, and resource
+  state.
+- **Accelerator visibility:** Inspect per-device allocation and vendor telemetry.
+- **Workload visibility:** Inspect current HAMi Pod/container assignments and the
+  monitoring data available for their devices.
+
+Current provider integrations include NVIDIA GPUs, Huawei Ascend 910B/310P,
+Hygon DCUs, Cambricon MLUs, and MetaX GPUs/sGPUs. Metric coverage depends on the
+HAMi integration and exporter available for each device type.
+
+## Scope and security
+
+HAMi-WebUI is read-only. It does not schedule resources, create or mutate
+workloads, change nodes, provide built-in authentication or user RBAC, or
+aggregate multiple clusters. Deploy one instance per cluster and protect it
+with an authenticated Ingress or proxy unless it is reachable only from a
+trusted network.
 
 ## Get started
 
@@ -24,14 +40,13 @@ If you're interested in contributing to HAMi-WebUI:
 
 - Start by reading the [Contributing guide](CONTRIBUTING.md).
 - Set up your local environment by following our [Developer guide](docs/contribute/developer-guide.md).
-- Explore [beginner-friendly issues](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22).
+- Explore [good first issues](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
 ## Get involved
 
-- Regular Community Meeting: Friday at 16:00 UTC+8 (Chinese)(weekly). [Convert to your timezone](https://www.thetimezoneconverter.com/?t=14%3A30&tz=GMT%2B8&).
-  - [Meeting Notes and Agenda](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-  - [Meeting Link](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- Join our community on [Slack](https://join.slack.com/t/hami-hsf3791/shared_invite/zt-2gcteqiph-Ls8Atnpky6clrspCAQ_eGQ).
+HAMi-WebUI is discussed in the HAMi community. See the canonical
+[HAMi community channels](https://github.com/Project-HAMi/HAMi#community) for
+current meetings, Discord, Slack, and the mailing list.
 
 ## License
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -2,20 +2,27 @@
 
 [English](README.md) | [简体中文](README_ZH.md) | 日本語
 
-HAMi プロジェクトをベースとした、GPU リソースの管理・監視のためのオープンソースプラットフォーム
+[HAMi](https://github.com/Project-HAMi/HAMi) が管理する異種アクセラレータ向けの、オープンソースかつシングルクラスタ対応の可観測性 UI
 
-[![License](https://img.shields.io/github/license/Project-HAMi/HAMi)](LICENSE)
+[![License](https://img.shields.io/github/license/Project-HAMi/HAMi-WebUI)](LICENSE)
 
-HAMi-WebUI は [HAMi](https://github.com/Project-HAMi/HAMi) オープンソースプロジェクトをベースに構築されています。直感的な Web インターフェースを提供することで HAMi の機能を拡張し、各ノードにおける GPU リソースの割り当てと使用状況を可視化・管理できます。タスクや GPU の詳細ビューに対応しており、チームがリソース消費を効率的に監視できるようにします。
+HAMi-WebUI は、Kubernetes ノード上のアクセラレータのインベントリ、割り当て状態、および利用可能なベンダーテレメトリを可視化します。主な機能は次のとおりです。
 
-- **リソース概要:** ノードや GPU の使用状況を含む、すべてのリソースの包括的なビューを提供します。すべてのノードと GPU のステータスを素早く把握できます。
-- **ノード管理:** ノードのステータス、リソース使用状況、可用性など、詳細なノード情報を確認できます。
-- **GPU 管理:** 各ノードの GPU 使用状況を可視化し、演算能力とメモリの割り当て・使用状況を詳細に表示します。
-- **タスク管理:** タスクとそのリソース消費を追跡します。タスクの作成時刻、ステータス、GPU 割り当てなどを確認できます。
+- **クラスタ概要：** 検出されたアクセラレータの容量、割り当て、取得可能な使用率指標を確認します。
+- **ノードインベントリ：** アクセラレータノード、デバイス、およびリソース状態を確認します。
+- **アクセラレータ可視性：** デバイスごとの割り当てとベンダーテレメトリを確認します。
+- **ワークロード可視性：** 現在観測されている HAMi ワークロード（Pod/コンテナ）へのデバイス割り当てと、対象デバイスで利用可能な監視データを確認します。
+
+現在の連携対象は、NVIDIA GPU、Huawei Ascend 910B/310P、Hygon DCU、Cambricon MLU、および MetaX GPU/sGPU です。表示できるメトリクスは、デバイス種別ごとの HAMi 連携と exporter によって異なります。
+
+## スコープとセキュリティ境界
+
+HAMi-WebUI は読み取り専用です。リソースのスケジューリング、ワークロードの作成や変更、ノードの変更、組み込み認証やユーザー RBAC、マルチクラスタ集約は行いません。クラスタごとに 1 インスタンスをデプロイし、信頼されたネットワーク内だけで利用する場合を除き、認証付き Ingress またはプロキシで保護してください。
 
 ## はじめに
 
 - [インストールガイド](docs/installation/helm/index.md)
+- [URL プレフィックスとプラットフォームへの埋め込み](docs/installation/embedding.md)
 
 ## コントリビューション
 
@@ -23,14 +30,11 @@ HAMi-WebUI への貢献に興味がある方は：
 
 - まず[コントリビューションガイド](CONTRIBUTING.md)をお読みください。
 - [開発者ガイド](docs/contribute/developer-guide.md)に従ってローカル環境をセットアップしてください。
-- [初心者向けの Issue](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) を確認してみてください。
+- [Good first issue](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) を確認してみてください。
 
 ## コミュニティ
 
-- 定例ミーティング: 毎週金曜日 16:00 UTC+8（中国語）。[タイムゾーンを変換](https://www.thetimezoneconverter.com/?t=14%3A30&tz=GMT%2B8&)
-  - [議事録とアジェンダ](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-  - [ミーティングリンク](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- [Slack](https://join.slack.com/t/hami-hsf3791/shared_invite/zt-2gcteqiph-Ls8Atnpky6clrspCAQ_eGQ) コミュニティに参加してください。
+HAMi-WebUI は HAMi コミュニティの共通チャンネルを利用しています。最新のコミュニティミーティング、Discord、Slack、およびメーリングリストについては、[HAMi のコミュニティ案内](https://github.com/Project-HAMi/HAMi/blob/master/README_ja.md#コミュニティ) を参照してください。
 
 ## ライセンス
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,20 +2,27 @@
 
 [English](README.md) | 简体中文 | [日本語](README_JA.md)
 
-基于 HAMi 项目的开源 GPU 资源管理与监控平台
+面向 [HAMi](https://github.com/Project-HAMi/HAMi) 管理的异构加速器的开源单集群可观测界面
 
-[![License](https://img.shields.io/github/license/Project-HAMi/HAMi)](LICENSE)
+[![License](https://img.shields.io/github/license/Project-HAMi/HAMi-WebUI)](LICENSE)
 
-HAMi-WebUI 是基于 [HAMi](https://github.com/Project-HAMi/HAMi) 开源项目构建的。它通过提供一个直观的 Web 界面来扩展 HAMi 的功能，帮助用户可视化和管理节点上的 GPU 资源分配和使用情况。该平台支持任务和显卡的详细视图，使团队能够高效地监控资源消耗。
+HAMi-WebUI 用于查看 Kubernetes 节点上的加速器清单、分配状态，以及各厂商当前可提供的监控数据。主要包括：
 
-- **资源概览:** 提供所有资源的综合视图，包括节点和显卡的资源使用情况。快速评估所有节点和显卡的状态。
-- **节点管理:** 浏览详细的节点信息，包括节点状态、资源使用情况。
-- **显卡管理:** 可视化各节点的显卡使用情况，详细展示算力与显存的分配与使用。
-- **任务管理:** 追踪任务及其资源消耗。查看任务创建时间、状态、显卡分配等信息。
+- **集群概览：** 查看已识别加速器的容量、分配情况和可获取的使用率指标。
+- **节点清单：** 查看加速器节点、设备及其资源状态。
+- **加速器可见性：** 查看每个设备的分配情况和厂商监控数据。
+- **工作负载可见性：** 查看当前 HAMi Pod/容器的设备分配，以及对应设备可提供的监控数据。
+
+当前适配 NVIDIA GPU、华为昇腾 910B/310P、海光 DCU、寒武纪 MLU，以及沐曦 GPU/sGPU。不同设备类型可展示的指标取决于对应的 HAMi 适配和 exporter。
+
+## 范围与安全边界
+
+HAMi-WebUI 是只读界面，不负责调度资源、创建或修改工作负载、变更节点，也不内置登录、用户 RBAC 或多集群聚合。每个集群应独立部署一个实例；除非仅在可信网络内访问，否则请在前方配置带身份认证的 Ingress 或代理。
 
 ## 开始使用
 
 - [安装指南](docs/installation/helm/index.md)
+- [URL 前缀与平台嵌入](docs/installation/embedding.md)
 
 ## 参与贡献
 
@@ -23,16 +30,12 @@ HAMi-WebUI 是基于 [HAMi](https://github.com/Project-HAMi/HAMi) 开源项目�
 
 - 首先阅读[贡献指南](CONTRIBUTING.md)。
 - 按照我们的[开发者指南](docs/contribute/developer-guide.md)设置本地开发环境。
-- 查看[适合初学者的问题](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22)。
+- 查看[适合首次贡献的问题](https://github.com/Project-HAMi/HAMi-WebUI/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)。
 
 ## 参与社区
 
-- 周例会: Friday at 16:00 UTC+8 (Chinese)(weekly).
-  - [Meeting Notes and Agenda](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit#heading=h.g61sgp7w0d0c)
-  - [Meeting Link](https://meeting.tencent.com/dm/Ntiwq1BICD1P)
-- 加入我们的 [Slack 社区](https://join.slack.com/t/hami-hsf3791/shared_invite/zt-2gcteqiph-Ls8Atnpky6clrspCAQ_eGQ)。
+HAMi-WebUI 使用 HAMi 社区的统一沟通渠道。最新的社区会议、Discord、Slack 和邮件列表入口请查看 [HAMi 社区说明](https://github.com/Project-HAMi/HAMi/blob/master/README_cn.md#社区)。
 
 ## 许可证
 
 HAMi-WebUI 根据 [Apache-2.0](LICENSE) 许可证分发。如需了解详细情况，请参阅 [LICENSE](LICENSE)。
-

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -24,6 +24,7 @@ brew install git
 brew install go
 brew install node@24
 brew install protobuf
+export PATH="$(brew --prefix node@24)/bin:$PATH"
 corepack enable
 ```
 
@@ -66,6 +67,11 @@ Node.js and pnpm remain build and test dependencies for the Vue application.
 They are not present in the production image.
 
 ### Backend development
+
+The backend reads the active kubeconfig context and
+[`server/config/config.yaml`](../../server/config/config.yaml). Select a
+development cluster you are authorized to inspect and configure a reachable
+Prometheus address before starting it.
 
 Generate the API code and start the backend from the repository root:
 


### PR DESCRIPTION
## Why

The project entry still described HAMi-WebUI as a GPU management platform even though the current product is a single-cluster, read-only observability UI for heterogeneous accelerators. The translated READMEs and contributor paths also contained stale labels, community links, and setup guidance.

## What changed

- Describe the observable inventory, allocation, telemetry, and Pod/container workload scope without implying scheduling or mutation.
- State the single-cluster, authentication, RBAC, and vendor-telemetry boundaries.
- Keep English, Chinese, and Japanese entry pages aligned and point community traffic to HAMi’s canonical channels.
- Repair the license badge, good-first-issue query, bug evidence guidance, macOS Node 24 path, backend prerequisites, and standalone Web-entry help text.

## Verification

- Traced the provider, Kubernetes RBAC, API, and runtime configuration contracts.
- Verified every changed external entry URL returns HTTP 200.
- `make help`
- `git diff --check`

Part of #209.