### PR TITLE
fix: secure external Prometheus authentication

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -83,7 +83,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | dcgm-exporter.serviceMonitor.interval | string | `"15s"`                                                                            |  |
 | env[0].name | string | `"TZ"` | Default environment variable name for the single application container. Use `frontend.*`, not reserved `HAMI_WEBUI_*` variables, for the public path and iframe policy. |
 | env[0].value | string | `"Asia/Shanghai"` | Default timezone value. |
-| externalPrometheus.address | string | `""` | Required Prometheus or VictoriaMetrics HTTP API address when external mode is enabled. |
+| externalPrometheus.address | string | `""` | Required Prometheus or VictoriaMetrics HTTP API address when external mode is enabled. URL user information is rejected; use the Secret-backed authentication values instead. |
+| externalPrometheus.authorization.type | string | `"Bearer"` | HTTP Authorization scheme. `Basic` is rejected; use `basicAuth` for HTTP Basic Authentication. |
+| externalPrometheus.authorization.existingSecret | string | `""` | Existing same-namespace Secret containing the Authorization credentials. Mutually exclusive with `basicAuth`. |
+| externalPrometheus.authorization.credentialsKey | string | `""` | Data key in the Authorization Secret. Configure together with `existingSecret`. |
+| externalPrometheus.basicAuth.existingSecret | string | `""` | Existing same-namespace Secret containing the Basic Authentication username and password. Mutually exclusive with `authorization`. |
+| externalPrometheus.basicAuth.usernameKey | string | `""` | Data key in the Basic Authentication Secret containing the username. |
+| externalPrometheus.basicAuth.passwordKey | string | `""` | Data key in the Basic Authentication Secret containing the password. |
 | externalPrometheus.enabled | bool | `false`                                                                            | Use an existing metrics backend. Exactly one of this value and `kube-prometheus-stack.enabled` must be true. |
 | externalPrometheus.timeout | string | `"1m"` | Timeout sent with each upstream PromQL request. |
 | externalPrometheus.tls.insecureSkipVerify | bool | `false` | Disable HTTPS certificate verification. Use only as a temporary break-glass setting. |
@@ -216,5 +222,5 @@ kube-prometheus-stack:
 The external path requires a running Prometheus Operator and matching
 ServiceMonitor label/namespace selectors. The self-contained path creates
 cluster-scoped resources. Raw scraping, reuse of an existing Operator, HTTPS
