### PR TITLE
chore(web): enforce source language hygiene

### DIFF
--- a/.github/workflows/pr-frontend.yaml
+++ b/.github/workflows/pr-frontend.yaml
@@ -45,6 +45,7 @@ jobs:
               - 'server/go.sum'
               - 'server/internal/webentry/**'
               - 'scripts/precompress-web-assets.mjs'
+              - 'scripts/verify-source-language.mjs'
               - 'scripts/verify-toolchain-versions.sh'
               - 'scripts/verify-vite-env-boundary.mjs'
               - 'test/web-entry/**'
@@ -105,8 +106,8 @@ jobs:
       - name: Lint Web-entry tooling and Web
         run: make lint
 
-  # Single required status check: green only if every frontend job passed (or
-  # there were no frontend-relevant changes).
+  # Single required status check: green only if the source-language guard and
+  # every frontend job passed (or there were no frontend-relevant changes).
   pr-frontend-required:
     runs-on: ubuntu-latest
     needs:
@@ -115,6 +116,14 @@ jobs:
       - lint
     if: always()
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+      - name: Verify source language
+        run: node scripts/verify-source-language.mjs
       - name: Aggregate frontend check results
         run: |
           if [[ "${{ needs.changes.result }}" != "success" ]]; then

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "eslint \"test/web-entry/**/*.mjs\" \"scripts/*.mjs\"",
+    "lint": "pnpm run verify:source-language && eslint \"test/web-entry/**/*.mjs\" \"scripts/*.mjs\"",
     "test:web-entry-contract": "node --test --test-concurrency=1 test/web-entry/web-entry.contract.test.mjs",
     "test:web-entry-browser": "node --test --test-concurrency=1 test/web-entry/web-entry.browser.test.mjs",
     "precompress:web-assets": "node scripts/precompress-web-assets.mjs",
-    "verify:vite-env": "node scripts/verify-vite-env-boundary.mjs"
+    "verify:vite-env": "node scripts/verify-vite-env-boundary.mjs",
+    "verify:source-language": "node scripts/verify-source-language.mjs"
   },
   "devDependencies": {
     "axios": "1.18.0",

--- a/packages/web/projects/vgpu/components/config.js
+++ b/packages/web/projects/vgpu/components/config.js
@@ -55,10 +55,10 @@ export const getPreviewBarPie = (statusConfig, { title }) => {
       },
     ],
     grid: {
-      top: 1, // 上边距
-      bottom: 1, // 下边距
-      left: 1, // 左边距
-      right: 1, // 右边距
+      top: 1,
+      bottom: 1,
+      left: 1,
+      right: 1,
     },
   };
 };
