### PR TITLE
fix(metrics): deduplicate workload detail allocation

### DIFF
--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -1,4 +1,5 @@
 const METRICS = Object.freeze({
+  vgpuAllocated: 'hami_container_vgpu_allocated',
   computeAllocated: 'hami_container_vcore_allocated',
   computeAllocationKnown: 'hami_container_vcore_allocation_known',
   computeCapacity: 'hami_core_size',
@@ -107,12 +108,27 @@ export const buildTaskComputeAllocationQuery = ({
   const allocated = metricSeries(METRICS.computeAllocated, selector);
   const aggregate = groupLabel
     ? `avg by (${groupLabel}) (${allocated})`
-    : `sum(${allocated})`;
+    : aggregateAcrossExporterReplicas(allocated);
 
   return excludeUnknownComputeAllocations(aggregate, {
     selector,
     groupLabel,
   });
+};
+
+export const buildTaskResourceOverviewQueries = ({ selector = '' } = {}) => {
+  const gpuCards = aggregateAcrossExporterReplicas(
+    metricSeries(METRICS.vgpuAllocated, selector),
+  );
+  const memory = aggregateAcrossExporterReplicas(
+    metricSeries(METRICS.memoryAllocated, selector),
+  );
+
+  return {
+    gpuCards,
+    computeLimit: buildTaskComputeAllocationQuery({ selector }),
+    singleCardMemory: `${memory} / clamp_min(${gpuCards}, 1) / 1024`,
+  };
 };
 
 export const buildTaskCountQueries = () => ({

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -9,6 +9,7 @@ import {
   buildMemoryUsageQueries,
   buildTaskComputeAllocationQuery,
   buildTaskCountQueries,
+  buildTaskResourceOverviewQueries,
 } from './query-contract.mjs';
 
 test('compute allocation stays idle at real zero and hides unknown allocations', () => {
@@ -49,14 +50,45 @@ test('task compute queries reject partial unknown allocations', () => {
     groupLabel: 'container_pod_uuid',
   });
 
-  assert.match(detail, /^\(sum\(hami_container_vcore_allocated\{/);
+  assert.match(
+    detail,
+    /^\(avg\(sum by \(instance\) \(hami_container_vcore_allocated\{/,
+  );
   assert.match(
     detail,
     /unless on \(\) max\(hami_container_vcore_allocation_known\{.*\} == 0\)$/,
   );
   assert.match(
     ranked,
+    /^\(avg by \(container_pod_uuid\) \(hami_container_vcore_allocated\)/,
+  );
+  assert.match(
+    ranked,
     /unless on \(container_pod_uuid\) max by \(container_pod_uuid\)/,
+  );
+});
+
+test('task resource totals stay stable for one or two exporter replicas and multiple cards', () => {
+  const selector =
+    'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+  const queries = buildTaskResourceOverviewQueries({ selector });
+  const vgpuSeries = `hami_container_vgpu_allocated{${selector}}`;
+  const coreSeries = `hami_container_vcore_allocated{${selector}}`;
+  const memorySeries = `hami_container_vmemory_allocated{${selector}}`;
+  const replicaSafeVgpu = `avg(sum by (instance) (${vgpuSeries}))`;
+  const replicaSafeCore = `avg(sum by (instance) (${coreSeries}))`;
+  const replicaSafeMemory = `avg(sum by (instance) (${memorySeries}))`;
+
+  // sum by (instance) totals all cards inside one exporter snapshot; averaging
+  // those totals keeps one and two equivalent WebUI replicas at the same value.
+  assert.equal(queries.gpuCards, replicaSafeVgpu);
+  assert.equal(
+    queries.computeLimit,
+    `(${replicaSafeCore}) unless on () max(hami_container_vcore_allocation_known{${selector}} == 0)`,
+  );
+  assert.equal(
+    queries.singleCardMemory,
+    `${replicaSafeMemory} / clamp_min(${replicaSafeVgpu}, 1) / 1024`,
   );
 });
 

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -226,7 +226,7 @@ import DetailPageState from '~/vgpu/components/DetailPageState.vue';
 import { classifyDetailPayload } from '~/vgpu/hooks/detail-resource-state.mjs';
 import useDetailResource from '~/vgpu/hooks/useDetailResource';
 import { buildNodeDetailLocation } from '~/vgpu/views/node/detail-location.mjs';
-import { buildTaskComputeAllocationQuery } from '~/vgpu/metrics/query-contract.mjs';
+import { buildTaskResourceOverviewQueries } from '~/vgpu/metrics/query-contract.mjs';
 
 const route = useRoute();
 const router = useRouter();
@@ -366,24 +366,24 @@ const basicImageTooltip = computed(() => {
 const basicCreateTime = computed(() => (
   detail.value?.createTime ? timeParse(detail.value.createTime) : '--'
 ));
+const taskAllocationSelector =
+  'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+const taskResourceOverviewQueries = buildTaskResourceOverviewQueries({
+  selector: taskAllocationSelector,
+});
 const resourceOverviewData = useInstantVector(
   [
     {
       key: 'gpuCards',
-      query: `sum(hami_container_vgpu_allocated{container_name="$container",pod_name=~"$pod",namespace_name="$namespace"})`,
+      query: taskResourceOverviewQueries.gpuCards,
     },
     {
       key: 'computeLimit',
-      query: buildTaskComputeAllocationQuery({
-        selector:
-          'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"',
-      }),
+      query: taskResourceOverviewQueries.computeLimit,
     },
     {
       key: 'singleCardMemory',
-      query:
-        `sum(hami_container_vmemory_allocated{container_name="$container",pod_name=~"$pod",namespace_name="$namespace"}) ` +
-        `/ clamp_min(sum(hami_container_vgpu_allocated{container_name="$container",pod_name=~"$pod",namespace_name="$namespace"}), 1) / 1024`,
+      query: taskResourceOverviewQueries.singleCardMemory,
     },
     {
       key: 'cpuLimit',


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Every WebUI replica exports the same cluster-wide allocation series and
Prometheus adds an instance label for each scrape target. Workload detail used
direct sums, so replicaCount=2 doubled GPU count and compute limit.

Aggregate each exporter snapshot with sum by (instance), then average equivalent
replicas. The existing meanings remain unchanged: total allocated vGPU slots,
total allocated vCore, and allocated memory per slot. The unknown compute
allocation guard from #260 is preserved.

CPU and memory limits come from kube-state-metrics and are not changed.

**Verification**

- query contracts cover one and two equivalent exporter replicas plus multiple cards
- grouped Top queries remain unchanged
- unknown compute allocation still excludes the whole workload value
- make verify passes, including 19 Chromium tests

The final release UAT will also compare live workload detail with
replicaCount=1 and replicaCount=2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task resource metrics to remain accurate when data is reported by multiple exporter replicas.
  * Corrected GPU, compute, and memory totals across multiple GPU cards.

* **Improvements**
  * Enhanced task resource overviews with consistent reporting for GPU cards, compute limits, and per-card memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->