### PR TITLE
fix(metrics): stabilize physical compute capacity

### DIFF
--- a/server/internal/biz/node.go
+++ b/server/internal/biz/node.go
@@ -6,6 +6,11 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+// PhysicalCoreBaselinePerDevice is the normalized physical-compute denominator
+// used by WebUI allocation metrics. It represents one accelerator at 100
+// percentage points; it is not a CUDA-core, AI-core, or schedulable-vCore count.
+const PhysicalCoreBaselinePerDevice int32 = 100
+
 type Node struct {
 	Name                    string
 	IP                      string

--- a/server/internal/biz/summary.go
+++ b/server/internal/biz/summary.go
@@ -52,7 +52,7 @@ func (t *SummaryUseCase) GetGPUSummary(ctx context.Context, deviceId string, nod
 		if deviceId != "" && deviceId != device.Id {
 			continue
 		}
-		res.CoreTotal = res.CoreTotal + device.Devcore
+		res.CoreTotal += PhysicalCoreBaselinePerDevice
 		res.MemoryTotal = res.MemoryTotal + device.Devmem
 		res.VgpuTotal = res.VgpuTotal + device.Count
 

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -252,7 +252,7 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 		s.set(HamiVmemorySize, float64(device.Devmem), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		s.set(HamiVcoreSize, float64(device.Devcore), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		s.set(HamiVCoreScaling, float64(device.Devcore)/100, device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
-		s.set(HamiCoreSize, 100, device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
+		s.set(HamiCoreSize, float64(biz.PhysicalCoreBaselinePerDevice), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		deviceMemUsed, memoryUsedErr := s.deviceMemUsed(ctx, provider, device.Id)
 		if memoryUsedErr == nil {
 			s.set(HamiMemoryUsed, float64(deviceMemUsed), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)

--- a/server/internal/service/allocation_capacity_test.go
+++ b/server/internal/service/allocation_capacity_test.go
@@ -2,107 +2,102 @@ package service
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
 	pb "vgpu/api/v1"
 	"vgpu/internal/biz"
-	"vgpu/internal/data/prom"
 )
 
-func TestAllocationListsKeepRegisteredMemoryCapacity(t *testing.T) {
-	const registeredMemory = int32(65536)
-
-	var (
-		queriesMu sync.Mutex
-		queries   []string
-	)
-	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.FormValue("query")
-		queriesMu.Lock()
-		queries = append(queries, query)
-		queriesMu.Unlock()
-
-		label, value := "device_uuid", "100"
-		if strings.Contains(query, "by (node)") {
-			label = "node"
-		}
-		if strings.Contains(query, "hami_memory_size") {
-			// A physical-memory metric deliberately differs from the registered
-			// schedulable capacity. Allocation APIs must never use this value.
-			value = "32768"
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"%s":"%s"},"value":[1788050000,"%s"]}]}}`, label, map[string]string{"node": "node-a", "device_uuid": "GPU-1"}[label], value)
-	}))
-	defer prometheus.Close()
-
-	device := &biz.DeviceInfo{
+func TestAllocationCapacityUsesDeterministicPhysicalCoreBaseline(t *testing.T) {
+	device1 := &biz.DeviceInfo{
 		Id:       "GPU-1",
 		AliasId:  "GPU-1",
 		Count:    1,
-		Devmem:   registeredMemory,
+		Devmem:   65536,
 		Devcore:  200,
 		NodeName: "node-a",
 		NodeUid:  "node-uid-a",
 	}
+	device2 := &biz.DeviceInfo{
+		Id:       "GPU-2",
+		AliasId:  "GPU-2",
+		Count:    2,
+		Devmem:   32768,
+		Devcore:  300,
+		NodeName: "node-a",
+		NodeUid:  "node-uid-a",
+	}
 	nodeRepo := &capacityTestNodeRepo{
-		nodes:   []*biz.Node{{Name: "node-a", Uid: "node-uid-a", Devices: []*biz.DeviceInfo{device}}},
-		devices: []*biz.DeviceInfo{device},
+		nodes:   []*biz.Node{{Name: "node-a", Uid: "node-uid-a", Devices: []*biz.DeviceInfo{device1, device2}}},
+		devices: []*biz.DeviceInfo{device1, device2},
 	}
 	podRepo := &capacityTestPodRepo{}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, prom.HTTPConfig{}, log.DefaultLogger)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	monitor := NewMonitorService(promClient, nodeUsecase, podUsecase)
+	summaryUsecase := biz.NewSummaryUseCase(nodeRepo, podRepo, log.DefaultLogger)
+	nodeService := NewNodeService(nodeUsecase, podUsecase, summaryUsecase)
+	cardService := NewCardService(nodeUsecase, podUsecase)
 
-	nodes, err := NewNodeService(nodeUsecase, podUsecase, nil, monitor).GetAllNodes(
+	nodes, err := nodeService.GetAllNodes(
 		context.Background(),
 		&pb.GetAllNodesReq{Filters: &pb.GetAllNodesReq_Filters{}},
 	)
 	if err != nil {
 		t.Fatalf("GetAllNodes: %v", err)
 	}
-	if got := nodes.List[0].MemoryTotal; got != registeredMemory {
-		t.Fatalf("node memory_total = %d, want registered capacity %d", got, registeredMemory)
+	if len(nodes.List) != 1 {
+		t.Fatalf("GetAllNodes returned %d nodes, want 1", len(nodes.List))
 	}
-	if got := nodes.List[0].CoreTotal; got != 100 {
-		t.Fatalf("node core_total = %d, want physical baseline 100", got)
-	}
+	assertCapacity(t, "node list", nodes.List[0].CoreTotal, nodes.List[0].MemoryTotal, 200, 98304)
 
-	cards, err := NewCardService(nodeUsecase, podUsecase, monitor).GetAllGPUs(
+	node, err := nodeService.GetNode(context.Background(), &pb.GetNodeReq{Uid: "node-uid-a"})
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	assertCapacity(t, "node detail", node.CoreTotal, node.MemoryTotal, 200, 98304)
+
+	cards, err := cardService.GetAllGPUs(
 		context.Background(),
 		&pb.GetAllGpusReq{Filters: &pb.GetAllGpusReq_Filters{}},
 	)
 	if err != nil {
 		t.Fatalf("GetAllGPUs: %v", err)
 	}
-	if got := cards.List[0].MemoryTotal; got != registeredMemory {
-		t.Fatalf("card memory_total = %d, want registered capacity %d", got, registeredMemory)
+	if len(cards.List) != 2 {
+		t.Fatalf("GetAllGPUs returned %d cards, want 2", len(cards.List))
 	}
-	if got := cards.List[0].CoreTotal; got != 100 {
-		t.Fatalf("card core_total = %d, want physical baseline 100", got)
+	assertCapacity(t, "first card list", cards.List[0].CoreTotal, cards.List[0].MemoryTotal, 100, 65536)
+	assertCapacity(t, "second card list", cards.List[1].CoreTotal, cards.List[1].MemoryTotal, 100, 32768)
+
+	card, err := cardService.GetGPU(context.Background(), &pb.GetGpuReq{Uid: "GPU-2"})
+	if err != nil {
+		t.Fatalf("GetGPU: %v", err)
+	}
+	assertCapacity(t, "card detail", card.CoreTotal, card.MemoryTotal, 100, 32768)
+
+	summary, err := nodeService.GetSummary(context.Background(), &pb.GetSummaryReq{})
+	if err != nil {
+		t.Fatalf("GetSummary: %v", err)
+	}
+	assertCapacity(t, "summary", summary.CoreTotal, summary.MemoryTotal, 200, 98304)
+	if summary.GpuCount != 2 || summary.NodeCount != 1 || summary.VgpuTotal != 3 {
+		t.Fatalf("summary counts = gpu:%d node:%d vgpu:%d, want 2/1/3", summary.GpuCount, summary.NodeCount, summary.VgpuTotal)
 	}
 
-	queriesMu.Lock()
-	defer queriesMu.Unlock()
-	if len(queries) != 2 {
-		t.Fatalf("Prometheus queries = %v, want one core query per list API", queries)
+	filteredSummary, err := nodeService.GetSummary(context.Background(), &pb.GetSummaryReq{
+		Filters: &pb.GetSummaryReq_Filters{DeviceId: "GPU-1"},
+	})
+	if err != nil {
+		t.Fatalf("GetSummary filtered by device: %v", err)
 	}
-	for _, query := range queries {
-		if !strings.Contains(query, "hami_core_size") || strings.Contains(query, "memory_size") {
-			t.Fatalf("unexpected allocation-list query %q", query)
-		}
+	assertCapacity(t, "filtered summary", filteredSummary.CoreTotal, filteredSummary.MemoryTotal, 100, 65536)
+}
+
+func assertCapacity(t *testing.T, scope string, core, memory, wantCore, wantMemory int32) {
+	t.Helper()
+	if core != wantCore || memory != wantMemory {
+		t.Fatalf("%s capacity = core:%d memory:%d, want core:%d memory:%d", scope, core, memory, wantCore, wantMemory)
 	}
 }
 

--- a/server/internal/service/card.go
+++ b/server/internal/service/card.go
@@ -13,11 +13,10 @@ type CardService struct {
 
 	node *biz.NodeUsecase
 	pod  *biz.PodUseCase
-	ms   *MonitorService
 }
 
-func NewCardService(node *biz.NodeUsecase, pod *biz.PodUseCase, ms *MonitorService) *CardService {
-	return &CardService{node: node, pod: pod, ms: ms}
+func NewCardService(node *biz.NodeUsecase, pod *biz.PodUseCase) *CardService {
+	return &CardService{node: node, pod: pod}
 }
 
 func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*pb.GPUsReply, error) {
@@ -38,12 +37,6 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		return nil, err
 	}
 
-	// Pull the normalized compute baseline for all devices in one query keyed by
-	// device_uuid. Memory capacity already comes from DeviceInfo.Devmem, HAMi's
-	// registered schedulable value, so querying the exporter's delayed copy would
-	// be redundant.
-	coreSizeByUUID := s.queryGaugeByLabel(ctx, "avg(hami_core_size) by (device_uuid)", "device_uuid")
-
 	var res = &pb.GPUsReply{List: []*pb.GPUReply{}}
 	for _, device := range deviceInfos {
 		gpu := &pb.GPUReply{}
@@ -63,7 +56,7 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		gpu.NodeName = device.NodeName
 		gpu.Type = device.Type
 		gpu.VgpuTotal = device.Count
-		gpu.CoreTotal = device.Devcore
+		gpu.CoreTotal = biz.PhysicalCoreBaselinePerDevice
 		gpu.MemoryTotal = device.Devmem
 		gpu.NodeUid = device.NodeUid
 		gpu.Health = device.Health
@@ -75,9 +68,6 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		gpu.CoreUsedKnown = &coreKnown
 		gpu.MemoryUsed = memory
 
-		if v, ok := coreSizeByUUID[device.Id]; ok {
-			gpu.CoreTotal = v
-		}
 		res.List = append(res.List, gpu)
 	}
 
@@ -85,25 +75,6 @@ func (s *CardService) GetAllGPUs(ctx context.Context, req *pb.GetAllGpusReq) (*p
 		return res.List[i].Uuid < res.List[j].Uuid
 	})
 	return res, nil
-}
-
-// queryGaugeByLabel runs a single instant query and returns the result values
-// keyed by the given label, so callers can batch what used to be per-entity
-// lookups into one round-trip to Prometheus / VictoriaMetrics.
-func (s *CardService) queryGaugeByLabel(ctx context.Context, query, label string) map[string]int32 {
-	out := map[string]int32{}
-	resp, err := s.ms.QueryInstant(ctx, &pb.QueryInstantRequest{Query: query})
-	if err != nil {
-		return out
-	}
-	for _, sample := range resp.Data {
-		key := sample.Metric[label]
-		if key == "" {
-			continue
-		}
-		out[key] = int32(sample.Value)
-	}
-	return out
 }
 
 func (s *CardService) GetAllGPUTypes(ctx context.Context, req *pb.GetAllGpusReq) (*pb.GPUsReply, error) {
@@ -151,7 +122,7 @@ func (s *CardService) GetGPU(ctx context.Context, req *pb.GetGpuReq) (*pb.GPURep
 		gpu.NodeName = device.NodeName
 		gpu.Type = device.Type
 		gpu.VgpuTotal = device.Count
-		gpu.CoreTotal = device.Devcore
+		gpu.CoreTotal = biz.PhysicalCoreBaselinePerDevice
 		gpu.MemoryTotal = device.Devmem
 		gpu.NodeUid = device.NodeUid
 		gpu.Health = device.Health

--- a/server/internal/service/empty_filters_test.go
+++ b/server/internal/service/empty_filters_test.go
@@ -2,25 +2,14 @@ package service
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
 	pb "vgpu/api/v1"
 	"vgpu/internal/biz"
-	"vgpu/internal/data/prom"
 )
 
 func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
-	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
-	}))
-	defer prometheus.Close()
-
 	device := &biz.DeviceInfo{
 		Id:       "GPU-1",
 		AliasId:  "GPU-1",
@@ -44,18 +33,12 @@ func TestRequestsTreatMissingFiltersAsEmpty(t *testing.T) {
 	}}}
 	nodeUsecase := biz.NewNodeUsecase(nodeRepo, log.DefaultLogger)
 	podUsecase := biz.NewPodUseCase(podRepo, log.DefaultLogger)
-	promClient, err := prom.NewClient(prometheus.URL, time.Second, prom.HTTPConfig{}, log.DefaultLogger)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	monitor := NewMonitorService(promClient, nodeUsecase, podUsecase)
 	nodes := NewNodeService(
 		nodeUsecase,
 		podUsecase,
 		biz.NewSummaryUseCase(nodeRepo, podRepo, log.DefaultLogger),
-		monitor,
 	)
-	cards := NewCardService(nodeUsecase, podUsecase, monitor)
+	cards := NewCardService(nodeUsecase, podUsecase)
 	containers := NewContainerService(nodeUsecase, podUsecase)
 
 	tests := []struct {

--- a/server/internal/service/node.go
+++ b/server/internal/service/node.go
@@ -19,11 +19,10 @@ type NodeService struct {
 	uc      *biz.NodeUsecase
 	pod     *biz.PodUseCase
 	summary *biz.SummaryUseCase
-	ms      *MonitorService
 }
 
-func NewNodeService(uc *biz.NodeUsecase, pod *biz.PodUseCase, summary *biz.SummaryUseCase, ms *MonitorService) *NodeService {
-	return &NodeService{uc: uc, pod: pod, summary: summary, ms: ms}
+func NewNodeService(uc *biz.NodeUsecase, pod *biz.PodUseCase, summary *biz.SummaryUseCase) *NodeService {
+	return &NodeService{uc: uc, pod: pod, summary: summary}
 }
 
 func (s *NodeService) GetSummary(ctx context.Context, req *pb.GetSummaryReq) (*pb.DeviceSummaryReply, error) {
@@ -48,23 +47,19 @@ func (s *NodeService) GetAllNodes(ctx context.Context, req *pb.GetAllNodesReq) (
 		return nil, err
 	}
 
-	// Fetch containers once (StatisticsByDeviceId used to re-list per device) and
-	// pull the per-node normalized compute baseline in one query keyed by node.
+	// Fetch containers once (StatisticsByDeviceId used to re-list per device).
 	// Memory capacity already comes from DeviceInfo.Devmem, HAMi's registered
-	// schedulable value, so querying the exporter's delayed copy would be redundant.
+	// schedulable value. Compute capacity is the deterministic physical baseline
+	// assembled from the same inventory below.
 	containers, err := s.pod.ListAllContainers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	coreByNode := s.queryNodeGauge(ctx, "avg(sum(hami_core_size) by (node, instance)) by (node)")
 
 	var res = &pb.NodesReply{List: []*pb.NodeReply{}}
 	for _, node := range nodes {
 		nodeReply := s.buildNodeReply(node, containers)
 
-		if v, ok := coreByNode[node.Name]; ok {
-			nodeReply.CoreTotal = v
-		}
 		if filters.Ip != "" && filters.Ip != nodeReply.Ip {
 			continue
 		}
@@ -127,7 +122,7 @@ func (s *NodeService) buildNodeReply(node *biz.Node, containers []*biz.Container
 	for _, device := range node.Devices {
 		nodeReply.Type = append(nodeReply.Type, device.Type)
 		nodeReply.VgpuTotal += device.Count
-		nodeReply.CoreTotal += device.Devcore
+		nodeReply.CoreTotal += biz.PhysicalCoreBaselinePerDevice
 		nodeReply.MemoryTotal += device.Devmem
 		vGPU, core, memory, coreKnown := biz.ContainersStatisticsInfo(containers, device.AliasId)
 		nodeReply.VgpuUsed += vGPU
@@ -143,23 +138,4 @@ func (s *NodeService) buildNodeReply(node *biz.Node, containers []*biz.Container
 	nodeReply.CardCnt = int32(len(node.Devices))
 
 	return nodeReply
-}
-
-// queryNodeGauge runs a single instant query whose result is grouped by the
-// "node" label and returns value-by-node, batching what used to be two PromQL
-// per node into one round-trip.
-func (s *NodeService) queryNodeGauge(ctx context.Context, query string) map[string]int32 {
-	out := map[string]int32{}
-	resp, err := s.ms.QueryInstant(ctx, &pb.QueryInstantRequest{Query: query})
-	if err != nil {
-		return out
-	}
-	for _, sample := range resp.Data {
-		node := sample.Metric["node"]
-		if node == "" {
-			continue
-		}
-		out[node] = int32(sample.Value)
-	}
-	return out
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`core_total` could switch between `DeviceInfo.Devcore` and the normalized
`hami_core_size=100` depending on whether Prometheus returned a sample. That
made the same allocation percentage change during scrape delays or monitoring
failures, and list/detail/summary endpoints did not share one capacity contract.

Use the device inventory as the single source of truth for physical compute
capacity: each registered accelerator contributes 100 percentage points.
`Devcore` remains the schedulable vCore capacity, while registered memory
continues to come from `DeviceInfo.Devmem`. The node and card services no longer
depend on Prometheus just to recover this constant baseline.

Tests cover two devices with non-default vCore capacities across node/card lists,
node/card details, aggregate summary, and a device-filtered summary.

**Verification**:

- `go test -count=1 -mod=readonly ./...`
- `go vet -mod=readonly ./...`
- `make verify-mod`
- pinned protobuf and Wire generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized reported physical compute capacity to a consistent 100-point baseline per accelerator.
  * Ensured node, GPU, summary, allocation, and exported metrics display matching capacity values.
  * Improved reliability by removing variability from externally queried device core measurements.

* **Tests**
  * Added coverage confirming consistent capacity results across node, GPU, summary, and filtered views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->