-trust, duplicate-target prevention, and verification queries are documented in
+trust and authentication, duplicate-target prevention, and verification queries are documented in
 the [installation guide](../../docs/installation/helm/index.md#select-a-prometheus-ownership-mode).

--- a/charts/hami-webui/templates/_helpers.tpl
+++ b/charts/hami-webui/templates/_helpers.tpl
@@ -190,12 +190,19 @@ does not exist, so an unconfigured or ambiguous mode must fail at render time.
 {{- fail "Prometheus is not configured; enable externalPrometheus with an explicit address or enable kube-prometheus-stack" -}}
 {{- end -}}
 {{- if $externalEnabled -}}
-{{- $address := trim (default "" (get $external "address")) -}}
+{{- $rawAddress := default "" (get $external "address") -}}
+{{- $address := trim $rawAddress -}}
 {{- if empty $address -}}
 {{- fail "externalPrometheus.address is required when externalPrometheus.enabled=true" -}}
 {{- end -}}
+{{- if ne $rawAddress $address -}}
+{{- fail "externalPrometheus.address must not contain leading or trailing whitespace" -}}
+{{- end -}}
 {{- if not (regexMatch "^https?://[^[:space:]]+$" $address) -}}
 {{- fail "externalPrometheus.address must be an absolute http:// or https:// URL without whitespace" -}}
+{{- end -}}
+{{- if regexMatch "^https?://[^/?#]*@" $address -}}
+{{- fail "externalPrometheus.address must not include user information; configure authorization or basicAuth instead" -}}
 {{- end -}}
 {{- $parsedAddress := urlParse $address -}}
 {{- if empty (get $parsedAddress "hostname") -}}
@@ -221,6 +228,81 @@ own helpers so release-name, namespace and port overrides cannot drift.
 {{- else if (index .Values "kube-prometheus-stack").enabled -}}
 {{- $stack := index .Subcharts "kube-prometheus-stack" -}}
 {{- printf "http://%s-prometheus.%s.svc.cluster.local:%v" (include "kube-prometheus-stack.fullname" $stack) (include "kube-prometheus-stack.namespace" $stack) $stack.Values.prometheus.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate file-backed authentication for an external Prometheus endpoint. Secret
+contents never enter values or rendered configuration; the Chart only accepts a
+Secret name and selected data keys.
+*/}}
+{{- define "hami-webui.validatePrometheusAuthentication" -}}
+{{- $external := default (dict) .Values.externalPrometheus -}}
+{{- $rawAuthorization := get $external "authorization" -}}
+{{- $rawBasicAuth := get $external "basicAuth" -}}
+{{- if and $rawAuthorization (not (kindIs "map" $rawAuthorization)) -}}
+{{- fail "externalPrometheus.authorization must be a map" -}}
+{{- end -}}
+{{- if and $rawBasicAuth (not (kindIs "map" $rawBasicAuth)) -}}
+{{- fail "externalPrometheus.basicAuth must be a map" -}}
+{{- end -}}
+{{- $authorization := default (dict) $rawAuthorization -}}
+{{- $basicAuth := default (dict) $rawBasicAuth -}}
+{{- range $field := list "type" "existingSecret" "credentialsKey" -}}
+{{- if and (hasKey $authorization $field) (not (kindIs "string" (get $authorization $field))) -}}
+{{- fail (printf "externalPrometheus.authorization.%s must be a string" $field) -}}
+{{- end -}}
+{{- $value := default "" (get $authorization $field) -}}
+{{- if ne $value (trim $value) -}}
+{{- fail (printf "externalPrometheus.authorization.%s must not contain leading or trailing whitespace" $field) -}}
+{{- end -}}
+{{- end -}}
+{{- range $field := list "existingSecret" "usernameKey" "passwordKey" -}}
+{{- if and (hasKey $basicAuth $field) (not (kindIs "string" (get $basicAuth $field))) -}}
+{{- fail (printf "externalPrometheus.basicAuth.%s must be a string" $field) -}}
+{{- end -}}
+{{- $value := default "" (get $basicAuth $field) -}}
+{{- if ne $value (trim $value) -}}
+{{- fail (printf "externalPrometheus.basicAuth.%s must not contain leading or trailing whitespace" $field) -}}
+{{- end -}}
+{{- end -}}
+{{- $authorizationType := trim (default "Bearer" (get $authorization "type")) -}}
+{{- $authorizationSecret := trim (default "" (get $authorization "existingSecret")) -}}
+{{- $credentialsKey := trim (default "" (get $authorization "credentialsKey")) -}}
+{{- $basicAuthSecret := trim (default "" (get $basicAuth "existingSecret")) -}}
+{{- $usernameKey := trim (default "" (get $basicAuth "usernameKey")) -}}
+{{- $passwordKey := trim (default "" (get $basicAuth "passwordKey")) -}}
+{{- $authorizationConfigured := or (ne $authorizationSecret "") (ne $credentialsKey "") (ne $authorizationType "Bearer") -}}
+{{- $basicAuthConfigured := or (ne $basicAuthSecret "") (ne $usernameKey "") (ne $passwordKey "") -}}
+{{- if and $authorizationConfigured $basicAuthConfigured -}}
+{{- fail "externalPrometheus.authorization and externalPrometheus.basicAuth are mutually exclusive" -}}
+{{- end -}}
+{{- if and (or $authorizationConfigured $basicAuthConfigured) (not (get $external "enabled")) -}}
+{{- fail "external Prometheus authentication requires externalPrometheus.enabled=true" -}}
+{{- end -}}
+{{- if $authorizationConfigured -}}
+{{- if or (empty $authorizationSecret) (empty $credentialsKey) -}}
+{{- fail "externalPrometheus.authorization.existingSecret and credentialsKey must be configured together" -}}
+{{- end -}}
+{{- if empty $authorizationType -}}
+{{- fail "externalPrometheus.authorization.type must not be empty" -}}
+{{- end -}}
+{{- if eq (lower $authorizationType) "basic" -}}
+{{- fail "externalPrometheus.authorization.type cannot be Basic; use externalPrometheus.basicAuth" -}}
+{{- end -}}
+{{- if not (regexMatch "^[A-Za-z0-9._-]+$" $credentialsKey) -}}
+{{- fail (printf "externalPrometheus authorization Secret key %q is invalid" $credentialsKey) -}}
+{{- end -}}
+{{- end -}}
+{{- if $basicAuthConfigured -}}
+{{- if or (empty $basicAuthSecret) (empty $usernameKey) (empty $passwordKey) -}}
+{{- fail "externalPrometheus.basicAuth.existingSecret, usernameKey and passwordKey must be configured together" -}}
+{{- end -}}
+{{- range $key := list $usernameKey $passwordKey -}}
+{{- if not (regexMatch "^[A-Za-z0-9._-]+$" $key) -}}
+{{- fail (printf "externalPrometheus basicAuth Secret key %q is invalid" $key) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/hami-webui/templates/configmap.yaml
+++ b/charts/hami-webui/templates/configmap.yaml
@@ -1,6 +1,11 @@
 {{- include "hami-webui.validateChart2Values" . -}}
+{{- include "hami-webui.validatePrometheusAuthentication" . -}}
 {{- include "hami-webui.validatePrometheusTLS" . -}}
 {{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
+{{- $prometheusAuthorization := default (dict) (get $externalPrometheus "authorization") -}}
+{{- $prometheusBasicAuth := default (dict) (get $externalPrometheus "basicAuth") -}}
+{{- $prometheusAuthorizationSecret := default "" (get $prometheusAuthorization "existingSecret") -}}
+{{- $prometheusBasicAuthSecret := default "" (get $prometheusBasicAuth "existingSecret") -}}
 {{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
 {{- $prometheusTLSSecret := default "" (get $prometheusTLS "existingSecret") -}}
 {{- $prometheusCAKey := default "" (get $prometheusTLS "caKey") -}}
@@ -19,6 +24,15 @@ data:
     prometheus:
       address: {{ include "hami-webui.prometheusAddress" . }}
       timeout: {{ .Values.externalPrometheus.timeout | default "1m" }}
+      {{- if and (get $externalPrometheus "enabled") $prometheusAuthorizationSecret }}
+      authorization:
+        type: {{ default "Bearer" (get $prometheusAuthorization "type") | quote }}
+        credentials_file: "/apps/prometheus-auth/credentials"
+      {{- else if and (get $externalPrometheus "enabled") $prometheusBasicAuthSecret }}
+      basic_auth:
+        username_file: "/apps/prometheus-auth/username"
+        password_file: "/apps/prometheus-auth/password"
+      {{- end }}
       {{- if (get $externalPrometheus "enabled") }}
       tls:
         insecure_skip_verify: {{ default false (get $prometheusTLS "insecureSkipVerify") }}

--- a/charts/hami-webui/templates/deployment.yaml
+++ b/charts/hami-webui/templates/deployment.yaml
@@ -3,8 +3,15 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.podAnnotations) (dict "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)) -}}
 {{- $env := default (list) .Values.env -}}
 {{- $frontendSettings := default (dict) .Values.frontend -}}
+{{- include "hami-webui.validatePrometheusAuthentication" . -}}
 {{- include "hami-webui.validatePrometheusTLS" . -}}
 {{- $externalPrometheus := default (dict) .Values.externalPrometheus -}}
+{{- $prometheusAuthorization := default (dict) (get $externalPrometheus "authorization") -}}
+{{- $prometheusBasicAuth := default (dict) (get $externalPrometheus "basicAuth") -}}
+{{- $prometheusAuthorizationSecret := default "" (get $prometheusAuthorization "existingSecret") -}}
+{{- $prometheusBasicAuthSecret := default "" (get $prometheusBasicAuth "existingSecret") -}}
+{{- $prometheusAuthSecret := default "" (coalesce $prometheusAuthorizationSecret $prometheusBasicAuthSecret) -}}
+{{- $mountPrometheusAuth := and (get $externalPrometheus "enabled") (ne $prometheusAuthSecret "") -}}
 {{- $prometheusTLS := default (dict) (get $externalPrometheus "tls") -}}
 {{- $prometheusTLSSecret := default "" (get $prometheusTLS "existingSecret") -}}
 {{- $mountPrometheusTLS := and (get $externalPrometheus "enabled") (ne $prometheusTLSSecret "") -}}
@@ -102,6 +109,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /apps/config/
+            {{- if $mountPrometheusAuth }}
+            - name: prometheus-auth
+              mountPath: /apps/prometheus-auth/
+              readOnly: true
+            {{- end }}
             {{- if $mountPrometheusTLS }}
             - name: prometheus-tls
               mountPath: /apps/prometheus-tls/
@@ -123,6 +135,21 @@ spec:
         - name: config
           configMap:
             name: {{ include "hami-webui.fullname" . }}-config
+        {{- if $mountPrometheusAuth }}
+        - name: prometheus-auth
+          secret:
+            secretName: {{ $prometheusAuthSecret | quote }}
+            items:
+              {{- if $prometheusAuthorizationSecret }}
+              - key: {{ get $prometheusAuthorization "credentialsKey" | quote }}
+                path: credentials
+              {{- else }}
+              - key: {{ get $prometheusBasicAuth "usernameKey" | quote }}
+                path: username
+              - key: {{ get $prometheusBasicAuth "passwordKey" | quote }}
+                path: password
+              {{- end }}
+        {{- end }}
         {{- if $mountPrometheusTLS }}
         - name: prometheus-tls
           secret:

--- a/charts/hami-webui/values.schema.json
+++ b/charts/hami-webui/values.schema.json
@@ -102,6 +102,37 @@
           "type": "string",
           "minLength": 1
         },
+        "authorization": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "minLength": 1
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "credentialsKey": {
+              "type": "string"
+            }
+          }
+        },
+        "basicAuth": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "existingSecret": {
+              "type": "string"
+            },
+            "usernameKey": {
+              "type": "string"
+            },
+            "passwordKey": {
+              "type": "string"
+            }
+          }
+        },
         "tls": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -168,6 +168,20 @@ externalPrometheus:
   address: ""
   # Single PromQL upstream timeout (sent to Prometheus / VictoriaMetrics as the &timeout= parameter).
   timeout: "1m"
+  # Optional HTTP Authorization credentials. Set existingSecret and
+  # credentialsKey together to enable this mode. The Secret value is mounted as
+  # a file and is never copied into the ConfigMap or Pod environment.
+  authorization:
+    type: "Bearer"
+    existingSecret: ""
+    credentialsKey: ""
+  # Optional HTTP Basic Authentication credentials. This mode is mutually
+  # exclusive with authorization. Use HTTPS unless transport security is
+  # provided outside the application.
+  basicAuth:
+    existingSecret: ""
+    usernameKey: ""
+    passwordKey: ""
   tls:
     # HTTPS certificates are verified by default. Use this only as a temporary
     # escape hatch when a CA cannot yet be supplied.

--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -119,8 +119,8 @@ helm history my-hami-webui --namespace kube-system
 ```
 
 Create a new `values-v2.yaml` from the Chart 2 defaults, then copy only the
-settings you still need. Chart 2 supports external Prometheus and TLS settings,
-ServiceMonitor labels, Ingress, scheduling, security contexts,
+settings you still need. Chart 2 supports external Prometheus authentication
+and TLS settings, ServiceMonitor labels, Ingress, scheduling, security contexts,
 `frontend.basePath`, and `frontend.frameAncestors`; copy only settings that are
 actually present in your deployment.
 
@@ -196,6 +196,73 @@ If a compatible Operator and CRDs already exist but a separate Prometheus
 instance is desired, enable only `kube-prometheus-stack.enabled`; the Chart's
 defaults deliberately leave that dependency's CRDs and Operator disabled. The
 existing Operator must watch the HAMi-WebUI namespace.
+
+### Authenticate to an external Prometheus
+
+Use an existing Kubernetes Secret in the HAMi-WebUI namespace. The Chart does
+not accept inline credentials and does not copy Secret values, names, or data
+keys into its ConfigMap or Pod environment. It mounts only the selected keys at
+fixed file paths. The examples read credentials from local files so their values
+do not become command-line arguments or shell history.
+
+For a bearer token or another HTTP Authorization scheme, create the Secret and
+select its data key:
+
+```bash
+kubectl create secret generic hami-webui-prometheus-auth \
+  --namespace kube-system \
+  --from-file=token=/secure/path/prometheus-token
+```
+
+```yaml
+externalPrometheus:
+  enabled: true
+  address: "https://prometheus.example.com"
+  authorization:
+    type: Bearer
+    existingSecret: hami-webui-prometheus-auth
+    credentialsKey: token
+```
+
+For HTTP Basic Authentication, use one Secret containing both fields:
+
+```bash
+kubectl create secret generic hami-webui-prometheus-basic-auth \
+  --namespace kube-system \
+  --from-file=username=/secure/path/prometheus-username \
+  --from-file=password=/secure/path/prometheus-password
+```
+
+```yaml
+externalPrometheus:
+  enabled: true
+  address: "https://prometheus.example.com"
+  basicAuth:
+    existingSecret: hami-webui-prometheus-basic-auth
+    usernameKey: username
+    passwordKey: password
+```
+
+`authorization` and `basicAuth` are mutually exclusive. The Chart rejects
+credentials embedded in `externalPrometheus.address` such as
+`https://user:password@prometheus.example.com`; URL credentials are readily
+exposed by configuration output and logs. Basic Authentication and bearer
+tokens should use HTTPS unless transport security is provided elsewhere.
+Authenticated redirects are followed only when the scheme, host and effective
+port remain the same; cross-origin redirects fail before a request is sent to
+the new origin.
+
+The Prometheus client reads these files for every request. After Kubernetes
+propagates a Secret update to the mounted volume, new requests use the
+rotated credentials without restarting the Pod. The Chart deliberately mounts
+the directory rather than using `subPath`, because a `subPath` mount does not
+receive automated Secret updates.
+
+The direct server configuration field `prometheus.auth` remains available for
+pre-2.0 compatibility but is deprecated. New direct configurations should use
+`prometheus.authorization.credentials_file` or
+`prometheus.basic_auth.username_file` and `password_file`; these modes are
+mutually exclusive with the legacy field.
 
 ### HTTPS external Prometheus
 

--- a/scripts/verify-chart.sh
+++ b/scripts/verify-chart.sh
@@ -337,6 +337,22 @@ assert_prometheus_mode_rejected 'externalPrometheus.address must include a hostn
 assert_prometheus_mode_rejected 'externalPrometheus.address must include a hostname' \
   --set 'externalPrometheus.enabled=true' \
   --set-string 'externalPrometheus.address=http://:9090'
+prometheus_userinfo_password='must-not-appear%zz'
+if prometheus_userinfo_output="$(helm template test "${work_dir}/hami-webui" \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address=https://metrics-user:${prometheus_userinfo_password}@prometheus.example.com" 2>&1)"; then
+  echo "Prometheus address user information was accepted" >&2
+  exit 1
+fi
+if ! grep -Fq 'externalPrometheus.address must not include user information' <<<"${prometheus_userinfo_output}" ||
+  grep -Fq "${prometheus_userinfo_password}" <<<"${prometheus_userinfo_output}"; then
+  echo "Prometheus user-information rejection was missing or exposed the password" >&2
+  echo "${prometheus_userinfo_output}" >&2
+  exit 1
+fi
+assert_prometheus_mode_rejected 'externalPrometheus.address must not contain leading or trailing whitespace' \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string "externalPrometheus.address= ${external_address} "
 assert_prometheus_mode_rejected 'kube-prometheus-stack.prometheus.enabled must remain true' \
   --set 'externalPrometheus.enabled=false' \
   --set 'kube-prometheus-stack.enabled=true' \
@@ -400,8 +416,100 @@ fi
 external_deployment_render="$(render_template templates/deployment.yaml \
   --set 'externalPrometheus.enabled=true' \
   --set-string "externalPrometheus.address=${external_address}")"
-if grep -Fq 'prometheus-tls' <<<"${external_deployment_render}"; then
-  echo "External Prometheus must not mount TLS material unless a Secret is configured" >&2
+if grep -Eq 'prometheus-(auth|tls)' <<<"${external_deployment_render}"; then
+  echo "External Prometheus must not mount auth or TLS material unless a Secret is configured" >&2
+  exit 1
+fi
+
+prometheus_authorization_config="$(render_template templates/configmap.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.authorization.existingSecret=prometheus-authorization' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=access-token')"
+prometheus_authorization_deployment="$(render_template templates/deployment.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.authorization.existingSecret=prometheus-authorization' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=access-token')"
+if ! grep -Fq 'type: "Bearer"' <<<"${prometheus_authorization_config}" ||
+  ! grep -Fq 'credentials_file: "/apps/prometheus-auth/credentials"' <<<"${prometheus_authorization_config}" ||
+  grep -Eq 'prometheus-authorization|access-token' <<<"${prometheus_authorization_config}" ||
+  ! grep -Fq 'secretName: "prometheus-authorization"' <<<"${prometheus_authorization_deployment}" ||
+  ! grep -A1 -F 'key: "access-token"' <<<"${prometheus_authorization_deployment}" | grep -Fq 'path: credentials' ||
+  [[ "$(grep -c 'name: prometheus-auth' <<<"${prometheus_authorization_deployment}")" -ne 2 ]] ||
+  ! grep -A2 -F 'mountPath: /apps/prometheus-auth/' <<<"${prometheus_authorization_deployment}" | grep -Fq 'readOnly: true' ||
+  grep -Fq 'subPath:' <<<"${prometheus_authorization_deployment}"; then
+  echo "Authorization Secret was not rendered as a file-backed, read-only mount" >&2
+  exit 1
+fi
+
+prometheus_basic_auth_config="$(render_template templates/configmap.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.basicAuth.existingSecret=prometheus-basic-auth' \
+  --set-string 'externalPrometheus.basicAuth.usernameKey=login-id' \
+  --set-string 'externalPrometheus.basicAuth.passwordKey=login-secret')"
+prometheus_basic_auth_deployment="$(render_template templates/deployment.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.basicAuth.existingSecret=prometheus-basic-auth' \
+  --set-string 'externalPrometheus.basicAuth.usernameKey=login-id' \
+  --set-string 'externalPrometheus.basicAuth.passwordKey=login-secret')"
+if ! grep -Fq 'username_file: "/apps/prometheus-auth/username"' <<<"${prometheus_basic_auth_config}" ||
+  ! grep -Fq 'password_file: "/apps/prometheus-auth/password"' <<<"${prometheus_basic_auth_config}" ||
+  grep -Eq 'prometheus-basic-auth|login-id|login-secret' <<<"${prometheus_basic_auth_config}" ||
+  ! grep -Fq 'secretName: "prometheus-basic-auth"' <<<"${prometheus_basic_auth_deployment}" ||
+  ! grep -A1 -F 'key: "login-id"' <<<"${prometheus_basic_auth_deployment}" | grep -Fq 'path: username' ||
+  ! grep -A1 -F 'key: "login-secret"' <<<"${prometheus_basic_auth_deployment}" | grep -Fq 'path: password' ||
+  [[ "$(grep -c 'name: prometheus-auth' <<<"${prometheus_basic_auth_deployment}")" -ne 2 ]] ||
+  ! grep -A2 -F 'mountPath: /apps/prometheus-auth/' <<<"${prometheus_basic_auth_deployment}" | grep -Fq 'readOnly: true' ||
+  grep -Fq 'subPath:' <<<"${prometheus_basic_auth_deployment}"; then
+  echo "Basic-auth Secret was not rendered as two file-backed credentials" >&2
+  exit 1
+fi
+
+prometheus_custom_authorization_config="$(render_template templates/configmap.yaml \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.authorization.type=Token' \
+  --set-string 'externalPrometheus.authorization.existingSecret=prometheus-authorization' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=access-token')"
+if ! grep -Fq 'type: "Token"' <<<"${prometheus_custom_authorization_config}"; then
+  echo "Custom HTTP Authorization scheme was not preserved" >&2
+  exit 1
+fi
+
+for invalid_prometheus_auth in \
+  '--set-string=externalPrometheus.authorization.existingSecret=auth-only' \
+  '--set-string=externalPrometheus.authorization.credentialsKey=token-only' \
+  '--set-string=externalPrometheus.authorization.existingSecret=auth --set-string=externalPrometheus.authorization.credentialsKey=token --set-string=externalPrometheus.authorization.type=Basic' \
+  '--set-string=externalPrometheus.basicAuth.existingSecret=basic --set-string=externalPrometheus.basicAuth.usernameKey=username' \
+  '--set-string=externalPrometheus.basicAuth.existingSecret=basic --set-string=externalPrometheus.basicAuth.passwordKey=password' \
+  '--set-string=externalPrometheus.authorization.existingSecret=auth --set-string=externalPrometheus.authorization.credentialsKey=token --set-string=externalPrometheus.basicAuth.existingSecret=basic --set-string=externalPrometheus.basicAuth.usernameKey=username --set-string=externalPrometheus.basicAuth.passwordKey=password' \
+  '--set-string=externalPrometheus.authorization.unknownField=value' \
+  '--set-string=externalPrometheus.basicAuth.unknownField=value' \
+  '--set-json=externalPrometheus.authorization=true' \
+  '--set-json=externalPrometheus.basicAuth=true'; do
+  read -r -a invalid_args <<<"${invalid_prometheus_auth}"
+  if helm template test "${work_dir}/hami-webui" "${invalid_args[@]}" >/dev/null 2>&1; then
+    echo "Invalid external Prometheus authentication values were accepted: ${invalid_prometheus_auth}" >&2
+    exit 1
+  fi
+done
+
+if helm template test "${work_dir}/hami-webui" \
+  --set-string 'externalPrometheus.authorization.existingSecret= auth-with-whitespace ' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=token' >/dev/null 2>&1; then
+  echo "External Prometheus authentication accepted surrounding whitespace" >&2
+  exit 1
+fi
+
+if helm template test "${work_dir}/hami-webui" \
+  --set 'externalPrometheus.enabled=false' \
+  --set 'kube-prometheus-stack.enabled=true' \
+  --set-string 'externalPrometheus.authorization.existingSecret=unused-auth' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=token' >/dev/null 2>&1; then
+  echo "Authentication configured for disabled external Prometheus was accepted" >&2
   exit 1
 fi
 
@@ -422,6 +530,31 @@ if ! grep -Fq 'ca_file: "/apps/prometheus-tls/ca.crt"' <<<"${prometheus_tls_ca_c
   [[ "$(grep -c 'name: prometheus-tls' <<<"${prometheus_tls_ca_deployment}")" -ne 2 ]] ||
   ! grep -A2 -F 'mountPath: /apps/prometheus-tls/' <<<"${prometheus_tls_ca_deployment}" | grep -Fq 'readOnly: true'; then
   echo "Private-CA Secret was not rendered as a single unified-container fixed-path mount" >&2
+  exit 1
+fi
+
+prometheus_auth_tls_render="$(helm template test "${work_dir}/hami-webui" \
+  --namespace hami-webui-test \
+  --set 'externalPrometheus.enabled=true' \
+  --set-string 'externalPrometheus.address=https://prometheus.example.com' \
+  --set-string 'externalPrometheus.authorization.existingSecret=prometheus-authorization' \
+  --set-string 'externalPrometheus.authorization.credentialsKey=access-token' \
+  --set-string 'externalPrometheus.tls.existingSecret=prometheus-ca' \
+  --set-string 'externalPrometheus.tls.caKey=company-ca.pem' \
+  --show-only templates/configmap.yaml \
+  --show-only templates/deployment.yaml)"
+for expected in \
+  'credentials_file: "/apps/prometheus-auth/credentials"' \
+  'ca_file: "/apps/prometheus-tls/ca.crt"' \
+  'secretName: "prometheus-authorization"' \
+  'secretName: "prometheus-ca"'; do
+  if ! grep -Fq "${expected}" <<<"${prometheus_auth_tls_render}"; then
+    echo "Combined Prometheus authentication and TLS rendering is missing ${expected}" >&2
+    exit 1
+  fi
+done
+if grep -Fq 'subPath:' <<<"${prometheus_auth_tls_render}"; then
+  echo "Combined Prometheus authentication and TLS rendering used subPath" >&2
   exit 1
 fi
 
@@ -483,7 +616,7 @@ for invalid_prometheus_tls in \
   fi
 done
 
-if grep -Fq 'kind: Secret' <<<"${prometheus_mtls_render}"; then
+if grep -Fq 'kind: Secret' <<<"${prometheus_mtls_render}${prometheus_authorization_deployment}${prometheus_basic_auth_deployment}"; then
   echo "The Chart must reference, not create, Prometheus credential Secrets" >&2
   exit 1
 fi

--- a/server/internal/app.go
+++ b/server/internal/app.go
@@ -45,9 +45,11 @@ func NewPromClient(c *conf.Bootstrap, logger log.Logger) *prom.Client {
 	if err != nil {
 		panic(err)
 	}
-	tlsConfig := prom.TLSConfig{}
+	httpConfig := prom.HTTPConfig{
+		LegacyAuthorization: c.Prometheus.Auth,
+	}
 	if c.Prometheus.Tls != nil {
-		tlsConfig = prom.TLSConfig{
+		httpConfig.TLS = prom.TLSConfig{
 			CAFile:             c.Prometheus.Tls.CaFile,
 			CertFile:           c.Prometheus.Tls.CertFile,
 			KeyFile:            c.Prometheus.Tls.KeyFile,
@@ -55,7 +57,19 @@ func NewPromClient(c *conf.Bootstrap, logger log.Logger) *prom.Client {
 			InsecureSkipVerify: c.Prometheus.Tls.InsecureSkipVerify,
 		}
 	}
-	client, err := prom.NewClient(c.Prometheus.Address, timeout, c.Prometheus.Auth, tlsConfig, logger)
+	if c.Prometheus.Authorization != nil {
+		httpConfig.Authorization = &prom.AuthorizationConfig{
+			Type:            c.Prometheus.Authorization.Type,
+			CredentialsFile: c.Prometheus.Authorization.CredentialsFile,
+		}
+	}
+	if c.Prometheus.BasicAuth != nil {
+		httpConfig.BasicAuth = &prom.BasicAuthConfig{
+			UsernameFile: c.Prometheus.BasicAuth.UsernameFile,
+			PasswordFile: c.Prometheus.BasicAuth.PasswordFile,
+		}
+	}
+	client, err := prom.NewClient(c.Prometheus.Address, timeout, httpConfig, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/server/internal/app_test.go
+++ b/server/internal/app_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+func TestPrometheusBasicAuthConfigurationIsWiredEndToEnd(t *testing.T) {
+	directory := t.TempDir()
+	usernameFile := filepath.Join(directory, "username")
+	passwordFile := filepath.Join(directory, "password")
+	if err := os.WriteFile(usernameFile, []byte("metrics-user\n"), 0o600); err != nil {
+		t.Fatalf("write username: %v", err)
+	}
+	if err := os.WriteFile(passwordFile, []byte("metrics-password\n"), 0o600); err != nil {
+		t.Fatalf("write password: %v", err)
+	}
+
+	type credentials struct {
+		username string
+		password string
+	}
+	received := make(chan credentials, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		username, password, _ := req.BasicAuth()
+		received <- credentials{username: username, password: password}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	configPath := filepath.Join(directory, "config.yaml")
+	config := fmt.Sprintf(`prometheus:
+  address: %q
+  timeout: 1s
+  basic_auth:
+    username_file: %q
+    password_file: %q
+`, server.URL, usernameFile, passwordFile)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write configuration: %v", err)
+	}
+	bootstrap, err := NewConfig(configPath)
+	if err != nil {
+		t.Fatalf("load configuration: %v", err)
+	}
+	client := NewPromClient(bootstrap, log.NewStdLogger(io.Discard))
+	if _, err := client.Query(context.Background(), "up"); err != nil {
+		t.Fatalf("query Prometheus: %v", err)
+	}
+	if got := <-received; got.username != "metrics-user" || got.password != "metrics-password" {
+		t.Fatalf("basic auth credentials = %#v, want metrics-user/metrics-password", got)
+	}
+}

--- a/server/internal/conf/conf.proto
+++ b/server/internal/conf/conf.proto
@@ -30,8 +30,21 @@ message Server {
 message Prometheus {
   string address = 1;
   string timeout = 2;
-  string auth = 3;
+  // Deprecated: use authorization or basic_auth with credentials mounted from files.
+  string auth = 3 [deprecated = true];
   PrometheusTLS tls = 4;
+  PrometheusAuthorization authorization = 5;
+  PrometheusBasicAuth basic_auth = 6;
+}
+
+message PrometheusAuthorization {
+  string type = 1;
+  string credentials_file = 2;
+}
+
+message PrometheusBasicAuth {
+  string username_file = 1;
+  string password_file = 2;
 }
 
 message PrometheusTLS {

--- a/server/internal/data/prom/client.go
+++ b/server/internal/data/prom/client.go
@@ -2,8 +2,11 @@ package prom
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -27,9 +30,70 @@ type TLSConfig struct {
 	InsecureSkipVerify bool
 }
 
+type AuthorizationConfig struct {
+	Type            string
+	CredentialsFile string
+}
+
+type BasicAuthConfig struct {
+	UsernameFile string
+	PasswordFile string
+}
+
+type HTTPConfig struct {
+	TLS                 TLSConfig
+	Authorization       *AuthorizationConfig
+	BasicAuth           *BasicAuthConfig
+	LegacyAuthorization string
+}
+
+// authorizationRoundTripper preserves the pre-2.0 raw auth setting for direct
+// configuration users. New configurations should use the file-backed standard
+// authorization or basic_auth transport instead.
 type authorizationRoundTripper struct {
 	auth string
 	next http.RoundTripper
+}
+
+// credentialOriginRoundTripper prevents inner authentication transports from
+// attaching credentials to a redirect or request outside the configured
+// Prometheus origin.
+type credentialOriginRoundTripper struct {
+	origin *url.URL
+	next   http.RoundTripper
+}
+
+func (t *credentialOriginRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !sameOrigin(t.origin, req.URL) {
+		return nil, errors.New("refusing to send Prometheus credentials to a different origin")
+	}
+	return t.next.RoundTrip(req)
+}
+
+func (t *credentialOriginRoundTripper) CloseIdleConnections() {
+	if closeIdler, ok := t.next.(interface{ CloseIdleConnections() }); ok {
+		closeIdler.CloseIdleConnections()
+	}
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectivePort(left) == effectivePort(right)
+}
+
+func effectivePort(address *url.URL) string {
+	if port := address.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(address.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }
 
 func (t *authorizationRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -39,21 +103,59 @@ func (t *authorizationRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	return t.next.RoundTrip(clone)
 }
 
-func NewClient(address string, timeout time.Duration, auth string, tlsConfig TLSConfig, logger log.Logger) (*Client, error) {
+func NewClient(address string, timeout time.Duration, config HTTPConfig, logger log.Logger) (*Client, error) {
+	parsedAddress, err := url.Parse(address)
+	if err != nil {
+		return nil, errors.New("invalid Prometheus address")
+	}
+	if parsedAddress.User != nil {
+		return nil, errors.New("prometheus address must not include user information; configure authentication separately")
+	}
+	if config.LegacyAuthorization != "" && (config.Authorization != nil || config.BasicAuth != nil) {
+		return nil, errors.New("legacy Prometheus auth cannot be combined with authorization or basic_auth")
+	}
+	if config.Authorization != nil && config.BasicAuth != nil {
+		return nil, errors.New("prometheus authorization and basic_auth are mutually exclusive")
+	}
+	if config.Authorization != nil && config.Authorization.CredentialsFile == "" {
+		return nil, errors.New("prometheus authorization credentials file is required")
+	}
+	if config.BasicAuth != nil && (config.BasicAuth.UsernameFile == "" || config.BasicAuth.PasswordFile == "") {
+		return nil, errors.New("prometheus basic_auth username and password files are required")
+	}
+
 	httpConfig := promconfig.DefaultHTTPClientConfig
 	httpConfig.TLSConfig = promconfig.TLSConfig{
-		CAFile:             tlsConfig.CAFile,
-		CertFile:           tlsConfig.CertFile,
-		KeyFile:            tlsConfig.KeyFile,
-		ServerName:         tlsConfig.ServerName,
-		InsecureSkipVerify: tlsConfig.InsecureSkipVerify,
+		CAFile:             config.TLS.CAFile,
+		CertFile:           config.TLS.CertFile,
+		KeyFile:            config.TLS.KeyFile,
+		ServerName:         config.TLS.ServerName,
+		InsecureSkipVerify: config.TLS.InsecureSkipVerify,
+	}
+	if config.Authorization != nil {
+		httpConfig.Authorization = &promconfig.Authorization{
+			Type:            config.Authorization.Type,
+			CredentialsFile: config.Authorization.CredentialsFile,
+		}
+	}
+	if config.BasicAuth != nil {
+		httpConfig.BasicAuth = &promconfig.BasicAuth{
+			UsernameFile: config.BasicAuth.UsernameFile,
+			PasswordFile: config.BasicAuth.PasswordFile,
+		}
+	}
+	if err := httpConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("validate Prometheus HTTP transport: %w", err)
 	}
 	roundTripper, err := promconfig.NewRoundTripperFromConfig(httpConfig, "hami-webui-prometheus")
 	if err != nil {
 		return nil, fmt.Errorf("create Prometheus HTTP transport: %w", err)
 	}
-	if auth != "" {
-		roundTripper = &authorizationRoundTripper{auth: auth, next: roundTripper}
+	if config.LegacyAuthorization != "" {
+		roundTripper = &authorizationRoundTripper{auth: config.LegacyAuthorization, next: roundTripper}
+	}
+	if config.LegacyAuthorization != "" || config.Authorization != nil || config.BasicAuth != nil {
+		roundTripper = &credentialOriginRoundTripper{origin: parsedAddress, next: roundTripper}
 	}
 
 	client, err := api.NewClient(api.Config{

--- a/server/internal/data/prom/client_test.go
+++ b/server/internal/data/prom/client_test.go
@@ -8,6 +8,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -64,7 +65,7 @@ func TestLegacyAuthorizationHeaderIsPreserved(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
-	client, err := NewClient(server.URL, time.Second, authorization, TLSConfig{}, log.DefaultLogger)
+	client, err := NewClient(server.URL, time.Second, HTTPConfig{LegacyAuthorization: authorization}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}
@@ -74,6 +75,318 @@ func TestLegacyAuthorizationHeaderIsPreserved(t *testing.T) {
 	}
 	if got := <-received; got != authorization {
 		t.Fatalf("Authorization header = %q, want %q", got, authorization)
+	}
+}
+
+func TestAuthorizationUsesCredentialsFileAndReloadsIt(t *testing.T) {
+	credentialsFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(credentialsFile, []byte("token-one\n"), 0o600); err != nil {
+		t.Fatalf("write credentials file: %v", err)
+	}
+	received := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		received <- req.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.URL, time.Second, HTTPConfig{
+		Authorization: &AuthorizationConfig{CredentialsFile: credentialsFile},
+	}, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request with authorization failed: %v", err)
+	}
+	if got := <-received; got != "Bearer token-one" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer token-one")
+	}
+
+	if err := os.WriteFile(credentialsFile, []byte("token-two\n"), 0o600); err != nil {
+		t.Fatalf("rotate credentials file: %v", err)
+	}
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request after credential rotation failed: %v", err)
+	}
+	if got := <-received; got != "Bearer token-two" {
+		t.Fatalf("Authorization header after rotation = %q, want %q", got, "Bearer token-two")
+	}
+}
+
+func TestAuthenticationIsNotForwardedAcrossRedirectOrigins(t *testing.T) {
+	directory := t.TempDir()
+	credentialsFile := filepath.Join(directory, "token")
+	usernameFile := filepath.Join(directory, "username")
+	passwordFile := filepath.Join(directory, "password")
+	if err := os.WriteFile(credentialsFile, []byte("redirect-secret"), 0o600); err != nil {
+		t.Fatalf("write credentials file: %v", err)
+	}
+	if err := os.WriteFile(usernameFile, []byte("metrics-user"), 0o600); err != nil {
+		t.Fatalf("write username file: %v", err)
+	}
+	if err := os.WriteFile(passwordFile, []byte("redirect-password"), 0o600); err != nil {
+		t.Fatalf("write password file: %v", err)
+	}
+	destinationRequests := make(chan string, 1)
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		destinationRequests <- req.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(destination.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, destination.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+	tests := []struct {
+		name   string
+		config HTTPConfig
+	}{
+		{
+			name: "authorization",
+			config: HTTPConfig{
+				Authorization: &AuthorizationConfig{CredentialsFile: credentialsFile},
+			},
+		},
+		{
+			name: "basic auth",
+			config: HTTPConfig{
+				BasicAuth: &BasicAuthConfig{UsernameFile: usernameFile, PasswordFile: passwordFile},
+			},
+		},
+		{name: "legacy authorization", config: HTTPConfig{LegacyAuthorization: "Bearer legacy-secret"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(redirector.URL, time.Second, tt.config, log.DefaultLogger)
+			if err != nil {
+				t.Fatalf("create client: %v", err)
+			}
+			err = request(t, client, redirector.URL)
+			select {
+			case authorization := <-destinationRequests:
+				t.Errorf("cross-origin redirect reached the destination with Authorization %q", authorization)
+			default:
+			}
+			if err == nil || !strings.Contains(err.Error(), "refusing to send Prometheus credentials to a different origin") {
+				t.Fatalf("cross-origin redirect error = %v, want credential boundary rejection", err)
+			}
+		})
+	}
+}
+
+func TestAuthenticationAllowsRedirectsWithinConfiguredOrigin(t *testing.T) {
+	credentialsFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(credentialsFile, []byte("same-origin-secret"), 0o600); err != nil {
+		t.Fatalf("write credentials file: %v", err)
+	}
+	received := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/redirect" {
+			http.Redirect(w, req, "/final", http.StatusFound)
+			return
+		}
+		received <- req.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.URL, time.Second, HTTPConfig{
+		Authorization: &AuthorizationConfig{CredentialsFile: credentialsFile},
+	}, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := request(t, client, server.URL+"/redirect"); err != nil {
+		t.Fatalf("same-origin redirect failed: %v", err)
+	}
+	if got := <-received; got != "Bearer same-origin-secret" {
+		t.Fatalf("Authorization header after same-origin redirect = %q", got)
+	}
+}
+
+func TestSameOriginUsesSchemeHostAndEffectivePort(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "same HTTPS origin", left: "https://prometheus.example", right: "https://PROMETHEUS.example:443/path", want: true},
+		{name: "same HTTP origin", left: "http://prometheus.example", right: "http://prometheus.example:80/path", want: true},
+		{name: "scheme downgrade", left: "https://prometheus.example", right: "http://prometheus.example", want: false},
+		{name: "different port", left: "https://prometheus.example", right: "https://prometheus.example:9090", want: false},
+		{name: "subdomain", left: "https://prometheus.example", right: "https://redirect.prometheus.example", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left, err := url.Parse(tt.left)
+			if err != nil {
+				t.Fatalf("parse left URL: %v", err)
+			}
+			right, err := url.Parse(tt.right)
+			if err != nil {
+				t.Fatalf("parse right URL: %v", err)
+			}
+			if got := sameOrigin(left, right); got != tt.want {
+				t.Fatalf("sameOrigin(%q, %q) = %t, want %t", tt.left, tt.right, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBasicAuthUsesCredentialFilesAndReloadsThem(t *testing.T) {
+	directory := t.TempDir()
+	usernameFile := filepath.Join(directory, "username")
+	passwordFile := filepath.Join(directory, "password")
+	if err := os.WriteFile(usernameFile, []byte("metrics-user\n"), 0o600); err != nil {
+		t.Fatalf("write username file: %v", err)
+	}
+	if err := os.WriteFile(passwordFile, []byte("p@ss:word\n"), 0o600); err != nil {
+		t.Fatalf("write password file: %v", err)
+	}
+	type credentials struct {
+		username string
+		password string
+		ok       bool
+	}
+	received := make(chan credentials, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		username, password, ok := req.BasicAuth()
+		received <- credentials{username: username, password: password, ok: ok}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.URL, time.Second, HTTPConfig{
+		BasicAuth: &BasicAuthConfig{
+			UsernameFile: usernameFile,
+			PasswordFile: passwordFile,
+		},
+	}, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request with basic auth failed: %v", err)
+	}
+	if got := <-received; !got.ok || got.username != "metrics-user" || got.password != "p@ss:word" {
+		t.Fatalf("basic auth credentials = %#v, want metrics-user/p@ss:word", got)
+	}
+
+	if err := os.WriteFile(usernameFile, []byte("rotated-user\n"), 0o600); err != nil {
+		t.Fatalf("rotate username file: %v", err)
+	}
+	if err := os.WriteFile(passwordFile, []byte("rotated-password\n"), 0o600); err != nil {
+		t.Fatalf("rotate password file: %v", err)
+	}
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("request after basic auth rotation failed: %v", err)
+	}
+	if got := <-received; !got.ok || got.username != "rotated-user" || got.password != "rotated-password" {
+		t.Fatalf("basic auth credentials after rotation = %#v, want rotated-user/rotated-password", got)
+	}
+}
+
+func TestAuthenticationComposesWithTLS(t *testing.T) {
+	credentialsFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(credentialsFile, []byte("secure-token"), 0o600); err != nil {
+		t.Fatalf("write credentials file: %v", err)
+	}
+	received := make(chan string, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		received <- req.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.Config.ErrorLog = stdlog.New(io.Discard, "", 0)
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(caFile, certificate, 0o600); err != nil {
+		t.Fatalf("write CA file: %v", err)
+	}
+	client, err := NewClient(server.URL, time.Second, HTTPConfig{
+		TLS:           TLSConfig{CAFile: caFile},
+		Authorization: &AuthorizationConfig{CredentialsFile: credentialsFile},
+	}, log.DefaultLogger)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if err := request(t, client, server.URL); err != nil {
+		t.Fatalf("authenticated TLS request failed: %v", err)
+	}
+	if got := <-received; got != "Bearer secure-token" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer secure-token")
+	}
+}
+
+func TestAuthenticationConfigurationIsValidated(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    HTTPConfig
+		wantError string
+	}{
+		{
+			name: "legacy and authorization",
+			config: HTTPConfig{
+				LegacyAuthorization: "Bearer legacy",
+				Authorization:       &AuthorizationConfig{CredentialsFile: "/credentials"},
+			},
+			wantError: "legacy Prometheus auth cannot be combined",
+		},
+		{
+			name: "authorization and basic auth",
+			config: HTTPConfig{
+				Authorization: &AuthorizationConfig{CredentialsFile: "/credentials"},
+				BasicAuth: &BasicAuthConfig{
+					UsernameFile: "/username",
+					PasswordFile: "/password",
+				},
+			},
+			wantError: "mutually exclusive",
+		},
+		{
+			name:      "authorization without credentials file",
+			config:    HTTPConfig{Authorization: &AuthorizationConfig{}},
+			wantError: "authorization credentials file is required",
+		},
+		{
+			name:      "basic auth without both files",
+			config:    HTTPConfig{BasicAuth: &BasicAuthConfig{UsernameFile: "/username"}},
+			wantError: "username and password files are required",
+		},
+		{
+			name: "basic authorization scheme",
+			config: HTTPConfig{Authorization: &AuthorizationConfig{
+				Type:            "Basic",
+				CredentialsFile: "/credentials",
+			}},
+			wantError: `authorization type cannot be set to "basic"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewClient("http://prometheus.example", time.Second, tt.config, log.DefaultLogger)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("NewClient error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestPrometheusAddressRejectsUserInformationWithoutExposingIt(t *testing.T) {
+	const password = "super-secret"
+	_, err := NewClient("https://metrics-user:"+password+"@prometheus.example", time.Second, HTTPConfig{}, log.DefaultLogger)
+	if err == nil {
+		t.Fatal("NewClient accepted an address with user information")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("NewClient error exposed the password: %v", err)
+	}
+	if !strings.Contains(err.Error(), "must not include user information") {
+		t.Fatalf("NewClient error = %v, want user-information guidance", err)
 	}
 }
 
@@ -90,7 +403,7 @@ func newTLSTestServer(t *testing.T) *httptest.Server {
 
 func newTestClient(t *testing.T, address string, tlsConfig TLSConfig) *Client {
 	t.Helper()
-	client, err := NewClient(address, time.Second, "", tlsConfig, log.NewStdLogger(io.Discard))
+	client, err := NewClient(address, time.Second, HTTPConfig{TLS: tlsConfig}, log.NewStdLogger(io.Discard))
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}
@@ -209,7 +522,7 @@ func newPrometheusAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Se
 
 func newTestClientWithLogger(t *testing.T, address string, tlsConfig TLSConfig, logger log.Logger) *Client {
 	t.Helper()
-	client, err := NewClient(address, time.Second, "", tlsConfig, logger)
+	client, err := NewClient(address, time.Second, HTTPConfig{TLS: tlsConfig}, logger)
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}

--- a/server/internal/service/allocation_capacity_test.go
+++ b/server/internal/service/allocation_capacity_test.go
@@ -60,7 +60,7 @@ func TestAllocationListsKeepRegisteredMemoryCapacity(t *testing.T) {
 	podRepo := &capacityTestPodRepo{}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{}, log.DefaultLogger)
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, prom.HTTPConfig{}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/server/internal/service/empty_filters_test.go
+++ b/server/internal/service/empty_filters_test.go
@@ -44,7 +44,7 @@ func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
 	}}}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, "", prom.TLSConfig{}, log.DefaultLogger)
+	promClient, err := prom.NewClient(prometheus.URL, time.Second, prom.HTTPConfig{}, log.DefaultLogger)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

Authenticated external Prometheus endpoints previously had no safe Helm configuration path. URL user information or the legacy raw `prometheus.auth` value could place credentials in rendered configuration.

This change:

- reads HTTP Authorization or Basic Authentication from selected keys in an existing same-namespace Secret;
- mounts credentials as files so Secret rotation is picked up without a Pod restart;
- composes authentication with the existing TLS, private CA, SNI and mTLS settings;
- rejects URL user information before parsing it, without echoing credentials;
- retains direct-server `prometheus.auth` as a deprecated compatibility field.

The implementation uses the file-backed transport from `prometheus/common`. The Chart never copies credential values into a ConfigMap or environment variable.

**Verification**

- Node 24 `make verify`
- `make -C server verify`
- `go test -race ./internal ./internal/data/prom`
- `bash scripts/verify-chart.sh`

The Chart tests cover Bearer, custom Authorization schemes, Basic Authentication, Secret rotation contract, TLS composition, invalid combinations, whitespace and malformed URL user information.

Fixes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bearer-token and HTTP Basic authentication for external Prometheus connections.
  - Credentials are securely loaded from Kubernetes Secrets and mounted as read-only files.
  - Authentication can be combined with existing TLS configuration.
  - Added validation for supported authentication settings and secure URL formats.

- **Documentation**
  - Updated Helm values, schema, README, and installation guidance with authentication configuration details.
  - Documented Secret rotation, mutually exclusive authentication modes, and deprecated settings.

- **Bug Fixes**
  - Prevented embedded URL credentials and invalid authentication configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->