### PR TITLE
fix(metrics): preserve missing workload telemetry

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -33,8 +33,9 @@ const (
 )
 
 var (
-	errNoMetricData        = errors.New("prometheus query returned no data")
-	errInvalidCoreCapacity = errors.New("allocated core capacity must be greater than zero")
+	errNoMetricData                 = errors.New("prometheus query returned no data")
+	errInvalidCoreCapacity          = errors.New("allocated core capacity must be greater than zero")
+	errWorkloadTelemetryUnsupported = errors.New("workload telemetry is not supported by provider")
 )
 
 type instantQuerier interface {
@@ -535,7 +536,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vcore\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
-		return 0, nil
+		return 0, errWorkloadTelemetryUnsupported
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_percent{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)
 	case biz.MetaxGPUDevice, metax.MetaxGPUDevice:
@@ -546,14 +547,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	val, present, err := s.queryInstantValWithPresence(ctx, query)
-	if err != nil {
-		return 0, err
-	}
-	if !present && provider == biz.NvidiaGPUDevice {
-		return 0, errNoMetricData
-	}
-	return val, nil
+	return s.queryRequiredInstantVal(ctx, query)
 }
 
 func nvidiaTaskCoreUsedQuery(deviceUUID, namespace, pod, container string) string {
@@ -614,7 +608,7 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_memory_utilization * on(uuid) group_right mlu_container{namespace=\"%s\",pod=\"%s\",container=\"%s\",type=\"mlu370.smlu.vmemory\"})", namespace, pod, container)
 	case biz.AscendGPUDevice:
-		return 0, nil
+		return 0, errWorkloadTelemetryUnsupported
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("avg(vdcu_usage_memory_size{pod_uuid=\"%s\", container_name=\"%s\"})", podUUID, container)
 	case metax.MetaxGPUDevice:
@@ -625,7 +619,7 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 	default:
 		return 0, errors.New("provider not exists")
 	}
-	return s.queryInstantVal(ctx, query)
+	return s.queryRequiredInstantVal(ctx, query)
 }
 
 func (s *MetricsGenerator) gpuTemperature(ctx context.Context, provider, deviceUUID string) (float32, error) {

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -21,11 +21,15 @@ type fakeInstantQuerier struct {
 	responses        []*pb.InstantResponse
 	responsesByQuery map[string]*pb.InstantResponse
 	errorsByQuery    map[string]error
+	queryErr         error
 	queries          []string
 }
 
 func (f *fakeInstantQuerier) QueryInstant(_ context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
 	f.queries = append(f.queries, req.GetQuery())
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
 	if err, ok := f.errorsByQuery[req.GetQuery()]; ok {
 		return nil, err
 	}
@@ -83,23 +87,72 @@ func TestNvidiaTaskCoreUsedQueryIncludesIdleSamples(t *testing.T) {
 	}
 }
 
-func TestTaskCoreUsedDistinguishesMissingFromIdle(t *testing.T) {
-	fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}
-	generator := &MetricsGenerator{monitorService: fake}
+func TestTaskUsageQueriesDistinguishMissingFailureAndIdle(t *testing.T) {
+	readers := []struct {
+		name string
+		read func(*MetricsGenerator) (float32, error)
+	}{
+		{name: "compute", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.taskCoreUsed(context.Background(), biz.CambriconGPUDevice, "research", "train", "worker", "pod-uid", "MLU-1", "node-1", 0)
+		}},
+		{name: "memory", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.taskMemoryUsed(context.Background(), biz.CambriconGPUDevice, "research", "train", "worker", "pod-uid", "MLU-1", "node-1", 0)
+		}},
+	}
 
