### PR TITLE
fix(metrics): correct vendor telemetry queries

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -652,9 +652,11 @@ func (s *MetricsGenerator) memoryTemperature(ctx context.Context, provider, devi
 	case biz.NvidiaGPUDevice:
 		query = fmt.Sprintf("avg(DCGM_FI_DEV_MEMORY_TEMP{UUID=\"%s\"})", deviceUUID)
 	case biz.CambriconGPUDevice:
-		query = fmt.Sprintf("avg(mlu_memory_temperature{uuid=\"%s\"})", deviceUUID)
+		query = fmt.Sprintf("avg(mlu_memory_temperature{uuid=\"%s\",memory_die=\"\"})", deviceUUID)
 	case biz.AscendGPUDevice:
-		query = fmt.Sprintf("avg(npu_chip_info_temperature{vdie_id=\"%s\"})", deviceUUID)
+		query = fmt.Sprintf("avg(npu_chip_info_hbm_temperature{vdie_id=\"%s\"})", deviceUUID)
+	case biz.MetaxGPUDevice:
+		query = fmt.Sprintf("avg(mx_chip_hbm_temp{uuid=\"%s\"})", deviceUUID)
 	default:
 		return 0, errors.New("provider not exists")
 	}
@@ -667,7 +669,7 @@ func (s *MetricsGenerator) gpuPower(ctx context.Context, provider, deviceUUID st
 	case biz.NvidiaGPUDevice:
 		query = fmt.Sprintf("avg(DCGM_FI_DEV_POWER_USAGE{UUID=\"%s\"})", deviceUUID)
 	case biz.CambriconGPUDevice:
-		query = fmt.Sprintf("avg(mlu_power_usage{uuid=\"%s\"})", deviceUUID)
+		query = fmt.Sprintf("avg(mlu_power_usage{uuid=\"%s\",vf=\"\"})", deviceUUID)
 	case biz.AscendGPUDevice:
 		query = fmt.Sprintf("avg(npu_chip_info_power{vdie_id=\"%s\"})", deviceUUID)
 	case biz.HygonGPUDevice:
@@ -724,7 +726,7 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 	case biz.AscendGPUDevice:
 		query = fmt.Sprintf("npu_chip_info_power{vdie_id=\"%s\"}", deviceUUID)
 	case biz.CambriconGPUDevice:
-		query = fmt.Sprintf("mlu_power_usage{uuid=\"%s\"}", deviceUUID)
+		query = fmt.Sprintf("mlu_power_usage{uuid=\"%s\",vf=\"\"}", deviceUUID)
 	case biz.HygonGPUDevice:
 		query = fmt.Sprintf("dcu_power_usage{device_id=\"%s\"}", deviceUUID)
 	case biz.MetaxGPUDevice:

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -297,6 +297,89 @@ func TestOptionalDeviceTelemetryDistinguishesMissingNonFiniteAndZero(t *testing.
 	}
 }
 
+func TestProviderDeviceTelemetryUsesPhysicalMetricSeries(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		wantQuery string
+		read      func(*MetricsGenerator, string, string) (float32, error)
+	}{
+		{
+			name:      "Ascend HBM temperature",
+			provider:  biz.AscendGPUDevice,
+			wantQuery: `avg(npu_chip_info_hbm_temperature{vdie_id="device-1"})`,
+			read: func(generator *MetricsGenerator, provider, deviceUUID string) (float32, error) {
+				return generator.memoryTemperature(context.Background(), provider, deviceUUID)
+			},
+		},
+		{
+			name:      "MetaX HBM temperature",
+			provider:  biz.MetaxGPUDevice,
+			wantQuery: `avg(mx_chip_hbm_temp{uuid="device-1"})`,
+			read: func(generator *MetricsGenerator, provider, deviceUUID string) (float32, error) {
+				return generator.memoryTemperature(context.Background(), provider, deviceUUID)
+			},
+		},
+		{
+			name:      "MLU physical memory temperature",
+			provider:  biz.CambriconGPUDevice,
+			wantQuery: `avg(mlu_memory_temperature{uuid="device-1",memory_die=""})`,
+			read: func(generator *MetricsGenerator, provider, deviceUUID string) (float32, error) {
+				return generator.memoryTemperature(context.Background(), provider, deviceUUID)
+			},
+		},
+		{
+			name:      "MLU physical power",
+			provider:  biz.CambriconGPUDevice,
+			wantQuery: `avg(mlu_power_usage{uuid="device-1",vf=""})`,
+			read: func(generator *MetricsGenerator, provider, deviceUUID string) (float32, error) {
+				return generator.gpuPower(context.Background(), provider, deviceUUID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			querier := &fakeInstantQuerier{responsesByQuery: map[string]*pb.InstantResponse{
+				tt.wantQuery: instantValue(42.5),
+			}}
+			generator := &MetricsGenerator{monitorService: querier}
+
+			value, err := tt.read(generator, tt.provider, "device-1")
+			if err != nil || value != 42.5 {
+				t.Fatalf("telemetry = (%v, %v), want (42.5, nil)", value, err)
+			}
+			if len(querier.queries) != 1 || querier.queries[0] != tt.wantQuery {
+				t.Fatalf("queries = %q, want [%q]", querier.queries, tt.wantQuery)
+			}
+		})
+	}
+}
+
+func TestMLUAdditionalInfoUsesPhysicalPowerSeries(t *testing.T) {
+	const wantQuery = `mlu_power_usage{uuid="device-1",vf=""}`
+	querier := &fakeInstantQuerier{responsesByQuery: map[string]*pb.InstantResponse{
+		wantQuery: {
+			Data: []*pb.Sample{{Metric: map[string]string{
+				"driver": "1.2.3",
+				"sn":     "MLU-serial",
+			}}},
+		},
+	}}
+	generator := &MetricsGenerator{monitorService: querier}
+
+	info, err := generator.queryDeviceAdditional(context.Background(), biz.CambriconGPUDevice, "device-1")
+	if err != nil {
+		t.Fatalf("queryDeviceAdditional() error = %v", err)
+	}
+	if len(querier.queries) != 1 || querier.queries[0] != wantQuery {
+		t.Fatalf("queries = %q, want [%q]", querier.queries, wantQuery)
+	}
+	if info.DriverVersion != "1.2.3" || info.DeviceNo != "MLU-serial" {
+		t.Fatalf("additional info = %+v, want driver 1.2.3 and device MLU-serial", info)
+	}
+}
+
 func TestDeviceMemoryQueriesConvertVendorUnitsToMiB(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What

Align optional device telemetry queries with the producers' physical-device series:

- use Ascend's HBM temperature metric instead of repeating chip temperature;
- expose MetaX HBM temperature;
- select the aggregate MLU memory-temperature series with `memory_die=""`; and
- select the physical MLU power series with `vf=""`, including device metadata lookup.

Without the MLU selectors, aggregate and per-die or physical and virtual-function series can be averaged together.

An empty-label matcher also matches a series where that label is absent, so older exporters without these labels remain compatible. Missing or non-finite samples continue to be omitted.

## Verification

- `go test -count=1 -mod=readonly ./internal/exporter`
- `go test -mod=readonly ./...`
- `go vet -mod=readonly ./...`
- `make verify-mod`
- `git diff --check`

The query contracts were checked against the Ascend, MetaX, and Cambricon producer sources. Physical-device validation remains required on representative vendor hardware before the stable 2.0 release.