@@ -112,10 +112,10 @@ export const getLineOptions = ({
       },
     },
     grid: {
-      top: 20, // 上边距
-      bottom: 30, // 下边距
-      left: 30, // 左边距
-      right: 30, // 右边距
+      top: 20,
+      bottom: 30,
+      left: 30,
+      right: 30,
     },
     dataZoom: [
       {

--- a/packages/web/projects/vgpu/components/previewBar.vue
+++ b/packages/web/projects/vgpu/components/previewBar.vue
@@ -252,7 +252,6 @@ ul {
       overflow-y: auto;
       padding-right: 10px;
 
-      /* 自定义滚动条样式（可选） */
       &::-webkit-scrollbar {
         width: 6px;
       }

--- a/packages/web/projects/vgpu/views/card/admin/getOptions.js
+++ b/packages/web/projects/vgpu/views/card/admin/getOptions.js
@@ -4,7 +4,6 @@ import i18n from '@/locales';
 export const getRangeOptions = ({ core = [], memory = [] }) => {
   return {
     legend: {
-      // data: [],
       bottom: 0,
       left: 'center',
     },
@@ -28,10 +27,10 @@ export const getRangeOptions = ({ core = [], memory = [] }) => {
       },
     },
     grid: {
-      top: 20, // 上边距
-      bottom: 60, // 下边距
-      left: '8%', // 左边距
-      right: 10, // 右边距
+      top: 20,
+      bottom: 60,
+      left: '8%',
+      right: 10,
     },
     xAxis: {
       type: 'category',
@@ -44,7 +43,6 @@ export const getRangeOptions = ({ core = [], memory = [] }) => {
     },
     yAxis: {
       type: 'value',
-      // max: 100,
       axisLabel: {
         formatter: function (value) {
           return `${value} %`;
@@ -57,10 +55,10 @@ export const getRangeOptions = ({ core = [], memory = [] }) => {
         data: core,
         type: 'line',
         itemStyle: {
-          color: 'rgb(84, 112, 198)', // 设置线条颜色为橙色
+          color: 'rgb(84, 112, 198)',
         },
         lineStyle: {
-          color: 'rgb(84, 112, 198)', // 设置线条颜色为橙色
+          color: 'rgb(84, 112, 198)',
         },
       },
       {
@@ -68,10 +66,10 @@ export const getRangeOptions = ({ core = [], memory = [] }) => {
         data: memory,
         type: 'line',
         itemStyle: {
-          color: 'rgb(145, 204, 117)', // 设置线条颜色为橙色
+          color: 'rgb(145, 204, 117)',
         },
         lineStyle: {
-          color: 'rgb(145, 204, 117)', // 设置线条颜色为橙色
+          color: 'rgb(145, 204, 117)',
         },
       },
     ],

--- a/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
+++ b/packages/web/projects/vgpu/views/monitor/overview/getOptions.js
@@ -146,7 +146,6 @@ export const getRangeOptions = (data) => {
   return {
     animation: true,
     legend: {
-      // data: [],
       bottom: 10,
       left: 'center',
     },
@@ -184,10 +183,10 @@ export const getRangeOptions = (data) => {
       },
     },
     grid: {
-      top: 20, // 上边距
-      bottom: 60, // 下边距
-      left: '7%', // 左边距
-      right: 10, // 右边距
+      top: 20,
+      bottom: 60,
+      left: '7%',
+      right: 10,
     },
     dataZoom: [
       {
@@ -202,18 +201,11 @@ export const getRangeOptions = (data) => {
       axisLabel: {
         formatter: function (value) {
           return timeParse(value, 'HH:mm');
-          // return timeParse(value, 'MM-DD');
         },
-        // interval: function (index, value) {
-        //   var date = new Date(value);
-        //
-        //   return date.getHours() % 2 === 0 && date.getMinutes() === 0;
-        // },
       },
     },
     yAxis: {
       type: 'value',
-      // max: 100,
       axisLabel: {
         formatter: function (value) {
           return `${value}`;
@@ -223,28 +215,6 @@ export const getRangeOptions = (data) => {
     series: normalizedData.map((item) =>
       buildRangeLineSeries({
         ...item,
-        // areaStyle: {
-        //   normal: {
-        //     color: {
-        //       type: 'linear',
-        //       x: 0, // 渐变起始点 0%
-        //       y: 0, // 渐变起始点 0%
-        //       x2: 0, // 渐变结束点 100%
-        //       y2: 1, // 渐变结束点 100%
-        //       colorStops: [
-        //         {
-        //           offset: 0,
-        //           color: 'rgba(34, 139, 34, 0.16)', // 渐变起始颜色
-        //         },
-        //         {
-        //           offset: 1,
-        //           color: 'rgba(34, 139, 34, 0.00)', // 渐变结束颜色
-        //         },
-        //       ],
-        //       global: false, // 缺省为 false
-        //     },
-        //   },
-        // },
       }),
     ),
   };

--- a/packages/web/projects/vgpu/views/node/admin/getOptions.js
+++ b/packages/web/projects/vgpu/views/node/admin/getOptions.js
@@ -52,10 +52,10 @@ export const getRangeOptions = (
       formatter: buildPercentTooltipFormatter(),
     },
     grid: {
-      top: 20, // 上边距
-      bottom: 60, // 下边距
-      left: '7%', // 左边距
-      right: 10, // 右边距
+      top: 20,
+      bottom: 60,
+      left: '7%',
+      right: 10,
     },
     dataZoom: [
       {

--- a/packages/web/src/components/Confirm/index.vue
+++ b/packages/web/src/components/Confirm/index.vue
@@ -68,26 +68,6 @@ import { Modal } from 'bootstrap';
 import i18n from '@/locales';
 
 export default {
-  //   props: {
-  //     confirmText: {
-  //       type: String,
-  //       default: '',
-  //     },
-  //     confirmObj: {
-  //       type: Object,
-  //       default: () => {
-  //         return {
-  //           confirmButtonText: '确定',
-  //           cancelButtonText: '取消',
-  //           type: '',
-  //         };
-  //       },
-  //     },
-  //     fn: {
-  //       type: Function,
-  //       default: null,
-  //     },
-  //   },
   data() {
     return {
       removeModal: null,

--- a/packages/web/src/components/LangSelect/index.vue
+++ b/packages/web/src/components/LangSelect/index.vue
@@ -83,7 +83,7 @@ const handleSetLanguage = (lang) => {
 </style>
 
 <style lang="scss">
-// 全局样式，用于定制 Popper 弹窗
+// The dropdown is teleported outside this component, so these overrides must stay global.
 .lang-dropdown-popper {
   .el-dropdown-menu {
     padding: 6px;
@@ -97,7 +97,7 @@ const handleSetLanguage = (lang) => {
     border-radius: 4px;
     margin: 2px 0;
     line-height: 1.5;
-    font-weight: 400; // 默认正常粗细
+    font-weight: 400;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -109,11 +109,10 @@ const handleSetLanguage = (lang) => {
       color: var(--el-color-primary);
     }
     
-    // 选中状态样式
     &.is-selected {
       color: var(--el-color-primary);
       font-weight: 600;
-      background-color: var(--el-color-primary-light-9); // 非常淡的背景，或者直接透明
+      background-color: var(--el-color-primary-light-9);
     }
 
     .dropdown-item-text {
@@ -126,7 +125,6 @@ const handleSetLanguage = (lang) => {
     }
   }
   
-  // 隐藏默认的箭头，看起来更干净
   .el-popper__arrow {
     display: none;
   }

--- a/packages/web/src/components/SvgIcon/index.vue
+++ b/packages/web/src/components/SvgIcon/index.vue
@@ -14,32 +14,21 @@
 import { isExternal as external } from '@/utils/validate';
 import { computed } from 'vue';
 const props = defineProps({
-  // icon 图标
   icon: {
     type: String,
     required: true,
   },
-  // 图标类名
   className: {
     type: String,
     default: '',
   },
 });
 
-/**
- * 判断是否为外部图标
- */
 const isExternal = computed(() => external(props.icon));
-/**
- * 外部图标样式
- */
 const styleExternalIcon = computed(() => ({
   mask: `url(${props.icon}) no-repeat 50% 50%`,
   '-webkit-mask': `url(${props.icon}) no-repeat 50% 50%`,
 }));
-/**
- * 项目内图标
- */
 const iconName = computed(() => `#icon-${props.icon}`);
 </script>
 

--- a/packages/web/src/main.js
+++ b/packages/web/src/main.js
@@ -8,7 +8,6 @@ import './plugins/echarts';
 import 'normalize.css/normalize.css'; // a modern alternative to CSS resets
 import '@/styles/index.scss'; // global css
 
-// 导入 svgIcon
 import installIcons from '@/icons';
 import Message from '@/components/Message/index.js';
 import Confirm from '@/components/Confirm/index.js';

--- a/packages/web/src/store/index.js
+++ b/packages/web/src/store/index.js
@@ -12,7 +12,7 @@ Object.keys(viteModules).forEach((key) => {
 
 const global = createPersistedState({
   key: 'global',
-  storage: window.localStorage, //window.localStorage
+  storage: window.localStorage,
   paths: ['global'],
 });
 
@@ -20,7 +20,6 @@ const store = new createStore({
   state: {},
   modules,
   getters,
-  // 将各个插件引用
   plugins: [global],
 });
 

--- a/packages/web/src/store/modules/global.js
+++ b/packages/web/src/store/modules/global.js
@@ -3,8 +3,6 @@ const global = {
     regionData: {},
   },
   mutations: {
-    // 这里填充数据的操作方法
-    // 提交方法 $store.commit('changeHello',value)
     changeRegion: (state, regionData) => {
       state.regionData = regionData;
     },

--- a/packages/web/src/store/modules/layout.js
+++ b/packages/web/src/store/modules/layout.js
@@ -3,8 +3,6 @@ const layout = {
     sidebarCollapse: false,
   },
   mutations: {
-    // 这里填充数据的操作方法
-    // 提交方法 $store.commit('changeHello',value)
     changeSidebarCollapse: (state) => {
       state.sidebarCollapse = !state.sidebarCollapse;
     },

--- a/packages/web/src/utils/index.js
+++ b/packages/web/src/utils/index.js
@@ -22,17 +22,14 @@ export const timeParse = (obj = new Date(), format = 'YYYY-MM-DD HH:mm:ss') => {
 
 export function roundToDecimal(num, decimalPlaces) {
   if (typeof num !== 'number' || typeof decimalPlaces !== 'number') {
-    throw new TypeError('参数必须是数字');
+    throw new TypeError('num and decimalPlaces must be numbers');
   }
 
-  // 判断是否是小数
   if (num % 1 !== 0) {
-    // 进行四舍五入
     const factor = Math.pow(10, decimalPlaces);
     return Math.round(num * factor) / factor;
   }
 
-  // 如果不是小数，返回原数字
   return num;
 }
 

--- a/scripts/verify-source-language.mjs
+++ b/scripts/verify-source-language.mjs
@@ -1,0 +1,204 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CJK_SOURCE_CHAR =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Bopomofo}]/u;
+
+const FIRST_PARTY_PREFIXES = [
+  '.github/',
+  'charts/',
+  'packages/web/',
+  'scripts/',
+  'server/',
+];
+
+const ROOT_SOURCE_FILES = new Set([
+  '.browserslistrc',
+  '.dockerignore',
+  '.eslintignore',
+  '.eslintrc.js',
+  '.node-version',
+  '.prettierrc',
+  'Dockerfile',
+  'Makefile',
+  'package.json',
+  'pnpm-workspace.yaml',
+]);
+
+const TEXT_EXTENSIONS = new Set([
+  '.cjs',
+  '.css',
+  '.go',
+  '.html',
+  '.js',
+  '.json',
+  '.jsx',
+  '.mjs',
+  '.mod',
+  '.proto',
+  '.scss',
+  '.sh',
+  '.toml',
+  '.tpl',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.vue',
+  '.yaml',
+  '.yml',
+]);
+
+const TEXT_BASENAMES = new Set([
+  '.browserslistrc',
+  '.dockerignore',
+  '.env.development',
+  '.env.production',
+  '.eslintignore',
+  '.gitignore',
+  '.go-version',
+  '.helmignore',
+  '.node-version',
+  '.prettierrc',
+  'Dockerfile',
+  'Makefile',
+]);
+
+const EXCLUDED_FILES = new Set([
+  'packages/web/src/locales/en.js',
+  'packages/web/src/locales/zh.js',
+  'server/openapi.yaml',
+]);
+
+const EXCLUDED_PREFIXES = [
+  'packages/web/public/',
+  'packages/web/src/assets/',
+  'packages/web/src/icons/svg/',
+  'packages/web/test/',
+  'scripts/chart/tests/',
+  'scripts/release/tests/',
+  'server/third_party/',
+  'test/',
+];
+
+const isGeneratedSource = (filePath) => {
+  const basename = path.posix.basename(filePath);
+  return (
+    basename === 'wire_gen.go' ||
+    basename.startsWith('zz_generated.') ||
+    filePath.endsWith('.pb.go') ||
+    filePath.endsWith('.pb.gw.go')
+  );
+};
+
+const isTestFixture = (filePath) => {
+  const basename = path.posix.basename(filePath);
+  return (
+    basename.includes('.test.') ||
+    basename.includes('.spec.') ||
+    basename.endsWith('_test.go')
+  );
+};
+
+const isTextSource = (filePath) => {
+  const basename = path.posix.basename(filePath);
+  return (
+    TEXT_BASENAMES.has(basename) || TEXT_EXTENSIONS.has(path.posix.extname(filePath))
+  );
+};
+
+const shouldScanPath = (filePath) => {
+  if (
+    EXCLUDED_FILES.has(filePath) ||
+    EXCLUDED_PREFIXES.some((prefix) => filePath.startsWith(prefix)) ||
+    isGeneratedSource(filePath) ||
+    isTestFixture(filePath)
+  ) {
+    return false;
+  }
+
+  const isFirstParty =
+    ROOT_SOURCE_FILES.has(filePath) ||
+    FIRST_PARTY_PREFIXES.some((prefix) => filePath.startsWith(prefix));
+  return isFirstParty && isTextSource(filePath);
+};
+
+const assertGuardContract = () => {
+  const matchingCodePoints = [0x6c49, 0x20000, 0x3042, 0x30a2, 0xac00, 0x3105];
+  for (const codePoint of matchingCodePoints) {
+    if (!CJK_SOURCE_CHAR.test(String.fromCodePoint(codePoint))) {
+      throw new Error(`CJK source regex must match U+${codePoint.toString(16)}`);
+    }
+  }
+
+  const nonMatchingCodePoints = [0x41, 0xb7, 0x2022, 0x1f680];
+  for (const codePoint of nonMatchingCodePoints) {
+    if (CJK_SOURCE_CHAR.test(String.fromCodePoint(codePoint))) {
+      throw new Error(`CJK source regex must not match U+${codePoint.toString(16)}`);
+    }
+  }
+
+  const pathAssertions = [
+    ['.github/workflows/pr-frontend.yaml', true],
+    ['charts/hami-webui/templates/deployment.yaml', true],
+    ['packages/web/src/main.js', true],
+    ['packages/web/src/locales/runtime.js', true],
+    ['scripts/verify-source-language.mjs', true],
+    ['server/internal/app.go', true],
+    ['.browserslistrc', true],
+    ['.eslintignore', true],
+    ['.node-version', true],
+    ['.prettierrc', true],
+    ['package.json', true],
+    ['README_ZH.md', false],
+    ['packages/web/src/locales/en.js', false],
+    ['packages/web/src/locales/zh.js', false],
+    ['packages/web/test/locale-resolution.test.mjs', false],
+    ['packages/web/src/example.test.mjs', false],
+    ['packages/web/src/assets/example.css', false],
+    ['packages/web/src/icons/svg/example.svg', false],
+    ['scripts/chart/tests/example.yaml', false],
+    ['scripts/release/tests/example.sh', false],
+    ['server/internal/app_test.go', false],
+    ['server/third_party/example.proto', false],
+    ['server/openapi.yaml', false],
+    ['server/api/v1/example.pb.go', false],
+    ['server/cmd/hami-webui/wire_gen.go', false],
+    ['pnpm-lock.yaml', false],
+  ];
+
+  for (const [filePath, expected] of pathAssertions) {
+    if (shouldScanPath(filePath) !== expected) {
+      throw new Error(`Unexpected source-language path rule for ${filePath}`);
+    }
+  }
+};
+
+assertGuardContract();
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const trackedFiles = execFileSync('git', ['-C', repoRoot, 'ls-files', '-z'], {
+  encoding: 'utf8',
+})
+  .split('\0')
+  .filter(Boolean);
+const sourceFiles = trackedFiles.filter(shouldScanPath);
+const violations = [];
+
+for (const filePath of sourceFiles) {
+  const lines = readFileSync(path.join(repoRoot, filePath), 'utf8').split(/\r?\n/u);
+  lines.forEach((line, index) => {
+    if (CJK_SOURCE_CHAR.test(line)) {
+      violations.push(`${filePath}:${index + 1}: ${line.trim()}`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error('CJK script characters are not allowed in active first-party source:');
+  violations.forEach((violation) => console.error(violation));
+  process.exit(1);
+}
+
+console.log(`Source language check passed (${sourceFiles.length} tracked files scanned).`);


### PR DESCRIPTION
## What

Remove redundant, misleading, or obsolete CJK comments and commented-out code from active frontend source. Keep one implementation rationale in concise English and translate the developer-facing numeric `TypeError`.

Add a tracked-file source-language guard with exact exclusions for locale catalogs, tests, assets, third-party code, and generated files. The guard has no baseline allowlist and runs both through local lint and the existing always-run `pr-frontend-required` job.

## Why

Localized product copy belongs in the locale catalogs, while active first-party source should remain reviewable in the project's shared development language. The guard prevents the same drift without creating another required status or triggering expensive frontend tests for unrelated PRs.

## Verification

- Guard passes across 229 tracked first-party text files
- Temporary Vue and Go violations report exact line numbers and exit 1
- Locale, test, asset, third-party, and generated fixtures remain excluded
- Unicode contract covers Han, Hiragana, Katakana, Hangul, and Bopomofo without matching `·`, emoji, or bullets
- Node.js 24 and pnpm 10.25.0 frozen install
- `make verify`, including 10 Web-entry contracts and 15 Chromium browser tests
- Workflow/toolchain validation and `git diff --check`

Part of #211.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated source-language verification to linting and required frontend checks.
  * Verification reports files and line numbers containing unsupported CJK characters.

* **Bug Fixes**
  * Standardized a utility error message in English.

* **Documentation**
  * Cleaned up outdated and commented-out source documentation without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->