### PR TITLE
fix(metrics): expose NVIDIA XID as diagnostic code

### DIFF
--- a/docs/installation/helm/index.md
+++ b/docs/installation/helm/index.md
@@ -150,6 +150,17 @@ Do not copy these Chart 1.x settings:
 - `frontend.proxyTimeout`, `backend.grpc`, or `service.legacyBackendPort`, which
   no longer apply to the in-process API and single-container Service topology.
 
+Chart 2 also renames the NVIDIA device metric
+`hami_device_hardware_health` to `hami_device_last_xid_error_code`. The value
+has always been the raw `DCGM_FI_DEV_XID_ERRORS` code: `0` means that no XID
+error was reported, non-zero values are diagnostic codes rather than a health
+status, and unavailable telemetry leaves the series absent. Dashboards that
+must query retained Chart 1.3 history can temporarily use:
+
+```promql
+hami_device_last_xid_error_code or hami_device_hardware_health
+```
+
 After Chart 2.0.0 is published, upgrade with Helm defaults reset so removed
 values cannot leak from release history:
 

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -296,9 +296,9 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 				s.set(HamiDeviceFanSpeedR, float64(fanSpeed), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 			}
 		}
-		gpuHardwareHealth, err := s.gpuHardwareHealth(ctx, provider, device.Id)
+		lastXIDErrorCode, err := s.lastXIDErrorCode(ctx, provider, device.Id)
 		if err == nil {
-			s.set(HamiDeviceHardwareHealth, float64(gpuHardwareHealth), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+			s.set(HamiDeviceLastXIDErrorCode, float64(lastXIDErrorCode), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		}
 	}
 	return nil
@@ -687,13 +687,13 @@ func (s *MetricsGenerator) gpuPower(ctx context.Context, provider, deviceUUID st
 	return power, err
 }
 
-func (s *MetricsGenerator) gpuHardwareHealth(ctx context.Context, provider, deviceUUID string) (float32, error) {
+func (s *MetricsGenerator) lastXIDErrorCode(ctx context.Context, provider, deviceUUID string) (float32, error) {
 	query := ""
 	switch provider {
 	case biz.NvidiaGPUDevice:
 		query = fmt.Sprintf("avg(DCGM_FI_DEV_XID_ERRORS{UUID=\"%s\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("last XID error code is not supported by provider %q", provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -248,9 +248,6 @@ func TestOptionalDeviceTelemetryDistinguishesMissingNonFiniteAndZero(t *testing.
 		{name: "fan speed", read: func(generator *MetricsGenerator, provider string) (float32, error) {
 			return generator.fanSpeed(context.Background(), provider, "GPU-1")
 		}},
-		{name: "hardware health", read: func(generator *MetricsGenerator, provider string) (float32, error) {
-			return generator.gpuHardwareHealth(context.Background(), provider, "GPU-1")
-		}},
 	}
 	tests := []struct {
 		name        string
@@ -294,6 +291,49 @@ func TestOptionalDeviceTelemetryDistinguishesMissingNonFiniteAndZero(t *testing.
 				t.Fatalf("unsupported provider made %d queries, want 0", len(querier.queries))
 			}
 		})
+	}
+}
+
+func TestLastXIDErrorCodeUsesNvidiaMetricAndRejectsUnsupportedProvider(t *testing.T) {
+	t.Run("NVIDIA", func(t *testing.T) {
+		querier := &fakeInstantQuerier{responses: []*pb.InstantResponse{instantValue(79)}}
+		generator := &MetricsGenerator{monitorService: querier}
+		value, err := generator.lastXIDErrorCode(context.Background(), biz.NvidiaGPUDevice, "GPU-1")
+		if err != nil || value != 79 {
+			t.Fatalf("last XID error code = (%v, %v), want (79, nil)", value, err)
+		}
+		if len(querier.queries) != 1 || querier.queries[0] != `avg(DCGM_FI_DEV_XID_ERRORS{UUID="GPU-1"})` {
+			t.Fatalf("queries = %v, want the NVIDIA XID query", querier.queries)
+		}
+	})
+
+	t.Run("unsupported provider", func(t *testing.T) {
+		querier := &fakeInstantQuerier{}
+		generator := &MetricsGenerator{monitorService: querier}
+		if _, err := generator.lastXIDErrorCode(context.Background(), "unsupported", "GPU-1"); err == nil {
+			t.Fatal("unsupported provider returned a nil error")
+		}
+		if len(querier.queries) != 0 {
+			t.Fatalf("unsupported provider made %d queries, want 0", len(querier.queries))
+		}
+	})
+}
+
+func TestLastXIDErrorMetricDescriptorNamesTheRawDiagnosticCode(t *testing.T) {
+	descriptors := make(chan *prometheus.Desc, 1)
+	HamiDeviceLastXIDErrorCode.Describe(descriptors)
+	descriptor := (<-descriptors).String()
+
+	for _, want := range []string{
+		`fqName: "hami_device_last_xid_error_code"`,
+		`help: "Last NVIDIA XID error code reported by DCGM; 0 means no error and non-zero values are diagnostic codes, not a health status"`,
+	} {
+		if !strings.Contains(descriptor, want) {
+			t.Fatalf("metric descriptor %q does not contain %q", descriptor, want)
+		}
+	}
+	if strings.Contains(descriptor, "hami_device_hardware_health") {
+		t.Fatalf("metric descriptor still exposes the removed health name: %s", descriptor)
 	}
 }
 
@@ -584,7 +624,6 @@ func TestGenerateDeviceMetricsExportsOnlyPresentFiniteOptionalTelemetry(t *testi
 				responses[`avg(DCGM_FI_DEV_MEMORY_TEMP{UUID="`+tt.deviceID+`"})`] = tt.response
 				responses[`avg(DCGM_FI_DEV_POWER_USAGE{UUID="`+tt.deviceID+`"})`] = tt.response
 				responses[`avg(DCGM_FI_DEV_FAN_SPEED{UUID="`+tt.deviceID+`"})`] = tt.response
-				responses[`avg(DCGM_FI_DEV_XID_ERRORS{UUID="`+tt.deviceID+`"})`] = tt.response
 			}
 			generator := newDeviceMetricsTestGenerator(
 				&biz.DeviceInfo{
@@ -604,12 +643,55 @@ func TestGenerateDeviceMetricsExportsOnlyPresentFiniteOptionalTelemetry(t *testi
 				HamiDeviceMemoryTemperature,
 				HamiDevicePower,
 				HamiDeviceFanSpeedP,
-				HamiDeviceHardwareHealth,
 			} {
 				assertGaugeTracked(t, generator, gauge, labels, tt.wantTracked)
 				if tt.wantTracked && testutil.ToFloat64(gauge.WithLabelValues(labels...)) != tt.wantValue {
 					t.Fatalf("optional gauge value = %v, want %v", testutil.ToFloat64(gauge.WithLabelValues(labels...)), tt.wantValue)
 				}
+			}
+		})
+	}
+}
+
+func TestGenerateDeviceMetricsExportsOnlyPresentXIDErrorCodes(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceID    string
+		response    *pb.InstantResponse
+		wantTracked bool
+		wantValue   float64
+	}{
+		{name: "missing", deviceID: "GPU-xid-missing"},
+		{name: "no error", deviceID: "GPU-xid-zero", response: instantValue(0), wantTracked: true},
+		{name: "informational code", deviceID: "GPU-xid-45", response: instantValue(45), wantTracked: true, wantValue: 45},
+		{name: "fallen off bus code", deviceID: "GPU-xid-79", response: instantValue(79), wantTracked: true, wantValue: 79},
+		{name: "NaN", deviceID: "GPU-xid-nan", response: instantValue(float32(math.NaN()))},
+		{name: "positive infinity", deviceID: "GPU-xid-pos-inf", response: instantValue(float32(math.Inf(1)))},
+		{name: "negative infinity", deviceID: "GPU-xid-neg-inf", response: instantValue(float32(math.Inf(-1)))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses := map[string]*pb.InstantResponse{}
+			if tt.response != nil {
+				responses[`avg(DCGM_FI_DEV_XID_ERRORS{UUID="`+tt.deviceID+`"})`] = tt.response
+			}
+			generator := newDeviceMetricsTestGenerator(
+				&biz.DeviceInfo{
+					Id: tt.deviceID, Devmem: 40960, Devcore: 100, Count: 1,
+					Type: "A100", NodeName: "node-xid", Provider: biz.NvidiaGPUDevice,
+				},
+				responses,
+			)
+			t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+			if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+				t.Fatalf("GenerateDeviceMetrics() error = %v", err)
+			}
+			labels := []string{"node-xid", biz.NvidiaGPUDevice, "A100", tt.deviceID, "", ""}
+			assertGaugeTracked(t, generator, HamiDeviceLastXIDErrorCode, labels, tt.wantTracked)
+			if tt.wantTracked && testutil.ToFloat64(HamiDeviceLastXIDErrorCode.WithLabelValues(labels...)) != tt.wantValue {
+				t.Fatalf("last XID error code gauge value = %v, want %v", testutil.ToFloat64(HamiDeviceLastXIDErrorCode.WithLabelValues(labels...)), tt.wantValue)
 			}
 		})
 	}
