### PR TITLE
chore(deps): bound npm update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,53 @@ updates:
         update-types:
           - major
 
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - kind/cleanup
+    groups:
+      npm-security-production:
+        applies-to: security-updates
+        dependency-type: production
+        patterns:
+          - "*"
+      npm-security-development:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - "*"
+      npm-routine-production:
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      npm-routine-development:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    # Coordinate major migrations explicitly; this does not suppress security updates.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
   - package-ecosystem: docker
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Add bounded Dependabot maintenance for the pnpm workspace:

- group security updates into production and development PRs;
- group routine minor/patch updates the same way;
- limit routine version PRs to two;
- apply a 3-day patch / 7-day default cooldown;
- leave major migrations to explicit maintainer work.

This does not add auto-merge. Dependabot security updates will be enabled in repository settings only after this configuration lands.

## Why

The npm security baseline is now clean after #249. This keeps future fixes visible without returning to one PR per dependency or mixing major migrations into routine maintenance.

## Verification

- parsed `.github/dependabot.yml` with Ruby `YAML.safe_load`;
- verified the options against GitHub's current Dependabot schema for pnpm 10 and grouped security updates.

Refs #127.