-	_, err := generator.taskCoreUsed(context.Background(), biz.NvidiaGPUDevice, "research", "train", "worker", "pod-uid", "GPU-1", "node-1", 0)
-	if !errors.Is(err, errNoMetricData) {
-		t.Fatalf("expected errNoMetricData, got %v", err)
+	for _, reader := range readers {
+		t.Run(reader.name+"/missing", func(t *testing.T) {
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}}
+			_, err := reader.read(generator)
+			if !errors.Is(err, errNoMetricData) {
+				t.Fatalf("expected errNoMetricData, got %v", err)
+			}
+		})
+
+		t.Run(reader.name+"/query failure", func(t *testing.T) {
+			queryErr := errors.New("prometheus unavailable")
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{queryErr: queryErr}}
+			_, err := reader.read(generator)
+			if !errors.Is(err, queryErr) {
+				t.Fatalf("expected query error, got %v", err)
+			}
+		})
+
+		t.Run(reader.name+"/idle", func(t *testing.T) {
+			generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{Data: []*pb.Sample{{Value: 0}}}}}}
+			value, err := reader.read(generator)
+			if err != nil || value != 0 {
+				t.Fatalf("idle sample = (%v, %v), want (0, nil)", value, err)
+			}
+		})
 	}
 }
 
-func TestTaskCoreUsedKeepsLegacyEmptyBehaviorForOtherProviders(t *testing.T) {
-	fake := &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}
-	generator := &MetricsGenerator{monitorService: fake}
+func TestAscendTaskUsageIsUnsupported(t *testing.T) {
+	readers := []struct {
+		name string
+		read func(*MetricsGenerator) (float32, error)
+	}{
+		{name: "compute", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.taskCoreUsed(context.Background(), biz.AscendGPUDevice, "research", "train", "worker", "pod-uid", "ascend-1", "node-1", 0)
+		}},
+		{name: "memory", read: func(generator *MetricsGenerator) (float32, error) {
+			return generator.taskMemoryUsed(context.Background(), biz.AscendGPUDevice, "research", "train", "worker", "pod-uid", "ascend-1", "node-1", 0)
+		}},
+	}
 
-	value, err := generator.taskCoreUsed(context.Background(), biz.CambriconGPUDevice, "research", "train", "worker", "pod-uid", "MLU-1", "node-1", 0)
-	if err != nil || value != 0 {
-		t.Fatalf("Cambricon empty result = (%v, %v), want (0, nil)", value, err)
+	for _, reader := range readers {
+		t.Run(reader.name, func(t *testing.T) {
+			querier := &fakeInstantQuerier{}
+			generator := &MetricsGenerator{monitorService: querier}
+			_, err := reader.read(generator)
+			if !errors.Is(err, errWorkloadTelemetryUnsupported) {
+				t.Fatalf("expected errWorkloadTelemetryUnsupported, got %v", err)
+			}
+			if len(querier.queries) != 0 {
+				t.Fatalf("unsupported telemetry made %d queries, want 0", len(querier.queries))
+			}
+		})
 	}
 }
 
@@ -614,7 +667,56 @@ func TestContainerCoreMetricsKeepsLegacyProviderConversions(t *testing.T) {
 	}
 }
 