@@ -639,7 +721,7 @@ func TestGenerateDeviceMetricsOmitsUnsupportedOptionalTelemetry(t *testing.T) {
 		HamiDeviceMemoryTemperature,
 		HamiDeviceFanSpeedP,
 		HamiDeviceFanSpeedR,
-		HamiDeviceHardwareHealth,
+		HamiDeviceLastXIDErrorCode,
 	} {
 		assertGaugeTracked(t, generator, gauge, labels, false)
 	}

--- a/server/internal/exporter/metrics.go
+++ b/server/internal/exporter/metrics.go
@@ -24,7 +24,7 @@ func init() {
 	prometheus.MustRegister(HamiDevicePower)
 	prometheus.MustRegister(HamiDeviceFanSpeedP)
 	prometheus.MustRegister(HamiDeviceFanSpeedR)
-	prometheus.MustRegister(HamiDeviceHardwareHealth)
+	prometheus.MustRegister(HamiDeviceLastXIDErrorCode)
 
 	// Container metrics.
 	prometheus.MustRegister(HamiContainerVgpuAllocated)
@@ -125,9 +125,9 @@ var (
 		Help: "gpu power",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
-	HamiDeviceHardwareHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "hami_device_hardware_health",
-		Help: "gpu hardware health",
+	HamiDeviceLastXIDErrorCode = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hami_device_last_xid_error_code",
+		Help: "Last NVIDIA XID error code reported by DCGM; 0 means no error and non-zero values are diagnostic codes, not a health status",
 	}, []string{"node", "provider", "device_type", "device_uuid", "driver_version", "device_no"})
 
 	HamiDeviceFanSpeedP = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
## What

Rename the exported NVIDIA metric:

`hami_device_hardware_health` → `hami_device_last_xid_error_code`

The source is `DCGM_FI_DEV_XID_ERRORS`, whose value is a specific XID code, not a health boolean. For example, NVIDIA documents XID 45 as informational and XID 79 as a drain-and-investigate event, so neither numeric ordering nor nonzero-as-unhealthy is valid.

The new metric preserves the raw code:

- `0`: no XID error reported;
- `45`, `79`, and other finite values: unchanged diagnostic codes; and
- missing or non-finite telemetry: no series.

This is an atomic RC-stage rename. The old misleading name is not dual-written, and the WebUI has no internal consumer of it. The Chart 1.3 → 2.0 upgrade guide documents the breaking change and a temporary query for retained history.

This does not introduce a GPU-health signal or upgrade dcgm-exporter.

## Verification

- `go test -count=1 -mod=readonly ./internal/exporter`
- `go test -mod=readonly ./...`
- `go vet -mod=readonly ./...`
- `make verify-mod`
- `git diff --check`

Tests cover XID `0`, `45`, `79`, missing, NaN, both infinities, and unsupported providers.