### PR TITLE
ci: update QEMU setup action to Node 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
           platforms: arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,7 +214,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
           platforms: arm64


### PR DESCRIPTION
## What

Pin `docker/setup-qemu-action` v4.2.0 in the development image smoke and stable release workflows. The pinned binfmt image and `arm64` platform input are unchanged.

## Why

The v4 action runs on Node.js 24, removing the deprecated Node.js 20 action runtime while preserving the existing QEMU setup contract.

## Verification

- Official v4.2.0 tag and immutable commit SHA verified
- `actionlint` 1.7.7
- Deterministic release-controller contract tests
- Toolchain pin, source-language guard, and `git diff --check`
- Existing PR image smoke will build and run both amd64 and arm64 images

Part of #211.