### PR TITLE
ci(release): migrate artifact transport to Node 24

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -67,11 +67,85 @@ jobs:
       - name: Run deterministic release contract tests
         run: bash scripts/release/tests/release-controller.sh
 
+  artifact-producer:
+    name: Upload release handoff fixtures
+    needs: changes
+    if: needs.changes.outputs.release == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Create distinct handoff fixtures
+        run: |
+          mkdir -p "${RUNNER_TEMP}/artifact-contract/part-a"
+          mkdir -p "${RUNNER_TEMP}/artifact-contract/part-b"
+          printf 'artifact-part-a\n' >"${RUNNER_TEMP}/artifact-contract/part-a/part-a.txt"
+          printf 'artifact-part-b\n' >"${RUNNER_TEMP}/artifact-contract/part-b/part-b.txt"
+
+      - name: Upload part A
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-a
+          path: ${{ runner.temp }}/artifact-contract/part-a/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload part B
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-b
+          path: ${{ runner.temp }}/artifact-contract/part-b/
+          if-no-files-found: error
+          retention-days: 1
+
+  artifact-consumer:
+    name: Verify release handoff downloads
+    needs:
+      - changes
+      - artifact-producer
+    if: needs.changes.outputs.release == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download one part by name
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-a
+          path: ${{ runner.temp }}/artifact-contract/by-name
+
+      - name: Download and merge all parts by pattern
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-*
+          path: ${{ runner.temp }}/artifact-contract/merged
+          merge-multiple: true
+
+      - name: Download through the authenticated handoff path
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-b
+          path: ${{ runner.temp }}/artifact-contract/authenticated
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
+
+      - name: Verify every downloaded byte and layout
+        run: |
+          set -euo pipefail
+          [[ "$(cat "${RUNNER_TEMP}/artifact-contract/by-name/part-a.txt")" == 'artifact-part-a' ]]
+          [[ "$(cat "${RUNNER_TEMP}/artifact-contract/merged/part-a.txt")" == 'artifact-part-a' ]]
+          [[ "$(cat "${RUNNER_TEMP}/artifact-contract/merged/part-b.txt")" == 'artifact-part-b' ]]
+          [[ "$(cat "${RUNNER_TEMP}/artifact-contract/authenticated/part-b.txt")" == 'artifact-part-b' ]]
+          [[ "$(find "${RUNNER_TEMP}/artifact-contract/merged" -type f | wc -l | tr -d ' ')" == '2' ]]
+
   pr-release-required:
     name: pr-release-required
     needs:
       - changes
       - validate
+      - artifact-producer
+      - artifact-consumer
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -88,6 +162,14 @@ jobs:
           fi
           if [[ "${{ needs.validate.result }}" != "success" ]]; then
             echo "Release controller checks did not complete successfully: ${{ needs.validate.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.artifact-producer.result }}" != "success" ]]; then
+            echo "Release artifact upload did not complete successfully: ${{ needs.artifact-producer.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.artifact-consumer.result }}" != "success" ]]; then
+            echo "Release artifact download did not complete successfully: ${{ needs.artifact-consumer.result }}"
             exit 1
           fi
           echo "All release controller checks passed."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
           } >>"${GITHUB_OUTPUT}"
 
       - name: Upload the fixed bootstrap package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-oci-bootstrap-${{ github.run_id }}
           path: bootstrap-bundle/
@@ -123,7 +123,7 @@ jobs:
           persist-credentials: false
 
       - name: Download the same bootstrap package
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-oci-bootstrap-${{ github.run_id }}
           path: bootstrap-bundle
@@ -267,7 +267,7 @@ jobs:
             candidate-metadata/webui.json
 
       - name: Upload image metadata
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate-part-${{ github.run_id }}-webui
           path: candidate-metadata/webui.json
@@ -292,7 +292,7 @@ jobs:
           persist-credentials: false
 
       - name: Download image metadata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-candidate-part-${{ github.run_id }}-*
           path: candidate-parts
@@ -313,7 +313,7 @@ jobs:
             "${GITHUB_RUN_ATTEMPT}"
 
       - name: Upload sealed candidate
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate-${{ github.run_id }}
           path: candidate.json
@@ -362,7 +362,7 @@ jobs:
           persist-credentials: false
 
       - name: Download sealed candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-candidate-${{ inputs.candidate_run_id }}
           path: candidate
@@ -422,7 +422,7 @@ jobs:
             release-bundle
 
       - name: Upload canonical release bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-bundle-${{ github.run_id }}
           path: release-bundle/
@@ -481,7 +481,7 @@ jobs:
           persist-credentials: false
 
       - name: Download the canonical bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-bundle-${{ github.run_id }}
           path: release-bundle


### PR DESCRIPTION
## What

Update the release controller to `actions/upload-artifact` v7.0.1 and `actions/download-artifact` v8.0.1, both pinned to immutable Node.js 24 commits.

Add a required PR round-trip with two one-day fixtures. It verifies by-name download, pattern merging, and the authenticated `github-token` + `run-id` handoff used by release publication.

## Why

The old actions run on Node.js 20, which GitHub is removing from hosted runners. The stable release workflow is dispatch-only, so syntax checks alone did not prove its artifact transport. Download v8 also fails closed on digest mismatch, matching the release contract.

## Local verification

- Official release tags, immutable SHAs, inputs, and Node.js 24 runtimes verified
- `actionlint` 1.7.7 with ShellCheck integration
- Deterministic release-controller contract tests
- Toolchain, install-documentation, source-language, and diff checks
- Independent producer/consumer and required-state review

Part of #209.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved release validation by verifying that required handoff artifacts are successfully created, transferred, downloaded, and authenticated.
  * Release completion now stops when artifact upload or download checks fail, helping prevent incomplete releases.

* **Maintenance**
  * Updated release artifact handling to use newer, pinned workflow tooling for more consistent and dependable uploads and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->