-func TestAscendContainerAllocationNormalizesProviderAndOmitsUnknownCore(t *testing.T) {
+func TestGenerateContainerMetricsPreservesMissingAndIdleUsage(t *testing.T) {
+	const (
+		deviceID   = "GPU-workload-presence"
+		nodeName   = "node-workload-presence"
+		deviceType = "A100"
+		podName    = "train"
+		container  = "worker"
+		namespace  = "research"
+		podUID     = "pod-uid"
+	)
+
+	tests := []struct {
+		name         string
+		response     *pb.InstantResponse
+		wantUsageSet bool
+	}{
+		{name: "empty vectors omit usage", response: &pb.InstantResponse{}, wantUsageSet: false},
+		{name: "real zero exports idle usage", response: instantValue(0), wantUsageSet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := &MetricsGenerator{
+				nodeUsecase: biz.NewNodeUsecase(&fakeNodeRepo{devices: []*biz.DeviceInfo{{
+					Id: deviceID, Type: deviceType, Provider: biz.NvidiaGPUDevice, NodeName: nodeName,
+				}}}, log.NewStdLogger(io.Discard)),
+				podUsecase: biz.NewPodUseCase(&fakePodRepo{containers: []*biz.Container{{
+					Name: container, PodName: podName, PodUID: podUID, Namespace: namespace,
+					ContainerDevices: biz.ContainerDevices{{UUID: deviceID, Type: biz.NvidiaGPUDevice, Usedmem: 1024, Usedcores: 50}},
+				}}}, log.NewStdLogger(io.Discard)),
+				monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{tt.response, tt.response}},
+				log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+			}
+			t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+			if err := generator.GenerateContainerMetrics(context.Background()); err != nil {
+				t.Fatalf("GenerateContainerMetrics() error = %v", err)
+			}
+			labels := []string{nodeName, biz.NvidiaGPUDevice, deviceType, deviceID, podName, container, namespace}
+			for _, gauge := range []*prometheus.GaugeVec{HamiContainerCoreUsed, HamiContainerCoreUtil, HamiContainerMemoryUsed, HamiContainerMemoryUtil} {
+				assertGaugeTracked(t, generator, gauge, labels, tt.wantUsageSet)
+				if tt.wantUsageSet && testutil.ToFloat64(gauge.WithLabelValues(labels...)) != 0 {
+					t.Fatalf("idle gauge value must be zero")
+				}
+			}
+		})
+	}
+}
+
+func TestAscendContainerAllocationOmitsUnknownCoreAndUnsupportedUsage(t *testing.T) {
 	tests := []struct {
 		name          string
 		core          int32
@@ -656,6 +758,13 @@ func TestAscendContainerAllocationNormalizesProviderAndOmitsUnknownCore(t *testi
 			assertGaugeTracked(t, generator, HamiContainerVgpuAllocated, labels, true)
 			assertGaugeTracked(t, generator, HamiContainerVmemoryAllocated, labels, true)
 			assertGaugeTracked(t, generator, HamiContainerVcoreAllocated, labels, tt.wantCoreGauge)
+			usageLabels := labels[:len(labels)-1]
+			for _, gauge := range []*prometheus.GaugeVec{HamiContainerCoreUsed, HamiContainerCoreUtil, HamiContainerMemoryUsed, HamiContainerMemoryUtil} {
+				assertGaugeTracked(t, generator, gauge, usageLabels, false)
+			}
+			if querier := generator.monitorService.(*fakeInstantQuerier); len(querier.queries) != 0 {
+				t.Fatalf("unsupported Ascend workload telemetry made %d queries, want 0", len(querier.queries))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Workload usage currently conflates a missing Prometheus result with a real zero for most providers, and hard-codes zero for Ascend. That publishes unsupported or unavailable telemetry as an idle workload.

Use the existing presence-aware query helper for all query-backed workload usage. Empty vectors and unsupported Ascend telemetry now omit the usage series, while an explicit zero sample remains a valid zero.

**Verification**:

- empty vector -> no workload usage series
- query failure -> no workload usage series
- real zero -> zero-valued usage series
- Ascend -> allocation remains available; unsupported workload usage is not queried or exported
- `make -C server verify`

**Which issue(s) this PR fixes**:

Related to #86. It does not close the issue because real Ascend per-container usage still requires a supported telemetry source.

**Does this PR introduce a user-facing change?**:

Yes. Missing or unsupported workload telemetry is no longer reported as 0%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload and task telemetry accuracy by distinguishing unavailable metrics, query failures, and genuine zero-usage (idle) values.
  * Missing usage data is no longer reported as zero, preventing misleading utilization readings.
  * Unsupported workload telemetry is now clearly identified instead of appearing as zero.
  * Container metrics preserve the difference between absent usage data and valid zero-value measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->