### PR TITLE
fix(metrics): preserve unknown compute allocation

### DIFF
--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -1,5 +1,6 @@
 const METRICS = Object.freeze({
   computeAllocated: 'hami_container_vcore_allocated',
+  computeAllocationKnown: 'hami_container_vcore_allocation_known',
   computeCapacity: 'hami_core_size',
   computeUsageAverage: 'hami_core_util_avg',
   memoryAllocated: 'hami_container_vmemory_allocated',
@@ -34,6 +35,27 @@ const aggregateAcrossExporterReplicas = (series, groupLabel = '') => {
 const divideForDisplay = (expression, divisor) =>
   divisor === 1 ? expression : `${expression} / ${divisor}`;
 
+// An absent allocated-core series can mean either a genuinely idle scope or an
+// Ascend allocation that WebUI cannot decode without guessing. Keep the idle
+// capacity-derived zero, but remove the entire scope when any explicit unknown
+// allocation is present so a known subset is never presented as the total.
+const excludeUnknownComputeAllocations = (
+  expression,
+  { selector = '', groupLabel = '' } = {},
+) => {
+  validateGroupLabel(groupLabel);
+  const unknownSeries = `${metricSeries(
+    METRICS.computeAllocationKnown,
+    selector,
+  )} == 0`;
+  const unknown = groupLabel
+    ? `max by (${groupLabel}) (${unknownSeries})`
+    : `max(${unknownSeries})`;
+  const match = groupLabel ? `on (${groupLabel})` : 'on ()';
+
+  return `(${expression}) unless ${match} ${unknown}`;
+};
+
 const buildAllocationQueries = ({
   allocatedMetric,
   capacityMetric,
@@ -60,12 +82,45 @@ const buildAllocationQueries = ({
   };
 };
 
-export const buildComputeAllocationQueries = (options = {}) =>
-  buildAllocationQueries({
+export const buildComputeAllocationQueries = (options = {}) => {
+  const queries = buildAllocationQueries({
     allocatedMetric: METRICS.computeAllocated,
     capacityMetric: METRICS.computeCapacity,
     ...options,
   });
+
+  return {
+    query: excludeUnknownComputeAllocations(queries.query, options),
+    totalQuery: queries.totalQuery,
+    percentQuery: excludeUnknownComputeAllocations(
+      queries.percentQuery,
+      options,
+    ),
+  };
+};
+
+export const buildTaskComputeAllocationQuery = ({
+  selector = '',
+  groupLabel = '',
+} = {}) => {
+  validateGroupLabel(groupLabel);
+  const allocated = metricSeries(METRICS.computeAllocated, selector);
+  const aggregate = groupLabel
+    ? `avg by (${groupLabel}) (${allocated})`
+    : `sum(${allocated})`;
+
+  return excludeUnknownComputeAllocations(aggregate, {
+    selector,
+    groupLabel,
+  });
+};
+
+export const buildTaskCountQueries = () => ({
+  byNode:
+    'topk(5, count by (node) (sum by (container_pod_uuid, node) (hami_container_vgpu_allocated)))',
+  byDevice:
+    'topk(5, count by (device_uuid) (sum by (container_pod_uuid, device_uuid) (hami_container_vgpu_allocated)))',
+});
 
 export const buildMemoryAllocationQueries = (options = {}) =>
   buildAllocationQueries({

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -3,10 +3,71 @@ import test from 'node:test';
 
 import {
   buildClusterTrendQueries,
+  buildComputeAllocationQueries,
   buildGroupedResourceTopQueries,
   buildMemoryAllocationQueries,
   buildMemoryUsageQueries,
+  buildTaskComputeAllocationQuery,
+  buildTaskCountQueries,
 } from './query-contract.mjs';
+
+test('compute allocation stays idle at real zero and hides unknown allocations', () => {
+  const queries = buildComputeAllocationQueries();
+
+  assert.match(queries.query, /hami_core_size\)\) \* 0/);
+  assert.match(
+    queries.query,
+    /unless on \(\) max\(hami_container_vcore_allocation_known == 0\)/,
+  );
+  assert.match(
+    queries.percentQuery,
+    /unless on \(\) max\(hami_container_vcore_allocation_known == 0\)/,
+  );
+  assert.doesNotMatch(
+    queries.totalQuery,
+    /hami_container_vcore_allocation_known/,
+  );
+});
+
+test('scoped compute allocation excludes the whole affected group', () => {
+  const queries = buildComputeAllocationQueries({
+    selector: 'node=~"$node"',
+    groupLabel: 'node',
+  });
+
+  assert.match(
+    queries.percentQuery,
+    /unless on \(node\) max by \(node\) \(hami_container_vcore_allocation_known\{node=~"\$node"\} == 0\)/,
+  );
+});
+
+test('task compute queries reject partial unknown allocations', () => {
+  const selector =
+    'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+  const detail = buildTaskComputeAllocationQuery({ selector });
+  const ranked = buildTaskComputeAllocationQuery({
+    groupLabel: 'container_pod_uuid',
+  });
+
+  assert.match(detail, /^\(sum\(hami_container_vcore_allocated\{/);
+  assert.match(
+    detail,
+    /unless on \(\) max\(hami_container_vcore_allocation_known\{.*\} == 0\)$/,
+  );
+  assert.match(
+    ranked,
+    /unless on \(container_pod_uuid\) max by \(container_pod_uuid\)/,
+  );
+});
+
+test('workload counts do not depend on compute-allocation availability', () => {
+  const queries = buildTaskCountQueries();
+
+  for (const query of Object.values(queries)) {
+    assert.match(query, /hami_container_vgpu_allocated/);
+    assert.doesNotMatch(query, /hami_container_vcore_allocated/);
+  }
+});
 
 test('memory allocation uses schedulable capacity and fills idle allocation', () => {
   const queries = buildMemoryAllocationQueries();
@@ -17,6 +78,10 @@ test('memory allocation uses schedulable capacity and fills idle allocation', ()
   }
   assert.match(queries.query, / or /);
   assert.match(queries.percentQuery, /\* 0/);
+  assert.doesNotMatch(
+    queries.percentQuery,
+    /hami_container_vcore_allocation_known/,
+  );
 });
 
 test('scoped memory allocation keeps the same contract for node and card details', () => {

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -88,12 +88,12 @@ test('memory utilization capacity only includes reporting devices', () => {
   );
 });
 
-test('node allocation rankings include every device and fully idle nodes', () => {
+test('node allocation rankings keep idle nodes and exclude unknown compute scopes', () => {
   const queries = createNodeTopQueries();
 
   assert.equal(
     queries.computeAllocation,
-    'topk(5, (avg by (node) (sum by (node, instance) (hami_container_vcore_allocated)) / avg by (node) (sum by (node, instance) (hami_core_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_core_size)) * 0))',
+    'topk(5, ((avg by (node) (sum by (node, instance) (hami_container_vcore_allocated)) / avg by (node) (sum by (node, instance) (hami_core_size)) * 100) or on (node) (avg by (node) (sum by (node, instance) (hami_core_size)) * 0)) unless on (node) max by (node) (hami_container_vcore_allocation_known == 0))',
   );
   assert.equal(
     queries.memoryAllocation,

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -218,11 +218,15 @@ import { getLineOptions } from '~/vgpu/components/config';
 import VChart from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
 import { formatWorkloadName } from './workload-identity.mjs';
-import { METRIC_STATUS } from '~/vgpu/hooks/instant-vector-state.mjs';
+import {
+  METRIC_STATUS,
+  readReadyMetricField,
+} from '~/vgpu/hooks/instant-vector-state.mjs';
 import DetailPageState from '~/vgpu/components/DetailPageState.vue';
 import { classifyDetailPayload } from '~/vgpu/hooks/detail-resource-state.mjs';
 import useDetailResource from '~/vgpu/hooks/useDetailResource';
 import { buildNodeDetailLocation } from '~/vgpu/views/node/detail-location.mjs';
+import { buildTaskComputeAllocationQuery } from '~/vgpu/metrics/query-contract.mjs';
 
 const route = useRoute();
 const router = useRouter();
@@ -370,7 +374,10 @@ const resourceOverviewData = useInstantVector(
     },
     {
       key: 'computeLimit',
-      query: `sum(hami_container_vcore_allocated{container_name="$container",pod_name=~"$pod",namespace_name="$namespace"})`,
+      query: buildTaskComputeAllocationQuery({
+        selector:
+          'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"',
+      }),
     },
     {
       key: 'singleCardMemory',
@@ -408,7 +415,7 @@ const toNumOrUndefined = (v) => {
 };
 const resourceOverviewTexts = computed(() => {
   const getMetric = (key) => resourceOverviewData.value.find((item) => item.key === key);
-  const get = (key) => getMetric(key)?.count;
+  const get = (key) => readReadyMetricField(getMetric(key), 'count');
   const containerInfo = getMetric('containerInfo');
   const hasContainerInfo =
     containerInfo?.hasData === true && Number(containerInfo.count) > 0;

--- a/packages/web/projects/vgpu/views/task/admin/top.vue
+++ b/packages/web/projects/vgpu/views/task/admin/top.vue
@@ -11,9 +11,17 @@ import nodeApi from '~/vgpu/api/node';
 import { ElMessage } from 'element-plus';
 import { useI18n } from 'vue-i18n';
 import { computed } from 'vue';
+import {
+  buildTaskComputeAllocationQuery,
+  buildTaskCountQueries,
+} from '~/vgpu/metrics/query-contract.mjs';
 
 const router = useRouter();
 const { t } = useI18n();
+const taskCountQueries = buildTaskCountQueries();
+const taskComputeAllocationQuery = buildTaskComputeAllocationQuery({
+  groupLabel: 'container_pod_uuid',
+});
 
 const handleChartClick = async (params) => {
   const name = params.data.name;
@@ -54,8 +62,7 @@ const topConfig = computed(() => [
         nameKey: 'node',
         data: [],
         unit: ' ',
-        query:
-          'topk(5, count by (node) (sum by (container_pod_uuid, node) (hami_container_vcore_allocated)))',
+        query: taskCountQueries.byNode,
       },
       {
         tab: t('dashboard.card'),
@@ -63,8 +70,7 @@ const topConfig = computed(() => [
         data: [],
         nameKey: 'device_uuid',
         unit: ' ',
-        query:
-          'topk(5, count by (device_uuid) (sum by (container_pod_uuid, device_uuid) (hami_container_vcore_allocated)))',
+        query: taskCountQueries.byDevice,
       },
     ],
   },
@@ -78,7 +84,7 @@ const topConfig = computed(() => [
         data: [],
         nameKey: 'container_pod_uuid',
         unit: ' ',
-        query: 'topk(5, avg by (container_pod_uuid) (hami_container_vcore_allocated))',
+        query: `topk(5, ${taskComputeAllocationQuery})`,
       },
       {
         tab: t('dashboard.memory'),

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -398,6 +398,11 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 			podUIDLabel := fmt.Sprintf("%s:%s", c.Name, c.PodUID)
 			s.set(HamiContainerVgpuAllocated, float64(vGPU), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			s.set(HamiContainerVmemoryAllocated, float64(memory), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
+			allocationKnown := float64(1)
+			if !coreAllocationKnown {
+				allocationKnown = 0
+			}
+			s.set(HamiContainerVcoreAllocationKnown, allocationKnown, device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 			if coreAllocationKnown {
 				s.set(HamiContainerVcoreAllocated, float64(core), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace, podUIDLabel)
 				used, util, err := s.containerCoreMetrics(ctx, provider, c.Namespace, c.PodName, c.Name, c.PodUID, device.Id, device.NodeName, device.Index, core)

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -722,9 +722,11 @@ func TestAscendContainerAllocationOmitsUnknownCoreAndUnsupportedUsage(t *testing
 		core          int32
 		coreKnown     bool
 		wantCoreGauge bool
+		wantKnown     float64
 	}{
-		{name: "known template", core: 25, coreKnown: true, wantCoreGauge: true},
-		{name: "unknown template", core: 0, coreKnown: false, wantCoreGauge: false},
+		{name: "known template", core: 25, coreKnown: true, wantCoreGauge: true, wantKnown: 1},
+		{name: "known zero", core: 0, coreKnown: true, wantCoreGauge: true, wantKnown: 1},
+		{name: "unknown template", core: 0, coreKnown: false, wantCoreGauge: false, wantKnown: 0},
 	}
 
 	for _, tt := range tests {
@@ -758,6 +760,7 @@ func TestAscendContainerAllocationOmitsUnknownCoreAndUnsupportedUsage(t *testing
 			assertGaugeTracked(t, generator, HamiContainerVgpuAllocated, labels, true)
 			assertGaugeTracked(t, generator, HamiContainerVmemoryAllocated, labels, true)
 			assertGaugeTracked(t, generator, HamiContainerVcoreAllocated, labels, tt.wantCoreGauge)
+			assertTrackedGaugeValue(t, generator, HamiContainerVcoreAllocationKnown, labels, tt.wantKnown)
 			usageLabels := labels[:len(labels)-1]
 			for _, gauge := range []*prometheus.GaugeVec{HamiContainerCoreUsed, HamiContainerCoreUtil, HamiContainerMemoryUsed, HamiContainerMemoryUtil} {
 				assertGaugeTracked(t, generator, gauge, usageLabels, false)
@@ -767,4 +770,34 @@ func TestAscendContainerAllocationOmitsUnknownCoreAndUnsupportedUsage(t *testing
 			}
 		})
 	}
+}
+
+func TestNonAscendContainerAllocationIsKnown(t *testing.T) {
+	const (
+		deviceID  = "GPU-allocation-known"
+		nodeName  = "nvidia-node"
+		podName   = "nvidia-pod"
+		container = "worker"
+		namespace = "research"
+		podUID    = "pod-uid"
+	)
+	generator := &MetricsGenerator{
+		nodeUsecase: biz.NewNodeUsecase(&fakeNodeRepo{devices: []*biz.DeviceInfo{{
+			Id: deviceID, AliasId: deviceID, Type: "A100", Provider: biz.NvidiaGPUDevice, NodeName: nodeName,
+		}}}, log.NewStdLogger(io.Discard)),
+		podUsecase: biz.NewPodUseCase(&fakePodRepo{containers: []*biz.Container{{
+			Name: container, PodName: podName, PodUID: podUID, Namespace: namespace,
+			ContainerDevices: biz.ContainerDevices{{UUID: deviceID, Type: biz.NvidiaGPUDevice, Usedmem: 8192, Usedcores: 0}},
+		}}}, log.NewStdLogger(io.Discard)),
+		monitorService: &fakeInstantQuerier{},
+		log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+	}
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	if err := generator.GenerateContainerMetrics(context.Background()); err != nil {
+		t.Fatalf("GenerateContainerMetrics() error = %v", err)
+	}
+	labels := []string{nodeName, biz.NvidiaGPUDevice, "A100", deviceID, podName, container, namespace, container + ":" + podUID}
+	assertTrackedGaugeValue(t, generator, HamiContainerVcoreAllocated, labels, 0)
+	assertTrackedGaugeValue(t, generator, HamiContainerVcoreAllocationKnown, labels, 1)
 }

--- a/server/internal/exporter/metrics.go
+++ b/server/internal/exporter/metrics.go
@@ -30,6 +30,7 @@ func init() {
 	prometheus.MustRegister(HamiContainerVgpuAllocated)
 	prometheus.MustRegister(HamiContainerVmemoryAllocated)
 	prometheus.MustRegister(HamiContainerVcoreAllocated)
+	prometheus.MustRegister(HamiContainerVcoreAllocationKnown)
 	prometheus.MustRegister(HamiContainerMemoryUsed)
 	prometheus.MustRegister(HamiContainerMemoryUtil)
 	prometheus.MustRegister(HamiContainerCoreUsed)
@@ -152,6 +153,11 @@ var (
 	HamiContainerVcoreAllocated = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hami_container_vcore_allocated",
 		Help: "task allocated vCore size",
+	}, []string{"node", "provider", "device_type", "device_uuid", "pod_name", "container_name", "namespace_name", "container_pod_uuid"})
+
+	HamiContainerVcoreAllocationKnown = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hami_container_vcore_allocation_known",
+		Help: "whether the task's allocated vCore size is known (1) or unavailable (0)",
 	}, []string{"node", "provider", "device_type", "device_uuid", "pod_name", "container_name", "namespace_name", "container_pod_uuid"})
 
 	HamiContainerMemoryUsed = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Compute-allocation queries use a capacity-derived zero so an idle scope still renders as 0%. For Ascend modes whose allocation annotation does not contain a decodable core quota, the exporter omits `hami_container_vcore_allocated`; the same fallback then misreports unknown as zero. A mixed scope can also expose only the known subset.

Export `hami_container_vcore_allocation_known` for every container/device allocation. Compute-allocation queries now omit an affected cluster, node, device or workload scope when any matching allocation is explicitly unknown. A known zero remains 0, idle scopes remain 0, and overcommit remains visible.

Workload counts use the device-allocation metric rather than the optional core-allocation metric, and task details only render ready samples.

**Verification**:

- known positive, known zero and unknown Ascend allocations
- non-Ascend known-zero allocation
- cluster, grouped and workload query contracts
- workload counts independent of core-allocation availability
- frontend lint/build/tests and browser contracts
- `make -C server verify`

**Does this PR introduce a user-facing change?**:

Yes. Unknown compute allocation is shown as unavailable instead of 0% or a partial total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for whether container compute allocation data is known or unavailable.
  - Added task-level compute allocation and workload count metrics for node and device views.
- **Bug Fixes**
  - Compute allocation metrics now distinguish genuine zero allocation from unknown allocation.
  - Unknown allocation data is excluded from affected scoped totals and rankings.
  - Workload counts remain available even when compute allocation data is missing.
  - Improved task resource details and monitoring views to use consistent metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->