### PR TITLE
ci: replace Node 20 protoc setup action

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   GOLANGCI_VERSION: "v2.12"
-  PROTOC_VERSION: "28.3"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,11 +54,10 @@ jobs:
           cache-dependency-path: server/go.sum
       - name: Verify toolchain versions
         run: bash ../scripts/verify-toolchain-versions.sh
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install checksum-verified protoc
+        run: |
+          bash hack/install-protoc.sh "${RUNNER_TEMP}/protoc"
+          echo "${RUNNER_TEMP}/protoc/bin" >>"${GITHUB_PATH}"
       - name: Install codegen tools (wire / kratos / protoc-gen-*)
         run: make install-deps
       - name: Generate, build, vet, and test
@@ -81,11 +79,10 @@ jobs:
         with:
           go-version-file: server/.go-version
           cache-dependency-path: server/go.sum
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install checksum-verified protoc
+        run: |
+          bash hack/install-protoc.sh "${RUNNER_TEMP}/protoc"
+          echo "${RUNNER_TEMP}/protoc/bin" >>"${GITHUB_PATH}"
       - name: Install codegen tools (wire / kratos / protoc-gen-*)
         run: make install-deps
       - name: Generate proto + wire
@@ -102,6 +99,25 @@ jobs:
           # by golangci-lint automatically.
           only-new-issues: true
 
+  # Cross-platform image builds execute protoc on BUILDPLATFORM, so an x86
+  # runner does not exercise the arm64 archive when it builds an arm64 binary.
+  protoc-arm64:
+    name: Verify arm64 protoc installer
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up arm64 execution
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+      - name: Install and execute the arm64 archive
+        run: bash server/hack/install-protoc.sh "${RUNNER_TEMP}/protoc-arm64" arm64
+
   # Single required status check: green only if every Go job passed (or there
   # were no Go-relevant changes).
   pr-go-required:
@@ -110,6 +126,7 @@ jobs:
       - changes
       - build-test
       - lint
+      - protoc-arm64
     if: always()
     steps:
       - name: Aggregate Go check results
@@ -124,7 +141,8 @@ jobs:
           fi
           for result in \
             "${{ needs.build-test.result }}" \
-            "${{ needs.lint.result }}"; do
+            "${{ needs.lint.result }}" \
+            "${{ needs.protoc-arm64.result }}"; do
             if [[ "${result}" != "success" ]]; then
               echo "Go checks did not complete successfully: ${result}"
               exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,6 @@ FROM go-base AS unified-builder
 
 ARG BUILDARCH
 ARG TARGETARCH
-ARG PROTOC_VERSION=28.3
-ARG PROTOC_SHA256_AMD64=0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f
-ARG PROTOC_SHA256_ARM64=1de522032a8b194002fe35cab86d747848238b5e4de4f99648372079f5b46f9a
 ARG DEBIAN_SNAPSHOT=20260824T000000Z
 ARG UNZIP_VERSION=6.0-28
 
