### PR TITLE
fix(ascend): decode variant allocation contracts

### DIFF
--- a/packages/web/projects/vgpu/views/card/admin/index.vue
+++ b/packages/web/projects/vgpu/views/card/admin/index.vue
@@ -243,8 +243,8 @@ const baseColumns = computed(() => [
     key: 'card-compute-remaining-total',
     dataIndex: 'used',
     width: 220,
-    render: ({ coreTotal, coreUsed, isExternal }) => {
-      if (isExternal || !coreTotal) return <span>--</span>;
+    render: ({ coreTotal, coreUsed, coreUsedKnown, isExternal }) => {
+      if (isExternal || coreUsedKnown === false || !coreTotal) return <span>--</span>;
       const stats = getRemainingTotalText({ total: coreTotal, used: coreUsed, divisor: 100 });
       if (!stats) return <span>--</span>;
       return (
@@ -262,8 +262,8 @@ const baseColumns = computed(() => [
     key: 'card-compute-allocation',
     dataIndex: 'used',
     width: 180,
-    render: ({ coreTotal, coreUsed, isExternal }) => {
-      if (isExternal || !coreTotal) return <span>--</span>;
+    render: ({ coreTotal, coreUsed, coreUsedKnown, isExternal }) => {
+      if (isExternal || coreUsedKnown === false || !coreTotal) return <span>--</span>;
       const percent = getAllocationPercent(coreUsed, coreTotal);
       if (!percent) return <span>--</span>;
       const color = getResourceColor(percent.progress);

--- a/packages/web/projects/vgpu/views/node/admin/index.vue
+++ b/packages/web/projects/vgpu/views/node/admin/index.vue
@@ -181,8 +181,8 @@ const baseColumns = computed(() => [
     key: 'node-compute-allocation',
     minWidth: 280,
     dataIndex: 'used',
-    render: ({ coreTotal, coreUsed, isExternal }) => {
-      if (isExternal || !coreTotal) return <span>--</span>;
+    render: ({ coreTotal, coreUsed, coreUsedKnown, isExternal }) => {
+      if (isExternal || coreUsedKnown === false || !coreTotal) return <span>--</span>;
       const rawPercent = (Number(coreUsed || 0) / Number(coreTotal)) * 100;
       const percentForProgress = Math.max(0, Math.min(100, rawPercent));
       const color = getResourceColor(percentForProgress);

--- a/packages/web/projects/vgpu/views/task/admin/index.vue
+++ b/packages/web/projects/vgpu/views/task/admin/index.vue
@@ -220,10 +220,10 @@ const baseColumns = computed(() => [
   {
     title: 'GPUs',
     dataIndex: 'deviceIds',
-    render: ({ deviceIds, allocatedCores, allocatedMem }) => {
+    render: ({ deviceIds, allocatedCores, allocatedCoresKnown, allocatedMem }) => {
       const ids = Array.isArray(deviceIds) ? deviceIds : [];
       const gpuCount = ids.length || '--';
-      const cores = allocatedCores === 0 || allocatedCores
+      const cores = allocatedCoresKnown !== false && (allocatedCores === 0 || allocatedCores)
         ? roundToDecimal(allocatedCores / 100, 1)
         : '--';
       const memoryGiB = allocatedMem === 0 || allocatedMem

--- a/server/api/v1/card.proto
+++ b/server/api/v1/card.proto
@@ -65,6 +65,7 @@ message GPUReply {
   string node_uid = 10;
   bool health = 11;
   string mode = 12;
+  optional bool core_used_known = 13;
 }
 
 message GPUsReply {

--- a/server/api/v1/container.proto
+++ b/server/api/v1/container.proto
@@ -67,6 +67,7 @@ message ContainerReply {
   string namespace = 17;
   repeated string device_ids = 18;
   repeated string images = 19;
+  optional bool allocated_cores_known = 20;
 }
 
 message ContainersReply {

--- a/server/api/v1/node.proto
+++ b/server/api/v1/node.proto
@@ -56,6 +56,7 @@ message DeviceSummaryReply {
   int32 memory_total = 6;
   int32 gpu_count = 7;
   int32 node_count = 8;
+  optional bool core_used_known = 9;
 }
 
 message GetAllNodesReq {
@@ -93,6 +94,7 @@ message NodeReply {
   string kube_proxy_version = 19;
   string architecture = 20;
   string creation_timestamp = 21;
+  optional bool core_used_known = 22;
 }
 
 message NodesReply {

--- a/server/internal/biz/biz.go
+++ b/server/internal/biz/biz.go
@@ -30,12 +30,13 @@ const (
 )
 
 type ContainerDevice struct {
-	Idx       int
-	UUID      string
-	Type      string
-	Usedmem   int32
-	Usedcores int32
-	Priority  string
+	Idx                 int
+	UUID                string
+	Type                string
+	Usedmem             int32
+	Usedcores           int32
+	CoreAllocationKnown bool
+	Priority            string
 }
 
 type ContainerDeviceRequest struct {

--- a/server/internal/biz/pod.go
+++ b/server/internal/biz/pod.go
@@ -56,26 +56,27 @@ func (uc *PodUseCase) FindOneContainer(ctx context.Context, podUID string, name 
 	return uc.repo.FindOne(ctx, podUID, name)
 }
 
-func (uc *PodUseCase) StatisticsByDeviceId(ctx context.Context, deviceId string) (int32, int32, int32, error) {
+func (uc *PodUseCase) StatisticsByDeviceId(ctx context.Context, deviceId string) (int32, int32, int32, bool, error) {
 	containers, err := uc.repo.ListAll(ctx)
 	var vGPU int32 = 0
 	var core int32 = 0
 	var memory int32 = 0
 	if err != nil {
-		return vGPU, core, memory, err
+		return vGPU, core, memory, false, err
 	}
-	vGPU, core, memory = ContainersStatisticsInfo(containers, deviceId)
-	return vGPU, core, memory, nil
+	vGPU, core, memory, coreKnown := ContainersStatisticsInfo(containers, deviceId)
+	return vGPU, core, memory, coreKnown, nil
 }
 
 func (uc *PodUseCase) ListAll(ctx context.Context) ([]*Container, error) {
 	return uc.repo.ListAll(ctx)
 }
 
-func ContainersStatisticsInfo(containers []*Container, deviceId string) (int32, int32, int32) {
+func ContainersStatisticsInfo(containers []*Container, deviceId string) (int32, int32, int32, bool) {
 	var vGPU int32 = 0
 	var core int32 = 0
 	var memory int32 = 0
+	coreKnown := true
 	for _, t := range containers {
 		for _, cd := range t.ContainerDevices {
 			if deviceId != "" && !strings.HasPrefix(cd.UUID, deviceId) {
@@ -84,7 +85,10 @@ func ContainersStatisticsInfo(containers []*Container, deviceId string) (int32, 
 			vGPU = vGPU + 1
 			core = core + cd.Usedcores
 			memory = memory + cd.Usedmem
+			if strings.HasPrefix(cd.Type, AscendGPUDevice) && !cd.CoreAllocationKnown {
+				coreKnown = false
+			}
 		}
 	}
-	return vGPU, core, memory
+	return vGPU, core, memory, coreKnown
 }

--- a/server/internal/biz/summary.go
+++ b/server/internal/biz/summary.go
@@ -16,14 +16,15 @@ type SummaryUseCase struct {
 }
 
 type SummaryInfo struct {
-	VgpuUsed    int32
-	VgpuTotal   int32
-	CoreUsed    int32
-	CoreTotal   int32
-	MemoryUsed  int32
-	MemoryTotal int32
-	GpuCount    int32
-	NodeCount   int32
+	VgpuUsed      int32
+	VgpuTotal     int32
+	CoreUsed      int32
+	CoreUsedKnown bool
+	CoreTotal     int32
+	MemoryUsed    int32
+	MemoryTotal   int32
+	GpuCount      int32
+	NodeCount     int32
 }
 
 func NewSummaryUseCase(node NodeRepo, pod PodRepo, logger log.Logger) *SummaryUseCase {
@@ -31,7 +32,7 @@ func NewSummaryUseCase(node NodeRepo, pod PodRepo, logger log.Logger) *SummaryUs
 }
 
 func (t *SummaryUseCase) GetGPUSummary(ctx context.Context, deviceId string, nodeUID string, deviceType string) (SummaryInfo, error) {
-	var res SummaryInfo
+	res := SummaryInfo{CoreUsedKnown: true}
 	deviceInfos, err := t.node.ListAllDevices(ctx)
 	if err != nil {
 		return res, err
@@ -55,8 +56,11 @@ func (t *SummaryUseCase) GetGPUSummary(ctx context.Context, deviceId string, nod
 		res.MemoryTotal = res.MemoryTotal + device.Devmem
 		res.VgpuTotal = res.VgpuTotal + device.Count
 
-		vGPU, core, memory := ContainersStatisticsInfo(containers, device.AliasId)
+		vGPU, core, memory, coreKnown := ContainersStatisticsInfo(containers, device.AliasId)
 		res.CoreUsed = res.CoreUsed + core
+		if !coreKnown {
+			res.CoreUsedKnown = false
+		}
 		res.MemoryUsed = res.MemoryUsed + memory
 		res.VgpuUsed = res.VgpuUsed + vGPU
 		res.GpuCount++

--- a/server/internal/data/pod.go
+++ b/server/internal/data/pod.go
@@ -64,10 +64,15 @@ func (r *podRepo) onAddPod(obj interface{}) {
 		r.delPod(pod)
 		return
 	}
+	nodeUID, ascendMode := r.nodeAllocationContext(pod)
 	bizPodDev := biz.PodDevices{}
-	podDev, _ := util.DecodePodDevices(pod, r.log)
+	podDev, err := util.DecodePodDevices(pod, r.log, ascendMode)
+	if err != nil {
+		r.log.Errorf("cannot decode device allocations for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		return
+	}
 	copier.Copy(&bizPodDev, podDev)
-	r.addPod(pod, nodeID, bizPodDev)
+	r.addPod(pod, nodeID, nodeUID, bizPodDev)
 }
 
 func (r *podRepo) onUpdatePod(_ interface{}, new interface{}) {
@@ -87,10 +92,10 @@ func (r *podRepo) onDeletedPod(obj interface{}) {
 	r.delPod(pod)
 }
 
-func (r *podRepo) addPod(pod *corev1.Pod, nodeID string, devices biz.PodDevices) {
+func (r *podRepo) addPod(pod *corev1.Pod, nodeID, nodeUID string, devices biz.PodDevices) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	ctrs := r.fetchContainerInfo(pod)
+	ctrs := r.fetchContainerInfo(pod, devices, nodeUID)
 	pi := &biz.PodInfo{Name: pod.Name, UID: pod.UID, Namespace: pod.Namespace, NodeID: nodeID, Devices: devices, Ctrs: ctrs}
 	r.pods[pod.UID] = pi
 	r.log.Infof("Pod added: Name: %s, UID: %s, Namespace: %s, NodeID: %s", pod.Name, pod.UID, pod.Namespace, nodeID)
@@ -106,28 +111,10 @@ func (r *podRepo) delPod(pod *corev1.Pod) {
 	}
 }
 
-func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
+func (r *podRepo) fetchContainerInfo(pod *corev1.Pod, pdevices biz.PodDevices, nodeUID string) []*biz.Container {
 	containers := []*biz.Container{}
-	pdevices, err := util.DecodePodDevices(pod, r.log)
-	if err != nil {
-		return containers
-	}
-	// Merge devices from all device types per container index.
-	// pdevices: map[deviceType]PodSingleDevice([]ContainerDevices)
 	totalContainers := len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
-	bizContainerDevices := make([]biz.ContainerDevices, totalContainers)
-	for devType, pds := range pdevices {
-		var bizPds biz.PodSingleDevice
-		if err := copier.Copy(&bizPds, pds); err != nil {
-			r.log.Warnf("failed to copy %s device info for pod %s/%s: %v", devType, pod.Namespace, pod.Name, err)
-			continue
-		}
-		for i, cd := range bizPds {
-			if i < totalContainers {
-				bizContainerDevices[i] = append(bizContainerDevices[i], cd...)
-			}
-		}
-	}
+	bizContainerDevices := mergeContainerDevicesBySlot(totalContainers, pdevices)
 	if len(pdevices) == 0 {
 		return containers
 	}
@@ -160,7 +147,7 @@ func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
 			PodUID:           string(pod.UID),
 			Image:            ctr.Image,
 			Status:           containerStat[ctr.Name],
-			NodeUID:          r.GetNodeUUID(pod),
+			NodeUID:          nodeUID,
 			Namespace:        pod.Namespace,
 			CreateTime:       r.GetCreateTime(pod),
 			ContainerDevices: containerDevices,
@@ -173,13 +160,49 @@ func (r *podRepo) fetchContainerInfo(pod *corev1.Pod) []*biz.Container {
 	return containers
 }
 
-func (r *podRepo) GetNodeUUID(pod *corev1.Pod) string {
+func mergeContainerDevicesBySlot(totalContainers int, podDevices biz.PodDevices) []biz.ContainerDevices {
+	containerDevices := make([]biz.ContainerDevices, totalContainers)
+	for _, devicesByContainer := range podDevices {
+		for i, devices := range devicesByContainer {
+			if i >= totalContainers {
+				break
+			}
+			containerDevices[i] = append(containerDevices[i], devices...)
+		}
+	}
+	return containerDevices
+}
+
+func (r *podRepo) nodeAllocationContext(pod *corev1.Pod) (string, util.AscendAllocationMode) {
+	podMode := pod.Annotations[util.AscendVNPUModeAnnotation]
+	if pod.Spec.NodeName == "" {
+		return "", resolveAscendAllocationMode(podMode, "")
+	}
 	node, err := r.data.k8sCl.CoreV1().Nodes().Get(context.Background(), pod.Spec.NodeName, metav1.GetOptions{})
 	if err != nil {
-		//p.log.Warnf("Error getting node: %s", err)
-		return ""
-	} else {
-		return string(node.UID)
+		r.log.Warnf("cannot resolve Ascend allocation mode for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		return "", resolveAscendAllocationMode(podMode, "")
+	}
+	return string(node.UID), resolveAscendAllocationMode(podMode, node.Annotations[util.AscendNodeHamiCoreAnnotation])
+}
+
+func resolveAscendAllocationMode(podMode, nodeHamiCore string) util.AscendAllocationMode {
+	if podMode != "" {
+		if podMode == util.AscendVNPUModeHamiCore {
+			return util.AscendAllocationModeHamiCore
+		}
+		return util.AscendAllocationModeTemplate
+	}
+	switch nodeHamiCore {
+	case "true":
+		// Released plugin images disagree on whether an unannotated Pod inherits
+		// soft mode from the Node. The Node flag does not encode that runtime
+		// version, so this allocation cannot be decoded without guessing.
+		return util.AscendAllocationModeUnknown
+	case "false":
+		return util.AscendAllocationModeTemplate
+	default:
+		return util.AscendAllocationModeUnknown
 	}
 }
 

--- a/server/internal/data/pod_test.go
+++ b/server/internal/data/pod_test.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"testing"
+
+	"vgpu/internal/biz"
+	"vgpu/internal/provider/util"
+)
+
+func TestMergeContainerDevicesBySlotKeepsInitAlignmentAndDeviceTypes(t *testing.T) {
+	podDevices := biz.PodDevices{
+		"Ascend910B3": {{}, {{UUID: "B3-0", Type: "Ascend910B3", Usedmem: 28672, Usedcores: 40, CoreAllocationKnown: true}}, {}},
+		"NVIDIA":      {{}, {}, {{UUID: "GPU-0", Type: "NVIDIA", Usedmem: 4096, Usedcores: 20}}},
+	}
+	got := mergeContainerDevicesBySlot(3, podDevices)
+	if len(got) != 3 || len(got[0]) != 0 || len(got[1]) != 1 || len(got[2]) != 1 {
+		t.Fatalf("merged slots = %#v", got)
+	}
+	if got[1][0].Type != "Ascend910B3" || got[2][0].Type != "NVIDIA" {
+		t.Fatalf("device types moved or overwrote one another: %#v", got)
+	}
+}
+
+func TestResolveAscendAllocationModeUsesPodThenNodeContract(t *testing.T) {
+	tests := []struct {
+		name, podMode, nodeHamiCore string
+		want                        util.AscendAllocationMode
+	}{
+		{name: "explicit hami-core", podMode: util.AscendVNPUModeHamiCore, nodeHamiCore: "false", want: util.AscendAllocationModeHamiCore},
+		{name: "explicit template", podMode: "template", nodeHamiCore: "true", want: util.AscendAllocationModeTemplate},
+		{name: "annotation-less true node is ambiguous across deployed plugin versions", nodeHamiCore: "true", want: util.AscendAllocationModeUnknown},
+		{name: "annotation-less hard node", nodeHamiCore: "false", want: util.AscendAllocationModeTemplate},
+		{name: "unresolved node mode", want: util.AscendAllocationModeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAscendAllocationMode(tt.podMode, tt.nodeHamiCore); got != tt.want {
+				t.Fatalf("resolveAscendAllocationMode(%q, %q) = %v, want %v", tt.podMode, tt.nodeHamiCore, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -13,6 +13,7 @@ import (
 	"vgpu/internal/conf"
 	"vgpu/internal/data/prom"
 	"vgpu/internal/provider/metax"
+	providerutil "vgpu/internal/provider/util"
 	"vgpu/internal/service"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -377,6 +378,7 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			var core int32 = 0
 			var memory int32 = 0
 			var provider string = ""
+			coreAllocationKnown := true
 			for _, cd := range c.ContainerDevices {
 				if device.AliasId != "" && !strings.HasPrefix(cd.UUID, device.AliasId) {
 					continue
@@ -384,7 +386,10 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				vGPU = vGPU + 1
 				core = core + cd.Usedcores
 				memory = memory + cd.Usedmem
-				provider = cd.Type
+				provider = providerutil.VendorOf(cd.Type)
+				if provider == biz.AscendGPUDevice && !cd.CoreAllocationKnown {
+					coreAllocationKnown = false
+				}
 			}
 			if provider == "" || provider == metax.MetaxGPUDevice {
 				continue
@@ -392,11 +397,13 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			podUIDLabel := fmt.Sprintf("%s:%s", c.Name, c.PodUID)
 			s.set(HamiContainerVgpuAllocated, float64(vGPU), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			s.set(HamiContainerVmemoryAllocated, float64(memory), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
-			s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
-			used, util, err := s.containerCoreMetrics(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index, core)
-			if err == nil {
-				s.set(HamiContainerCoreUsed, used, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
-				s.set(HamiContainerCoreUtil, util, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
+			if coreAllocationKnown {
+				s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
+				used, util, err := s.containerCoreMetrics(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index, core)
+				if err == nil {
+					s.set(HamiContainerCoreUsed, used, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
+					s.set(HamiContainerCoreUtil, util, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
+				}
 			}
 			taskMemoryUsed, err := s.taskMemoryUsed(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index)
 			if err == nil {

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -60,6 +60,18 @@ func (f *fakeNodeRepo) FindDeviceByAliasId(string) (*biz.DeviceInfo, error) {
 	return nil, nil
 }
 
+type fakePodRepo struct {
+	containers []*biz.Container
+}
+
+func (f *fakePodRepo) ListAll(context.Context) ([]*biz.Container, error) {
+	return f.containers, nil
+}
+
+func (f *fakePodRepo) FindOne(context.Context, string, string) (*biz.Container, error) {
+	return nil, nil
+}
+
 func TestNvidiaTaskCoreUsedQueryIncludesIdleSamples(t *testing.T) {
 	query := nvidiaTaskCoreUsedQuery("GPU-1", "research", "train", "worker")
 	want := `avg(avg_over_time(hami_container_device_utilization_ratio{device_uuid="GPU-1", namespace="research", pod="train", container="worker"}[1m]))`
@@ -598,6 +610,52 @@ func TestContainerCoreMetricsKeepsLegacyProviderConversions(t *testing.T) {
 			if len(fake.queries) != 2 {
 				t.Fatalf("legacy provider made %d queries, want 2", len(fake.queries))
 			}
+		})
+	}
+}
+
+func TestAscendContainerAllocationNormalizesProviderAndOmitsUnknownCore(t *testing.T) {
+	tests := []struct {
+		name          string
+		core          int32
+		coreKnown     bool
+		wantCoreGauge bool
+	}{
+		{name: "known template", core: 25, coreKnown: true, wantCoreGauge: true},
+		{name: "unknown template", core: 0, coreKnown: false, wantCoreGauge: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				aliasID   = "B4-alias"
+				deviceID  = "B4-telemetry"
+				nodeName  = "ascend-node"
+				podName   = "ascend-pod"
+				container = "worker"
+				namespace = "research"
+				podUID    = "pod-uid"
+			)
+			generator := &MetricsGenerator{
+				nodeUsecase: biz.NewNodeUsecase(&fakeNodeRepo{devices: []*biz.DeviceInfo{{
+					Id: deviceID, AliasId: aliasID, Type: "Ascend910B4", Provider: biz.AscendGPUDevice, NodeName: nodeName,
+				}}}, log.NewStdLogger(io.Discard)),
+				podUsecase: biz.NewPodUseCase(&fakePodRepo{containers: []*biz.Container{{
+					Name: container, PodName: podName, PodUID: podUID, Namespace: namespace,
+					ContainerDevices: biz.ContainerDevices{{UUID: aliasID, Type: "Ascend910B4", Usedmem: 8192, Usedcores: tt.core, CoreAllocationKnown: tt.coreKnown}},
+				}}}, log.NewStdLogger(io.Discard)),
+				monitorService: &fakeInstantQuerier{},
+				log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+			}
+			t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+			if err := generator.GenerateContainerMetrics(context.Background()); err != nil {
+				t.Fatalf("GenerateContainerMetrics() error = %v", err)
+			}
+			labels := []string{nodeName, biz.AscendGPUDevice, "Ascend910B4", deviceID, podName, container, namespace, container + ":" + podUID}
+			assertGaugeTracked(t, generator, HamiContainerVgpuAllocated, labels, true)
+			assertGaugeTracked(t, generator, HamiContainerVmemoryAllocated, labels, true)
+			assertGaugeTracked(t, generator, HamiContainerVcoreAllocated, labels, tt.wantCoreGauge)
 		})
 	}
 }

--- a/server/internal/provider/ascend/device.go
+++ b/server/internal/provider/ascend/device.go
@@ -15,14 +15,12 @@ const (
 )
 
 var (
-	AscendResourceCount     string
-	AscendResourceMemory    string
-	AscendResourceCores     string
-	AscendNodeRegisterAnnos []string
+	AscendResourceCount  string
+	AscendResourceMemory string
+	AscendResourceCores  string
 )
 
 func init() {
-	AscendNodeRegisterAnnos = []string{Ascend910BNodeRegisterAnno, Ascend310PNodeRegisterAnno}
 	util.InRequestDevices[AscendDevice] = "hami.io/Ascend910B-devices-to-allocate"
 	util.SupportDevices[AscendDevice] = "hami.io/Ascend910B-devices-allocated"
 	util.InRequestDevices[Ascend310PDevice] = "hami.io/Ascend310P-devices-to-allocate"

--- a/server/internal/provider/ascend/device_test.go
+++ b/server/internal/provider/ascend/device_test.go
@@ -1,0 +1,16 @@
+package ascend
+
+import (
+	"testing"
+
+	"vgpu/internal/provider/util"
+)
+
+func TestLegacyAscendAnnotationsRemainRegistered(t *testing.T) {
+	if got := util.SupportDevices[AscendDevice]; got != "hami.io/Ascend910B-devices-allocated" {
+		t.Fatalf("legacy Ascend910B allocation annotation = %q", got)
+	}
+	if got := util.SupportDevices[Ascend310PDevice]; got != "hami.io/Ascend310P-devices-allocated" {
+		t.Fatalf("legacy Ascend310P allocation annotation = %q", got)
+	}
+}

--- a/server/internal/provider/ascend/provider.go
+++ b/server/internal/provider/ascend/provider.go
@@ -134,6 +134,9 @@ func decodeRegisteredDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
 		}
 		reported, hasReport := parseAscendReportedTime(node.Annotations[handshakeBase+commonWord])
 		for _, device := range nodeDevices {
+			if device == nil {
+				return nil, fmt.Errorf("decode %s on node %s: nil device record", annotationKey, node.Name)
+			}
 			if device.ID == "" || device.Type != commonWord {
 				return nil, fmt.Errorf("decode %s on node %s: device id/type does not match commonWord %q", annotationKey, node.Name, commonWord)
 			}

--- a/server/internal/provider/ascend/provider.go
+++ b/server/internal/provider/ascend/provider.go
@@ -7,7 +7,9 @@ import (
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"strconv"
+	"sort"
+	"strings"
+	"time"
 	"vgpu/internal/data/prom"
 	"vgpu/internal/provider/util"
 )
@@ -53,13 +55,16 @@ func (a *Ascend) GetDevicesFromPrometheus(node *corev1.Node) map[string]*util.De
 			a.log.Warnf("vectorValue: %v, failed", vs)
 		} else {
 			for _, d := range ds {
-				id := d.Metric["id"]
+				vdieID := string(d.Metric["vdie_id"])
+				if vdieID == "" {
+					continue
+				}
 				health := false
 				if d.Value.Equal(1) {
 					health = true
 				}
-				device[string(id)] = &util.DeviceInfo{
-					ID:     string(d.Metric["vdie_id"]),
+				device[vdieID] = &util.DeviceInfo{
+					ID:     vdieID,
 					Type:   string(d.Metric["model_name"]),
 					Driver: "-",
 					Health: health,
@@ -71,26 +76,109 @@ func (a *Ascend) GetDevicesFromPrometheus(node *corev1.Node) map[string]*util.De
 }
 
 func (a *Ascend) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
-	for _, anno := range AscendNodeRegisterAnnos {
-		tmpDevice := a.GetDevicesFromPrometheus(node)
-		anno, ok := node.Annotations[anno]
-		if !ok {
-			log.Infof("anno %s not found", anno)
-			continue
+	nodeDevices, err := decodeRegisteredDevices(node)
+	if err != nil {
+		return nil, err
+	}
+	if len(nodeDevices) == 0 {
+		return []*util.DeviceInfo{}, nil
+	}
+
+	telemetryDevices := a.GetDevicesFromPrometheus(node)
+	for i, matched := range reconcileRegisteredDevices(nodeDevices, telemetryDevices) {
+		if !matched {
+			log.Infof("Ascend device %s (index %d) not found in Prometheus telemetry", nodeDevices[i].AliasId, nodeDevices[i].Index)
 		}
-		nodeDevices, err := util.UnMarshalNodeDevices(anno)
+	}
+	return nodeDevices, nil
+}
+
+func reconcileRegisteredDevices(nodeDevices []*util.DeviceInfo, telemetryDevices map[string]*util.DeviceInfo) []bool {
+	matched := make([]bool, len(nodeDevices))
+	for i, nodeDevice := range nodeDevices {
+		nodeDevices[i].AliasId = nodeDevice.ID
+		if telemetryDevice, exists := telemetryDevices[nodeDevice.ID]; exists {
+			nodeDevices[i].Health = telemetryDevice.Health
+			matched[i] = true
+		}
+	}
+	return matched
+}
+
+func decodeRegisteredDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
+	type candidate struct {
+		device    *util.DeviceInfo
+		reported  time.Time
+		hasReport bool
+		key       string
+	}
+	candidates := make(map[string]candidate)
+	annotationKeys := make([]string, 0)
+	const (
+		registerBase   = "hami.io/node-register-"
+		registerPrefix = registerBase + "Ascend"
+		handshakeBase  = "hami.io/node-handshake-"
+	)
+	for annotationKey := range node.Annotations {
+		if strings.HasPrefix(annotationKey, registerPrefix) && len(annotationKey) > len(registerBase) {
+			annotationKeys = append(annotationKeys, annotationKey)
+		}
+	}
+	sort.Strings(annotationKeys)
+	for _, annotationKey := range annotationKeys {
+		commonWord := strings.TrimPrefix(annotationKey, registerBase)
+		annotation := node.Annotations[annotationKey]
+		nodeDevices, err := util.UnMarshalNodeDevices(annotation)
 		if err != nil {
-			return []*util.DeviceInfo{}, err
+			return nil, fmt.Errorf("decode %s on node %s: %w", annotationKey, node.Name, err)
 		}
-		for i, nodedevice := range nodeDevices {
-			nodeDevices[i].AliasId = nodedevice.ID
-			if device, exists := tmpDevice[strconv.Itoa(i)]; exists {
-				nodeDevices[i].ID = device.ID
-			} else {
-				log.Infof("Key %d not found in tmpDevice", i)
+		reported, hasReport := parseAscendReportedTime(node.Annotations[handshakeBase+commonWord])
+		for _, device := range nodeDevices {
+			if device.ID == "" || device.Type != commonWord {
+				return nil, fmt.Errorf("decode %s on node %s: device id/type does not match commonWord %q", annotationKey, node.Name, commonWord)
+			}
+			// The plugin reports physical AI Core count in hard mode (for
+			// example 20), while WebUI's allocation contract is a normalized
+			// whole-card percentage. Keep the inventory denominator consistent
+			// with template shares and hami-core mode.
+			device.Devcore = 100
+			incoming := candidate{device: device, reported: reported, hasReport: hasReport, key: annotationKey}
+			existing, duplicate := candidates[device.ID]
+			if !duplicate {
+				candidates[device.ID] = incoming
+				continue
+			}
+			replace := incoming.hasReport && (!existing.hasReport || incoming.reported.After(existing.reported))
+			if replace {
+				candidates[device.ID] = incoming
+			}
+			if existing.device.Type != incoming.device.Type {
+				log.Warnf("conflicting Ascend registrations for device %s on node %s: %s and %s", device.ID, node.Name, existing.key, incoming.key)
 			}
 		}
-		return nodeDevices, nil
 	}
-	return []*util.DeviceInfo{}, fmt.Errorf("")
+	ordered := make([]candidate, 0, len(candidates))
+	for _, registered := range candidates {
+		ordered = append(ordered, registered)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].device.Index != ordered[j].device.Index {
+			return ordered[i].device.Index < ordered[j].device.Index
+		}
+		return ordered[i].device.ID < ordered[j].device.ID
+	})
+	devices := make([]*util.DeviceInfo, 0, len(ordered))
+	for _, registered := range ordered {
+		devices = append(devices, registered.device)
+	}
+	return devices, nil
+}
+
+func parseAscendReportedTime(value string) (time.Time, bool) {
+	const prefix = "Reported_"
+	if !strings.HasPrefix(value, prefix) {
+		return time.Time{}, false
+	}
+	reported, err := time.Parse("2006.01.02 15:04:05", strings.TrimPrefix(value, prefix))
+	return reported, err == nil
 }

--- a/server/internal/provider/ascend/provider_test.go
+++ b/server/internal/provider/ascend/provider_test.go
@@ -1,0 +1,133 @@
+package ascend
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"vgpu/internal/provider/util"
+)
+
+func TestDecodeRegisteredDevicesCollectsAscendVariants(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "ascend-node",
+		Annotations: map[string]string{
+			"hami.io/node-register-Ascend910B4": `[{"id":"B4-0","index":0,"count":1,"devmem":32768,"devcore":20,"type":"Ascend910B4","health":true}]`,
+			"hami.io/node-register-Ascend910C":  `[{"id":"C-2","index":2,"count":1,"devmem":65536,"devcore":20,"type":"Ascend910C","health":true}]`,
+		},
+	}}
+
+	devices, err := decodeRegisteredDevices(node)
+	if err != nil {
+		t.Fatalf("decodeRegisteredDevices() error = %v", err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("device count = %d, want 2", len(devices))
+	}
+	if devices[0].ID != "B4-0" || devices[1].ID != "C-2" {
+		t.Fatalf("device order = [%s, %s], want producer index order", devices[0].ID, devices[1].ID)
+	}
+	got := map[string]string{}
+	for _, device := range devices {
+		got[device.ID] = device.Type
+		if device.Devcore != 100 {
+			t.Errorf("device %s normalized core capacity = %d, want 100", device.ID, device.Devcore)
+		}
+	}
+	if got["B4-0"] != "Ascend910B4" || got["C-2"] != "Ascend910C" {
+		t.Fatalf("concrete device types were not preserved: %v", got)
+	}
+}
+
+func TestReconcileRegisteredDevicesPrefersVDIEIdentity(t *testing.T) {
+	// The exporter id is a physical index and may be non-contiguous after
+	// filtering. Matching registration index 0 first would incorrectly replace
+	// vdie-1 with the unrelated vdie-0.
+	registered := []*util.DeviceInfo{{ID: "vdie-1", Index: 0, Health: false}}
+	telemetry := map[string]*util.DeviceInfo{
+		"0":      {ID: "vdie-0", Health: false},
+		"vdie-1": {ID: "vdie-1", Health: true},
+	}
+	matched := reconcileRegisteredDevices(registered, telemetry)
+	if !matched[0] {
+		t.Fatalf("matched = %v, want vdie identity reconciled", matched)
+	}
+	if registered[0].ID != "vdie-1" || registered[0].AliasId != "vdie-1" {
+		t.Fatalf("registration was associated with the wrong telemetry device: %#v", registered[0])
+	}
+	if !registered[0].Health {
+		t.Fatalf("exact UUID telemetry did not refresh device health: %#v", registered[0])
+	}
+}
+
+func TestDecodeRegisteredDevicesNormalizesWebUICoreCapacity(t *testing.T) {
+	tests := []struct {
+		name, commonWord string
+		producerDevcore  int
+	}{
+		{name: "B3 hard mode physical cores", commonWord: "Ascend910B3", producerDevcore: 20},
+		{name: "B4 hard mode physical cores", commonWord: "Ascend910B4", producerDevcore: 20},
+		{name: "310P hard mode physical cores", commonWord: "Ascend310P", producerDevcore: 8},
+		{name: "hami-core already normalized", commonWord: "Ascend910B3", producerDevcore: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "ascend-node",
+				Annotations: map[string]string{
+					"hami.io/node-register-" + tt.commonWord: fmt.Sprintf(
+						`[{"id":"vdie-0","count":1,"devmem":65536,"devcore":%d,"type":%q,"health":true}]`,
+						tt.producerDevcore,
+						tt.commonWord,
+					),
+				},
+			}}
+			devices, err := decodeRegisteredDevices(node)
+			if err != nil || len(devices) != 1 {
+				t.Fatalf("decodeRegisteredDevices() = (%#v, %v)", devices, err)
+			}
+			if devices[0].Devcore != 100 {
+				t.Fatalf("WebUI percentage capacity = %d, want 100 (producer physical core value %d)", devices[0].Devcore, tt.producerDevcore)
+			}
+		})
+	}
+}
+
+func TestDecodeRegisteredDevicesDeduplicatesStaleCommonWordByHandshake(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "ascend-node",
+		Annotations: map[string]string{
+			"hami.io/node-register-Ascend910B3":  `[{"id":"same-vdie","count":1,"devmem":65536,"devcore":20,"type":"Ascend910B3","health":true}]`,
+			"hami.io/node-handshake-Ascend910B3": "Reported_2026.08.01 10:00:00",
+			"hami.io/node-register-Ascend910B4":  `[{"id":"same-vdie","count":1,"devmem":32768,"devcore":20,"type":"Ascend910B4","health":true}]`,
+			"hami.io/node-handshake-Ascend910B4": "Reported_2026.08.02 10:00:00",
+		},
+	}}
+
+	devices, err := decodeRegisteredDevices(node)
+	if err != nil {
+		t.Fatalf("decodeRegisteredDevices() error = %v", err)
+	}
+	if len(devices) != 1 || devices[0].ID != "same-vdie" || devices[0].Type != "Ascend910B4" {
+		t.Fatalf("deduplicated devices = %#v, want freshest B4 registration", devices)
+	}
+}
+
+func TestDecodeRegisteredDevicesDiscoversFutureAscendCommonWord(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "ascend-node",
+		Annotations: map[string]string{
+			"hami.io/node-register-AscendFuture": `[{"id":"future-vdie","count":1,"devmem":12345,"devcore":7,"type":"AscendFuture","health":true}]`,
+		},
+	}}
+
+	devices, err := decodeRegisteredDevices(node)
+	if err != nil || len(devices) != 1 {
+		t.Fatalf("decodeRegisteredDevices() = (%#v, %v)", devices, err)
+	}
+	if devices[0].Type != "AscendFuture" || devices[0].Devmem != 12345 || devices[0].Devcore != 100 {
+		t.Fatalf("future Ascend inventory = %#v", devices[0])
+	}
+}

--- a/server/internal/provider/ascend/provider_test.go
+++ b/server/internal/provider/ascend/provider_test.go
@@ -131,3 +131,16 @@ func TestDecodeRegisteredDevicesDiscoversFutureAscendCommonWord(t *testing.T) {
 		t.Fatalf("future Ascend inventory = %#v", devices[0])
 	}
 }
+
+func TestDecodeRegisteredDevicesRejectsNullRecord(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "ascend-node",
+		Annotations: map[string]string{
+			"hami.io/node-register-Ascend910B4": `[null]`,
+		},
+	}}
+
+	if _, err := decodeRegisteredDevices(node); err == nil {
+		t.Fatal("decodeRegisteredDevices() error = nil, want invalid device record error")
+	}
+}

--- a/server/internal/provider/util/types.go
+++ b/server/internal/provider/util/types.go
@@ -50,13 +50,22 @@ var (
 )
 
 type ContainerDevice struct {
-	Idx       int
-	UUID      string
-	Type      string
-	Usedmem   int32
-	Usedcores int32
-	Priority  string
+	Idx                 int
+	UUID                string
+	Type                string
+	Usedmem             int32
+	Usedcores           int32
+	CoreAllocationKnown bool
+	Priority            string
 }
+
+type AscendAllocationMode int
+
+const (
+	AscendAllocationModeUnknown AscendAllocationMode = iota
+	AscendAllocationModeHamiCore
+	AscendAllocationModeTemplate
+)
 
 type ContainerDeviceRequest struct {
 	Nums             int32

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -29,7 +30,21 @@ const (
 	DsmluProfileAndInstance = "CAMBRICON_DSMLU_PROFILE_INSTANCE"
 
 	NVIDIAPriority = "nvidia.com/priority"
+
+	AscendVNPUModeAnnotation     = "huawei.com/vnpu-mode"
+	AscendVNPUModeHamiCore       = "hami-core"
+	AscendNodeHamiCoreAnnotation = "hami-vnpu-core"
 )
+
+// VendorOf maps a concrete device type to the provider name used for metric
+// dispatch. Ascend annotations carry the chip commonWord as their type; keep
+// that concrete type in inventory and normalize only at the provider boundary.
+func VendorOf(deviceType string) string {
+	if strings.HasPrefix(deviceType, AscendGPUDevice) {
+		return AscendGPUDevice
+	}
+	return deviceType
+}
 
 type ascendDeviceConfig struct {
 	Usedmem   int32
@@ -45,15 +60,53 @@ var (
 func init() {
 	InRequestDevices = make(map[string]string)
 	SupportDevices = make(map[string]string)
+	// This is a compatibility snapshot of the templates shipped by HAMi. Custom
+	// operator templates are intentionally not guessed: their core allocation is
+	// reported as unavailable until WebUI has a configured source of truth.
 	ascendDeviceConfigs = map[string]map[int32]ascendDeviceConfig{
+		"Ascend910A": {
+			2184:  {Usedmem: 2184, Usedcores: 7},
+			4369:  {Usedmem: 4369, Usedcores: 13},
+			8738:  {Usedmem: 8738, Usedcores: 27},
+			17476: {Usedmem: 17476, Usedcores: 53},
+			32768: {Usedmem: 32768, Usedcores: 100},
+		},
 		"Ascend910B": {
 			16384: {Usedmem: 16384, Usedcores: 25},
 			32768: {Usedmem: 32768, Usedcores: 50},
+			65536: {Usedmem: 65536, Usedcores: 100},
+		},
+		"Ascend910B2": {
+			8192:  {Usedmem: 8192, Usedcores: 13},
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+			65536: {Usedmem: 65536, Usedcores: 100},
+		},
+		"Ascend910B3": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+			65536: {Usedmem: 65536, Usedcores: 100},
+		},
+		"Ascend910B4": {
+			8192:  {Usedmem: 8192, Usedcores: 25},
+			16384: {Usedmem: 16384, Usedcores: 50},
+			32768: {Usedmem: 32768, Usedcores: 100},
+		},
+		"Ascend910B4-1": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+			65536: {Usedmem: 65536, Usedcores: 100},
+		},
+		"Ascend910C": {
+			16384: {Usedmem: 16384, Usedcores: 25},
+			32768: {Usedmem: 32768, Usedcores: 50},
+			65536: {Usedmem: 65536, Usedcores: 100},
 		},
 		"Ascend310P": {
 			3072:  {Usedmem: 3072, Usedcores: 13},
 			6144:  {Usedmem: 6144, Usedcores: 25},
 			12288: {Usedmem: 12288, Usedcores: 50},
+			21527: {Usedmem: 21527, Usedcores: 100},
 		},
 	}
 	initMLUDevice()
@@ -185,39 +238,49 @@ func DecodeDCUContainerDevices(str, priority, nodeName string) (ContainerDevices
 	return contdev, nil
 }
 
-func DecodeNpuContainerDevices(str string) (ContainerDevices, error) {
+func DecodeNpuContainerDevices(str string, mode AscendAllocationMode) (ContainerDevices, error) {
 	if len(str) == 0 {
 		return ContainerDevices{}, nil
 	}
 	cd := strings.Split(str, OneContainerMultiDeviceSplitSymbol)
 	contdev := ContainerDevices{}
-	tmpdev := ContainerDevice{}
-	if len(str) == 0 {
-		return ContainerDevices{}, nil
-	}
 	for i, val := range cd {
 		if strings.Contains(val, ",") {
 			tmpstr := strings.Split(val, ",")
 			if len(tmpstr) < 4 {
 				return ContainerDevices{}, fmt.Errorf("pod annotation format error; information missing, please do not use nodeName field in task")
 			}
-			tmpdev.Idx = i
-			tmpdev.UUID = tmpstr[0]
-			tmpdev.Type = tmpstr[1]
-			devmem, _ := strconv.ParseInt(tmpstr[2], 10, 32)
-			tmpdev.Usedmem = int32(devmem)
-			tmpdev.Usedcores = 100
-
-			if configs, exists := ascendDeviceConfigs[tmpdev.Type]; exists {
-				if config, ok := configs[tmpdev.Usedmem]; ok {
-					tmpdev.Usedcores = config.Usedcores
-				}
+			devmem, err := strconv.ParseInt(tmpstr[2], 10, 32)
+			if err != nil || devmem < 0 {
+				return ContainerDevices{}, fmt.Errorf("invalid Ascend memory field %q", tmpstr[2])
 			}
+			devcores, err := strconv.ParseInt(tmpstr[3], 10, 32)
+			if err != nil || devcores < 0 {
+				return ContainerDevices{}, fmt.Errorf("invalid Ascend core field %q", tmpstr[3])
+			}
+			tmpdev := ContainerDevice{Idx: i, UUID: tmpstr[0], Type: tmpstr[1], Usedmem: int32(devmem)}
+			tmpdev.Usedcores, tmpdev.CoreAllocationKnown = ascendCoreAllocation(tmpdev.Type, tmpdev.Usedmem, int32(devcores), mode)
 
 			contdev = append(contdev, tmpdev)
 		}
 	}
 	return contdev, nil
+}
+
+func ascendCoreAllocation(deviceType string, memory, annotationCore int32, mode AscendAllocationMode) (int32, bool) {
+	switch mode {
+	case AscendAllocationModeHamiCore:
+		return annotationCore, true
+	case AscendAllocationModeTemplate:
+		if configs, exists := ascendDeviceConfigs[deviceType]; exists {
+			if config, ok := configs[memory]; ok {
+				return config.Usedcores, true
+			}
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
 }
 
 // DecodeMLUContainerDevices decodes the mlu container devices from a string.
@@ -307,8 +370,8 @@ func podContainerCount(pod *corev1.Pod) int {
 	return len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
 }
 
-func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
-	checklist := SupportDevices
+func DecodePodDevices(pod *corev1.Pod, log *log.Helper, ascendMode AscendAllocationMode) (PodDevices, error) {
+	checklist := supportDevicesForPod(pod.Annotations)
 
 	priorities := GetContainerPriorities(pod)
 
@@ -318,14 +381,20 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 	}
 	nodeName := annos[AssignedNodeAnnotations]
 	pd := make(PodDevices)
-	for devType, devs := range checklist {
+	deviceTypes := make([]string, 0, len(checklist))
+	for devType := range checklist {
+		deviceTypes = append(deviceTypes, devType)
+	}
+	sort.Strings(deviceTypes)
+	for _, devType := range deviceTypes {
+		devs := checklist[devType]
 		str, ok := annos[devs]
 		if !ok {
 			continue
 		}
 		pd[devType] = make(PodSingleDevice, 0)
-		switch devType {
-		case AscendGPUDevice, Ascend310PGPUDevice:
+		switch VendorOf(devType) {
+		case AscendGPUDevice:
 			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
 				if i >= podContainerCount(pod) {
 					break
@@ -334,9 +403,14 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 					pd[devType] = append(pd[devType], ContainerDevices{})
 					continue
 				}
-				cd, err := DecodeNpuContainerDevices(s)
+				cd, err := DecodeNpuContainerDevices(s, ascendMode)
 				if err != nil {
-					return PodDevices{}, nil
+					return PodDevices{}, err
+				}
+				for _, device := range cd {
+					if device.Type != devType {
+						return PodDevices{}, fmt.Errorf("ascend allocation annotation %s contains device type %q, want %q", devs, device.Type, devType)
+					}
 				}
 				if len(cd) == 0 {
 					continue
@@ -402,6 +476,40 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper) (PodDevices, error) {
 	}
 	log.Infof("Decoded pod annos: poddevices %v", pd)
 	return pd, nil
+}
+
+func supportDevicesForPod(annotations map[string]string) map[string]string {
+	devices := make(map[string]string, len(SupportDevices))
+	for deviceType, annotation := range SupportDevices {
+		devices[deviceType] = annotation
+	}
+
+	const (
+		ascendAllocatedPrefix = "hami.io/Ascend"
+		allocatedSuffix       = "-devices-allocated"
+	)
+	discovered := make([]string, 0)
+	for annotation := range annotations {
+		if strings.HasPrefix(annotation, ascendAllocatedPrefix) && strings.HasSuffix(annotation, allocatedSuffix) {
+			discovered = append(discovered, annotation)
+		}
+	}
+	sort.Strings(discovered)
+	for _, annotation := range discovered {
+		deviceType := strings.TrimSuffix(strings.TrimPrefix(annotation, "hami.io/"), allocatedSuffix)
+		if deviceType == "" {
+			continue
+		}
+		// Replace legacy aliases that point at the same annotation so a concrete
+		// producer commonWord is decoded exactly once and remains visible.
+		for existingType, existingAnnotation := range devices {
+			if existingAnnotation == annotation {
+				delete(devices, existingType)
+			}
+		}
+		devices[deviceType] = annotation
+	}
+	return devices
 }
 
 func UnMarshalNodeDevices(str string) ([]*DeviceInfo, error) {

--- a/server/internal/provider/util/util_test.go
+++ b/server/internal/provider/util/util_test.go
@@ -65,7 +65,7 @@ func TestDecodePodDevicesWithInitContainers(t *testing.T) {
 		},
 	}
 
-	got, err := DecodePodDevices(pod, logger)
+	got, err := DecodePodDevices(pod, logger, AscendAllocationModeUnknown)
 	if err != nil {
 		t.Fatalf("DecodePodDevices() error = %v", err)
 	}
@@ -118,7 +118,7 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 			want: PodDevices{
 				"Ascend310P": {
 					{
-						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 				},
 			},
@@ -142,10 +142,10 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 			want: PodDevices{
 				"Ascend310P": {
 					{
-						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 					{
-						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 				},
 			},
@@ -167,7 +167,7 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 			want: PodDevices{
 				"Ascend310P": {
 					{
-						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 				},
 			},
@@ -192,11 +192,11 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 			want: PodDevices{
 				"Ascend310P": {
 					{
-						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 					{}, // empty segment placeholder
 					{
-						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "D7E96E64-214123F1-E8E618E4-AED8030A-E3003039", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 				},
 			},
@@ -219,7 +219,7 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 				"Ascend310P": {
 					{},
 					{
-						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25},
+						{Idx: 0, UUID: "E0766E64-20C0AB59-CC9AB1A4-3778030A-83003019", Type: "Ascend310P", Usedmem: 6144, Usedcores: 25, CoreAllocationKnown: true},
 					},
 				},
 			},
@@ -257,7 +257,7 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DecodePodDevices(tt.pod, logger)
+			got, err := DecodePodDevices(tt.pod, logger, AscendAllocationModeTemplate)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DecodePodDevices() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -266,5 +266,102 @@ func Test_DecodePodDevices_Ascend(t *testing.T) {
 				t.Errorf("DecodePodDevices() = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDecodeNpuContainerDevicesUsesModeSpecificCoreContract(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		mode      AscendAllocationMode
+		wantCore  int32
+		wantKnown bool
+	}{
+		{name: "B3 hami-core uses annotation percentage", input: "B3-soft,Ascend910B3,28672,40:", mode: AscendAllocationModeHamiCore, wantCore: 40, wantKnown: true},
+		{name: "B3 hami-core zero remains zero", input: "B3-soft-zero,Ascend910B3,16384,0:", mode: AscendAllocationModeHamiCore, wantCore: 0, wantKnown: true},
+		{name: "910A hard template", input: "A-hard,Ascend910A,2184,0:", mode: AscendAllocationModeTemplate, wantCore: 7, wantKnown: true},
+		{name: "B2 hard template", input: "B2-hard,Ascend910B2,8192,0:", mode: AscendAllocationModeTemplate, wantCore: 13, wantKnown: true},
+		{name: "B4 hard template", input: "B4-hard,Ascend910B4,8192,0:", mode: AscendAllocationModeTemplate, wantCore: 25, wantKnown: true},
+		{name: "B4-1 hard template", input: "B4-1-hard,Ascend910B4-1,32768,0:", mode: AscendAllocationModeTemplate, wantCore: 50, wantKnown: true},
+		{name: "C hard full card", input: "C-hard,Ascend910C,65536,0:", mode: AscendAllocationModeTemplate, wantCore: 100, wantKnown: true},
+		{name: "unknown hard template is unavailable", input: "B4-custom,Ascend910B4,4096,0:", mode: AscendAllocationModeTemplate, wantCore: 0, wantKnown: false},
+		{name: "zero with unresolved mode is unavailable", input: "B4-ambiguous,Ascend910B4,8192,0:", mode: AscendAllocationModeUnknown, wantCore: 0, wantKnown: false},
+		{name: "positive core with unresolved mode is unavailable", input: "B3-positive,Ascend910B3,28672,40:", mode: AscendAllocationModeUnknown, wantCore: 0, wantKnown: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devices, err := DecodeNpuContainerDevices(tt.input, tt.mode)
+			if err != nil {
+				t.Fatalf("DecodeNpuContainerDevices() error = %v", err)
+			}
+			if len(devices) != 1 {
+				t.Fatalf("device count = %d, want 1", len(devices))
+			}
+			if devices[0].Usedcores != tt.wantCore || devices[0].CoreAllocationKnown != tt.wantKnown {
+				t.Fatalf("core allocation = (%d, known=%t), want (%d, known=%t)", devices[0].Usedcores, devices[0].CoreAllocationKnown, tt.wantCore, tt.wantKnown)
+			}
+		})
+	}
+}
+
+func TestDecodePodDevicesKeepsAscendInitContainerSlot(t *testing.T) {
+	const annotation = "hami.io/Ascend910B3-devices-allocated"
+	setSupportDeviceForTest(t, "Ascend910B3", annotation)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			annotation: ";B3-main,Ascend910B3,28672,40:;",
+		}},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init"}},
+			Containers:     []corev1.Container{{Name: "worker"}},
+		},
+	}
+
+	got, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger), AscendAllocationModeHamiCore)
+	if err != nil {
+		t.Fatalf("DecodePodDevices() error = %v", err)
+	}
+	slots := got["Ascend910B3"]
+	if len(slots) != 2 || len(slots[0]) != 0 || len(slots[1]) != 1 {
+		t.Fatalf("Ascend slots = %#v, want empty init slot and one worker device", slots)
+	}
+	if slots[1][0].UUID != "B3-main" || slots[1][0].Usedcores != 40 {
+		t.Fatalf("worker allocation = %#v", slots[1][0])
+	}
+}
+
+func TestDecodePodDevicesDiscoversFutureAscendCommonWord(t *testing.T) {
+	const annotation = "hami.io/AscendFuture-devices-allocated"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			annotation: "future-0,AscendFuture,12345,0:",
+		}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}},
+	}
+
+	got, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger), AscendAllocationModeTemplate)
+	if err != nil {
+		t.Fatalf("DecodePodDevices() error = %v", err)
+	}
+	devices := got["AscendFuture"]
+	if len(devices) != 1 || len(devices[0]) != 1 {
+		t.Fatalf("future Ascend devices = %#v", devices)
+	}
+	if devices[0][0].Usedmem != 12345 || devices[0][0].CoreAllocationKnown {
+		t.Fatalf("future Ascend allocation = %#v, want memory preserved and core unavailable", devices[0][0])
+	}
+}
+
+func TestDecodePodDevicesRejectsAscendCommonWordMismatch(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			"hami.io/Ascend910B3-devices-allocated": "device-0,Ascend910B4,16384,0:",
+		}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}},
+	}
+
+	if _, err := DecodePodDevices(pod, log.NewHelper(log.DefaultLogger), AscendAllocationModeTemplate); err == nil {
+		t.Fatal("DecodePodDevices() accepted a device type that did not match the annotation commonWord")
 	}
 }

--- a/server/internal/service/card.go
+++ b/server/internal/service/card.go
@@ -69,9 +69,10 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		gpu.Health = device.Health
 		gpu.Mode = device.Mode
 
-		vGPU, core, memory := biz.ContainersStatisticsInfo(containers, device.AliasId)
+		vGPU, core, memory, coreKnown := biz.ContainersStatisticsInfo(containers, device.AliasId)
 		gpu.VgpuUsed = vGPU
 		gpu.CoreUsed = core
+		gpu.CoreUsedKnown = &coreKnown
 		gpu.MemoryUsed = memory
 
 		if v, ok := coreSizeByUUID[device.Id]; ok {
@@ -156,10 +157,11 @@ func (s *CardService) GetGPU(ctx context.Context, req *pb.GetGpuReq) (*pb.GPURep
 		gpu.Health = device.Health
 		gpu.Mode = device.Mode
 
-		vGPU, core, memory, err := s.pod.StatisticsByDeviceId(ctx, device.AliasId)
+		vGPU, core, memory, coreKnown, err := s.pod.StatisticsByDeviceId(ctx, device.AliasId)
 		if err == nil {
 			gpu.VgpuUsed = vGPU
 			gpu.CoreUsed = core
+			gpu.CoreUsedKnown = &coreKnown
 			gpu.MemoryUsed = memory
 		}
 		return gpu, nil

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -94,6 +94,7 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 		containerReply.NodeUid = container.NodeUID
 		containerReply.Namespace = container.Namespace
 		containerReply.Priority = container.Priority
+		allocatedCoresKnown := true
 		for _, containerDevice := range container.ContainerDevices {
 			deviceID := containerDevice.UUID
 			if device, err := s.node.FindDeviceByAliasId(containerDevice.UUID); err == nil {
@@ -110,6 +111,9 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 
 			containerReply.DeviceIds = append(containerReply.DeviceIds, deviceID)
 			containerReply.AllocatedCores = containerReply.AllocatedCores + containerDevice.Usedcores
+			if strings.HasPrefix(containerDevice.Type, biz.AscendGPUDevice) && !containerDevice.CoreAllocationKnown {
+				allocatedCoresKnown = false
+			}
 			containerReply.AllocatedMem = containerReply.AllocatedMem + containerDevice.Usedmem
 			containerReply.Type = containerDevice.Type
 			containerReply.AllocatedDevices++
@@ -117,6 +121,7 @@ func (s *ContainerService) GetAllContainers(ctx context.Context, req *pb.GetAllC
 		if containerReply.DeviceIds == nil {
 			continue
 		}
+		containerReply.AllocatedCoresKnown = &allocatedCoresKnown
 		containerReply.CreateTime = container.CreateTime.Format(time.RFC3339)
 		res.Items = append(res.Items, containerReply)
 	}
@@ -140,6 +145,7 @@ func (s *ContainerService) GetContainer(ctx context.Context, req *pb.GetContaine
 	ctrReply.NodeUid = container.NodeUID
 	ctrReply.Namespace = container.Namespace
 	ctrReply.Priority = container.Priority
+	allocatedCoresKnown := true
 	allContainers, err := s.pod.ListAllContainers(ctx)
 	if err == nil {
 		images := make([]string, 0)
@@ -163,10 +169,14 @@ func (s *ContainerService) GetContainer(ctx context.Context, req *pb.GetContaine
 			ctrReply.DeviceIds = append(ctrReply.DeviceIds, device.Id)
 		}
 		ctrReply.AllocatedCores = ctrReply.AllocatedCores + containerDevice.Usedcores
+		if strings.HasPrefix(containerDevice.Type, biz.AscendGPUDevice) && !containerDevice.CoreAllocationKnown {
+			allocatedCoresKnown = false
+		}
 		ctrReply.AllocatedMem = ctrReply.AllocatedMem + containerDevice.Usedmem
 		ctrReply.Type = containerDevice.Type
 		ctrReply.AllocatedDevices++
 	}
+	ctrReply.AllocatedCoresKnown = &allocatedCoresKnown
 	ctrReply.CreateTime = container.CreateTime.Format(time.RFC3339)
 	return ctrReply, nil
 }

--- a/server/internal/service/container_test.go
+++ b/server/internal/service/container_test.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
+	"google.golang.org/protobuf/encoding/protojson"
 	pb "vgpu/api/v1"
 	"vgpu/internal/biz"
 )
@@ -72,6 +74,35 @@ func TestGetAllContainersMatchesPodOrContainerName(t *testing.T) {
 		if len(reply.Items) != 1 {
 			t.Fatalf("GetAllContainers(%q) returned %d items, want 1", filter, len(reply.Items))
 		}
+	}
+}
+
+func TestGetAllContainersMarksUnknownAscendCoreAllocation(t *testing.T) {
+	containers := []*biz.Container{{
+		Name: "worker", PodName: "ascend-job", Status: biz.ContainerStatusSuccess, PodUID: "pod-1", NodeName: "node-1",
+		ContainerDevices: biz.ContainerDevices{{UUID: "ascend-0", Type: "Ascend910B4", Usedmem: 4096, CoreAllocationKnown: false}},
+	}}
+	service := NewContainerService(
+		biz.NewNodeUsecase(&containerTestNodeRepo{}, log.DefaultLogger),
+		biz.NewPodUseCase(&containerTestPodRepo{containers: containers}, log.DefaultLogger),
+	)
+
+	reply, err := service.GetAllContainers(context.Background(), &pb.GetAllContainersReq{})
+	if err != nil {
+		t.Fatalf("GetAllContainers() error = %v", err)
+	}
+	if len(reply.Items) != 1 || reply.Items[0].AllocatedCoresKnown == nil || reply.Items[0].GetAllocatedCoresKnown() {
+		t.Fatalf("allocated core presence = %#v, want explicit unknown", reply.Items)
+	}
+	if reply.Items[0].AllocatedMem != 4096 || len(reply.Items[0].DeviceIds) != 1 {
+		t.Fatalf("unknown core must preserve device and memory allocation: %#v", reply.Items[0])
+	}
+	encoded, err := protojson.Marshal(reply.Items[0])
+	if err != nil {
+		t.Fatalf("marshal reply: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"allocatedCoresKnown":false`) {
+		t.Fatalf("optional false presence was lost in JSON: %s", encoded)
 	}
 }
 

--- a/server/internal/service/node.go
+++ b/server/internal/service/node.go
@@ -34,6 +34,7 @@ func (s *NodeService) GetSummary(ctx context.Context, req *pb.GetSummaryReq) (*p
 	var res = &pb.DeviceSummaryReply{}
 	t, err := s.summary.GetGPUSummary(ctx, filters.DeviceId, filters.NodeUid, filters.Type)
 	copier.Copy(&res, &t)
+	res.CoreUsedKnown = &t.CoreUsedKnown
 	return res, err
 }
 
@@ -106,6 +107,7 @@ func (s *NodeService) GetNode(ctx context.Context, req *pb.GetNodeReq) (*pb.Node
 // passes a pre-fetched container list so per-device usage stats reuse one scan
 // rather than re-listing all containers for each device.
 func (s *NodeService) buildNodeReply(node *biz.Node, containers []*biz.Container) *pb.NodeReply {
+	coreUsedKnown := true
 	nodeReply := &pb.NodeReply{
 		Name:                    node.Name,
 		Uid:                     node.Uid,
@@ -127,11 +129,15 @@ func (s *NodeService) buildNodeReply(node *biz.Node, containers []*biz.Container
 		nodeReply.VgpuTotal += device.Count
 		nodeReply.CoreTotal += device.Devcore
 		nodeReply.MemoryTotal += device.Devmem
-		vGPU, core, memory := biz.ContainersStatisticsInfo(containers, device.AliasId)
+		vGPU, core, memory, coreKnown := biz.ContainersStatisticsInfo(containers, device.AliasId)
 		nodeReply.VgpuUsed += vGPU
 		nodeReply.CoreUsed += core
+		if !coreKnown {
+			coreUsedKnown = false
+		}
 		nodeReply.MemoryUsed += memory
 	}
+	nodeReply.CoreUsedKnown = &coreUsedKnown
 
 	nodeReply.Type = arrutil.Unique(nodeReply.Type)
 	nodeReply.CardCnt = int32(len(node.Devices))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

HAMi derives Ascend allocation annotations from configurable `commonWord` values, while WebUI only consumed two legacy keys and treated unknown core templates as full cards.

This change:
- discovers Node and Pod Ascend annotations from the producer contract while preserving the concrete chip type;
- distinguishes explicit soft mode from hard templates and represents ambiguous or custom core allocations as unavailable instead of guessing;
- normalizes Ascend inventory to the WebUI percentage contract and joins telemetry only by `vdie_id` UUID;
- preserves init-container slots and multi-device aggregation.

Unknown core allocation is rendered as `--`. Device count and memory remain visible, and fake core metrics are not exported.

**Verification**

- Go build, vet, full tests, and targeted race tests
- frontend lint, unit tests, production build, and Chromium contract tests on Node 24
- fixtures for current and future commonWords, official hard templates, soft zero, unknown templates, stale registrations, filtered devices, and init-container alignment

**Which issue(s) this PR fixes**

Fixes #124.

Supersedes #125. Thanks @fyuan1316 for identifying the commonWord gap and contributing the initial mappings and slot coverage.

#47 remains open because Ascend runtime utilization is a separate telemetry path. Physical Ascend hardware validation is still welcome before the 2.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer reporting for Ascend device core allocation and usage when values cannot be determined.
  * Added support for recognizing and reconciling additional Ascend device variants and identifiers.
* **Bug Fixes**
  * GPU, node, task, and container views now display `--` instead of misleading core values when allocation data is unknown.
  * Metrics continue reporting known memory and device allocations while omitting unreliable core measurements.
* **Reliability**
  * Improved device ordering, duplicate handling, validation, and error reporting for Ascend hardware data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->