### PR TITLE
ci(release): migrate Pages deployment to Node 24

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -78,8 +78,10 @@ jobs:
         run: |
           mkdir -p "${RUNNER_TEMP}/artifact-contract/part-a"
           mkdir -p "${RUNNER_TEMP}/artifact-contract/part-b"
+          mkdir -p "${RUNNER_TEMP}/artifact-contract/pages"
           printf 'artifact-part-a\n' >"${RUNNER_TEMP}/artifact-contract/part-a/part-a.txt"
           printf 'artifact-part-b\n' >"${RUNNER_TEMP}/artifact-contract/part-b/part-b.txt"
+          printf 'pages-artifact-v5\n' >"${RUNNER_TEMP}/artifact-contract/pages/index.html"
 
       - name: Upload part A
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -95,6 +97,13 @@ jobs:
           name: pr-release-artifact-${{ github.run_id }}-${{ github.run_attempt }}-part-b
           path: ${{ runner.temp }}/artifact-contract/part-b/
           if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Pages fixture
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          name: pr-release-pages-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/artifact-contract/pages/
           retention-days: 1
 
   artifact-consumer:
@@ -130,6 +139,12 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.run_id }}
 
+      - name: Download the Pages fixture
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-release-pages-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/artifact-contract/pages-download
+
       - name: Verify every downloaded byte and layout
         run: |
           set -euo pipefail
@@ -138,6 +153,18 @@ jobs:
           [[ "$(cat "${RUNNER_TEMP}/artifact-contract/merged/part-b.txt")" == 'artifact-part-b' ]]
           [[ "$(cat "${RUNNER_TEMP}/artifact-contract/authenticated/part-b.txt")" == 'artifact-part-b' ]]
           [[ "$(find "${RUNNER_TEMP}/artifact-contract/merged" -type f | wc -l | tr -d ' ')" == '2' ]]
+          pages_archive="${RUNNER_TEMP}/artifact-contract/pages-download/artifact.tar"
+          mapfile -t pages_entries < <(tar -tf "${pages_archive}")
+          [[ "${#pages_entries[@]}" == '2' ]]
+          [[ "${pages_entries[0]}" == './' ]]
+          [[ "${pages_entries[1]}" == './index.html' ]]
+          mkdir -p "${RUNNER_TEMP}/artifact-contract/pages-unpacked"
+          tar -xf "${pages_archive}" \
+            -C "${RUNNER_TEMP}/artifact-contract/pages-unpacked"
+          pages_index="${RUNNER_TEMP}/artifact-contract/pages-unpacked/index.html"
+          [[ -f "${pages_index}" && ! -L "${pages_index}" ]]
+          printf 'pages-artifact-v5\n' >"${RUNNER_TEMP}/artifact-contract/pages-expected"
+          cmp --silent "${RUNNER_TEMP}/artifact-contract/pages-expected" "${pages_index}"
 
   pr-release-required:
     name: pr-release-required

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -599,13 +599,13 @@ jobs:
             "${PAGES_URL}"
 
       - name: Upload explicit Pages deployment artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: pages
 
       - name: Deploy GitHub Pages explicitly
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
           artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
 


### PR DESCRIPTION
/kind cleanup

## What

Update the stable Pages transport to the official Node 24 releases:

- `actions/upload-pages-artifact@v5.0.0`
- `actions/deploy-pages@v5.0.0`

The PR release contract now uploads a custom-named Pages artifact, downloads its `artifact.tar`, and verifies the exact unpacked content and layout. This keeps the archive contract executable without mutating the upstream Pages site.

## Verification

- Actionlint and release-controller contract tests
- Official v5 tag SHAs verified
- Disposable fork canary used the same pins and custom artifact name
- Canary deployed through a branch-protected `release` environment and the public marker was read back successfully
- The temporary Pages site, environments, workflow run, deployments, and branch were deleted afterward


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Pages deployment artifacts in pull request workflows.
* **Chores**
  * Updated the Pages upload and deployment actions to version 5 for stable releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->