@@ -87,16 +84,9 @@ RUN sed -i -E \
     test -s /etc/ssl/certs/ca-certificates.crt && \
     rm -rf /var/lib/apt/lists/*
 
-RUN case "${BUILDARCH}" in \
-      amd64) protoc_arch="x86_64"; protoc_sha="${PROTOC_SHA256_AMD64}" ;; \
-      arm64) protoc_arch="aarch_64"; protoc_sha="${PROTOC_SHA256_ARM64}" ;; \
-      *) echo "unsupported build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
-    esac && \
-    curl -fsSLo /tmp/protoc.zip \
-      "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip" && \
-    echo "${protoc_sha}  /tmp/protoc.zip" | sha256sum -c - && \
-    unzip -q /tmp/protoc.zip -d /usr/local && \
-    rm /tmp/protoc.zip
+COPY server/hack/install-protoc.sh /tmp/install-protoc.sh
+RUN bash /tmp/install-protoc.sh /usr/local "${BUILDARCH}" && \
+    rm /tmp/install-protoc.sh
 
 COPY server/Makefile ./
 RUN make install-deps

--- a/scripts/verify-toolchain-versions.sh
+++ b/scripts/verify-toolchain-versions.sh
@@ -9,5 +9,14 @@ go_version="$(<"${repo_root}/server/.go-version")"
 grep -Fq "node:${node_version}-bookworm@" "${repo_root}/Dockerfile"
 grep -Fq "golang:${go_version}-bookworm@" "${repo_root}/Dockerfile"
 grep -Fq "golang:${go_version}-bookworm@" "${repo_root}/server/Dockerfile"
+grep -Fq "server/hack/install-protoc.sh" "${repo_root}/Dockerfile"
+grep -Fq "hack/install-protoc.sh" "${repo_root}/server/Dockerfile"
+go_workflow="${repo_root}/.github/workflows/pr-go.yaml"
+ci_installer="bash hack/install-protoc.sh \"\${RUNNER_TEMP}/protoc\""
+[[ "$(grep -Fc "${ci_installer}" "${go_workflow}")" == "2" ]]
+if grep -Fq "arduino/setup-protoc" "${go_workflow}"; then
+  echo "pr-go.yaml still depends on the Node.js setup-protoc action" >&2
+  exit 1
+fi
 
-echo "Toolchain versions match their pinned Docker images."
+echo "Toolchain versions and the protoc installer match every build path."

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /src
 
 ARG BUILDARCH
 ARG TARGETARCH
-ARG PROTOC_VERSION=28.3
-ARG PROTOC_SHA256_AMD64=0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f
-ARG PROTOC_SHA256_ARM64=1de522032a8b194002fe35cab86d747848238b5e4de4f99648372079f5b46f9a
 ARG DEBIAN_SNAPSHOT=20260824T000000Z
 ARG UNZIP_VERSION=6.0-28
 
@@ -22,18 +19,10 @@ RUN sed -i -E \
     test -s /etc/ssl/certs/ca-certificates.crt && \
     rm -rf /var/lib/apt/lists/*
 
-# Install the exact protoc release used by CI. The archive checksum makes this
-# input immutable.
-RUN case "${BUILDARCH}" in \
-      amd64) protoc_arch="x86_64"; protoc_sha="${PROTOC_SHA256_AMD64}" ;; \
-      arm64) protoc_arch="aarch_64"; protoc_sha="${PROTOC_SHA256_ARM64}" ;; \
-      *) echo "unsupported build architecture: ${BUILDARCH}" >&2; exit 1 ;; \
-    esac && \
-    curl -fsSLo /tmp/protoc.zip \
-      "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${protoc_arch}.zip" && \
-    echo "${protoc_sha}  /tmp/protoc.zip" | sha256sum -c - && \
-    unzip -q /tmp/protoc.zip -d /usr/local && \
-    rm /tmp/protoc.zip
+# Install the same checksum-verified protoc release used by CI.
+COPY hack/install-protoc.sh /tmp/install-protoc.sh
+RUN bash /tmp/install-protoc.sh /usr/local "${BUILDARCH}" && \
+    rm /tmp/install-protoc.sh
 
 # Install code generators at versions compatible with the application's locked
 # Go dependencies. Never resolve release inputs from @latest.

--- a/server/hack/install-protoc.sh
+++ b/server/hack/install-protoc.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly PROTOC_VERSION="28.3"
+readonly PROTOC_SHA256_AMD64="0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f"
+readonly PROTOC_SHA256_ARM64="1de522032a8b194002fe35cab86d747848238b5e4de4f99648372079f5b46f9a"
+
+install_prefix="${1:-/usr/local}"
+architecture="${2:-$(uname -m)}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "the pinned protoc installer supports Linux only" >&2
+  exit 1
+fi
+
+case "${architecture}" in
+  amd64 | x86_64)
+    release_arch="x86_64"
+    archive_sha256="${PROTOC_SHA256_AMD64}"
+    ;;
+  arm64 | aarch64 | aarch_64)
+    release_arch="aarch_64"
+    archive_sha256="${PROTOC_SHA256_ARM64}"
+    ;;
+  *)
+    echo "unsupported protoc architecture: ${architecture}" >&2
+    exit 1
+    ;;
+esac
+
+for command in curl sha256sum unzip; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    echo "required command not found: ${command}" >&2
+    exit 1
+  }
+done
+
+install -d "${install_prefix}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+archive="${work_dir}/protoc.zip"
+
+curl --fail --location --silent --show-error \
+  --output "${archive}" \
+  "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${release_arch}.zip"
+printf '%s  %s\n' "${archive_sha256}" "${archive}" | sha256sum --check --status
+unzip -q -o "${archive}" -d "${install_prefix}"
+
+installed_version="$("${install_prefix}/bin/protoc" --version)"
+if [[ "${installed_version}" != "libprotoc ${PROTOC_VERSION}" ]]; then
+  echo "unexpected protoc version: ${installed_version}" >&2
+  exit 1
+fi
+
+printf 'Installed protoc %s for %s in %s\n' \
+  "${PROTOC_VERSION}" "${architecture}" "${install_prefix}"


### PR DESCRIPTION
/kind cleanup

## What

Replace `arduino/setup-protoc@v3`, which still runs on Node 20, with one Linux installer shared by CI and both Docker build paths.

The installer pins protoc 28.3 and the official amd64/arm64 archive checksums, verifies the downloaded archive, and executes the installed binary to confirm its version. CI installs it under `RUNNER_TEMP` without `sudo`; Docker builders use the same script with `BUILDARCH`.

An arm64/QEMU check is included because cross-platform image builds run code generators on `BUILDPLATFORM`, so an x86 runner would otherwise never execute the arm64 archive.

## Verification

- ShellCheck and Actionlint
- amd64 and arm64 installer execution: `libprotoc 28.3`
- unified image builds for linux/amd64 and linux/arm64
- standalone backend image build for linux/amd64
- toolchain and source-language guards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and security of Protocol Buffers compiler installation across Docker builds and Go checks.
  * Added checksum verification and version validation to prevent invalid or tampered downloads.
  * Added support for arm64 build validation.
  * Builds now provide clearer errors for unsupported platforms, architectures, or missing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->