### PR TITLE
fix(web): synchronize runtime locale

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ElConfigProvider } from 'element-plus';
 import { ConfigProvider as TConfigProvider } from 'tdesign-vue-next';
@@ -15,6 +15,7 @@ import tdesignEnUS from 'tdesign-vue-next/es/locale/en_US';
 import tdesignZhCN from 'tdesign-vue-next/es/locale/zh_CN';
 import zhCn from 'element-plus/es/locale/lang/zh-cn';
 import en from 'element-plus/es/locale/lang/en';
+import { toDocumentLanguage } from '@/locales/language.mjs';
 
 defineOptions({
   name: 'App',
@@ -28,5 +29,13 @@ const elLocale = computed(() => {
 
 const tdGlobalConfig = computed(() =>
   locale.value === 'en' ? tdesignEnUS : tdesignZhCN,
+);
+
+watch(
+  locale,
+  (language) => {
+    document.documentElement.lang = toDocumentLanguage(language);
+  },
+  { immediate: true },
 );
 </script>

--- a/packages/web/src/locales/language.mjs
+++ b/packages/web/src/locales/language.mjs
@@ -10,3 +10,7 @@ export function resolveLanguage(preferredLanguage, browserLanguage) {
   const browser = normalizeLanguage(browserLanguage).replaceAll('_', '-');
   return browser === 'zh' || browser.startsWith('zh-') ? 'zh' : 'en';
 }
+
+export function toDocumentLanguage(language) {
+  return language === 'zh' ? 'zh-CN' : 'en';
+}

--- a/packages/web/src/plugins/element.js
+++ b/packages/web/src/plugins/element.js
@@ -1,6 +1,5 @@
 import ElementPlus from 'element-plus'
-import locale from 'element-plus/dist/locale/zh-cn.mjs'
 
 export default (app) => {
-  app.use(ElementPlus, { locale })
+  app.use(ElementPlus)
 }

--- a/packages/web/test/locale-resolution.test.mjs
+++ b/packages/web/test/locale-resolution.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { resolveLanguage } from '../src/locales/language.mjs';
+import {
+  resolveLanguage,
+  toDocumentLanguage,
+} from '../src/locales/language.mjs';
 
 test('a supported saved preference overrides the browser language', () => {
   assert.equal(resolveLanguage('en', 'zh-CN'), 'en');
@@ -23,4 +26,10 @@ test('other browser locales use the English fallback', () => {
 test('an invalid saved preference does not become an application locale', () => {
   assert.equal(resolveLanguage('fr', 'zh-CN'), 'zh');
   assert.equal(resolveLanguage('zh-CN', 'en-US'), 'en');
+});
+
+test('application locales map to document language tags', () => {
+  assert.equal(toDocumentLanguage('en'), 'en');
+  assert.equal(toDocumentLanguage('zh'), 'zh-CN');
+  assert.equal(toDocumentLanguage('fr'), 'en');
 });

--- a/test/web-entry/web-entry.browser.test.mjs
+++ b/test/web-entry/web-entry.browser.test.mjs
@@ -710,6 +710,61 @@ test('browser language selects English without leaking active Chinese UI text', 
   }
 }, { timeout: 60_000 })
 
+test('runtime language updates the document and Element Plus services', async() => {
+  const target = await startWebEntry({ frameAncestors: undefined })
+  const page = await browser.newPage({ locale: 'en-US' })
+  let failNextNodesRequest = true
+
+  await page.route('**/api/vgpu/v1/nodes**', (route) => {
+    if (!failNextNodesRequest) return route.continue()
+    failNextNodesRequest = false
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 50008,
+        message: 'authentication expired'
+      })
+    })
+  })
+
+  try {
+    await page.goto(
+      `${target}${basePath}admin/vgpu/node/admin`,
+      { waitUntil: 'domcontentloaded' }
+    )
+    await page.locator('html[lang="en"]').waitFor()
+
+    const messageBox = page.locator('.el-message-box')
+    await messageBox.waitFor()
+    await messageBox.locator('.el-button--primary')
+      .filter({ hasText: 'OK' })
+      .click()
+
+    await page.locator('.lang-select-container').click()
+    await page.locator('.lang-dropdown-popper .el-dropdown-menu__item')
+      .filter({ hasText: '中文' })
+      .click()
+    await page.locator('html[lang="zh-CN"]').waitFor()
+
+    failNextNodesRequest = true
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await page.locator('html[lang="zh-CN"]').waitFor()
+    await messageBox.waitFor()
+    await messageBox.locator('.el-button--primary')
+      .filter({ hasText: '确定' })
+      .click()
+
+    await page.locator('.lang-select-container').click()
+    await page.locator('.lang-dropdown-popper .el-dropdown-menu__item')
+      .filter({ hasText: 'English' })
+      .click()
+    await page.locator('html[lang="en"]').waitFor()
+  } finally {
+    await page.close()
+  }
+}, { timeout: 60_000 })
+
 test('detail pages expose truthful asynchronous resource states', async(t) => {
   const target = await startWebEntry({ frameAncestors: undefined })
 


### PR DESCRIPTION
## What

- Let the root `ElConfigProvider` own the Element Plus locale instead of installing a fixed Chinese global locale.
- Keep `<html lang>` synchronized with the selected application language.
- Cover language switching, reload persistence, and command-style `ElMessageBox` text in Chromium.

## Why

The component tree already switched languages, but Element Plus global services stayed in Chinese on the English UI. The document language was also empty, including after a language change.

## Verification

- `make verify` with Node.js 24.19.0
- Chromium: `en -> zh-CN -> reload -> en`
- `ElMessageBox` confirmation: `OK` / `确定`

Part of #211.