### PR TITLE
fix(metrics): respect fan telemetry capabilities

### DIFF
--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -36,6 +36,7 @@ var (
 	errNoMetricData                 = errors.New("prometheus query returned no data")
 	errInvalidCoreCapacity          = errors.New("allocated core capacity must be greater than zero")
 	errWorkloadTelemetryUnsupported = errors.New("workload telemetry is not supported by provider")
+	errFanSpeedTelemetryUnsupported = errors.New("fan speed telemetry is not supported by provider")
 )
 
 type instantQuerier interface {
@@ -705,12 +706,17 @@ func (s *MetricsGenerator) fanSpeed(ctx context.Context, provider, deviceUUID st
 		query = fmt.Sprintf("avg(DCGM_FI_DEV_FAN_SPEED{UUID=\"%s\"})", deviceUUID)
 	case biz.CambriconGPUDevice:
 		query = fmt.Sprintf("avg(mlu_fan_speed{uuid=\"%s\"})", deviceUUID)
-	case biz.AscendGPUDevice:
-		query = fmt.Sprintf("avg(npu_chip_link_speed{vdie_id=\"%s\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, errFanSpeedTelemetryUnsupported
 	}
-	return s.queryRequiredInstantVal(ctx, query)
+	fanSpeed, err := s.queryRequiredInstantVal(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	if provider == biz.CambriconGPUDevice && fanSpeed == -1 {
+		return 0, errNoMetricData
+	}
+	return fanSpeed, nil
 }
 
 type DeviceAdditionalInfo struct {

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -294,6 +294,56 @@ func TestOptionalDeviceTelemetryDistinguishesMissingNonFiniteAndZero(t *testing.
 	}
 }
 
+func TestFanSpeedAppliesProviderCapabilitiesAndSentinels(t *testing.T) {
+	t.Run("Ascend is unsupported without a query", func(t *testing.T) {
+		querier := &fakeInstantQuerier{}
+		generator := &MetricsGenerator{monitorService: querier}
+		_, err := generator.fanSpeed(context.Background(), biz.AscendGPUDevice, "Ascend-1")
+		if !errors.Is(err, errFanSpeedTelemetryUnsupported) {
+			t.Fatalf("fanSpeed() error = %v, want errFanSpeedTelemetryUnsupported", err)
+		}
+		if len(querier.queries) != 0 {
+			t.Fatalf("unsupported Ascend fan speed made queries: %v", querier.queries)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		provider  string
+		deviceID  string
+		query     string
+		value     float32
+		wantValue float32
+		wantErr   error
+	}{
+		{
+			name: "MLU no-fan sentinel is unavailable", provider: biz.CambriconGPUDevice, deviceID: "MLU-1",
+			query: `avg(mlu_fan_speed{uuid="MLU-1"})`, value: -1, wantErr: errNoMetricData,
+		},
+		{
+			name: "MLU explicit zero is preserved", provider: biz.CambriconGPUDevice, deviceID: "MLU-2",
+			query: `avg(mlu_fan_speed{uuid="MLU-2"})`, value: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			querier := &fakeInstantQuerier{responsesByQuery: map[string]*pb.InstantResponse{tt.query: instantValue(tt.value)}}
+			generator := &MetricsGenerator{monitorService: querier}
+			value, err := generator.fanSpeed(context.Background(), tt.provider, tt.deviceID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("fanSpeed() error = %v, want %v", err, tt.wantErr)
+			}
+			if value != tt.wantValue {
+				t.Fatalf("fanSpeed() = %v, want %v", value, tt.wantValue)
+			}
+			if len(querier.queries) != 1 || querier.queries[0] != tt.query {
+				t.Fatalf("fanSpeed() queries = %v, want [%s]", querier.queries, tt.query)
+			}
+		})
+	}
+}
+
 func TestLastXIDErrorCodeUsesNvidiaMetricAndRejectsUnsupportedProvider(t *testing.T) {
 	t.Run("NVIDIA", func(t *testing.T) {
 		querier := &fakeInstantQuerier{responses: []*pb.InstantResponse{instantValue(79)}}
@@ -648,6 +698,65 @@ func TestGenerateDeviceMetricsExportsOnlyPresentFiniteOptionalTelemetry(t *testi
 				if tt.wantTracked && testutil.ToFloat64(gauge.WithLabelValues(labels...)) != tt.wantValue {
 					t.Fatalf("optional gauge value = %v, want %v", testutil.ToFloat64(gauge.WithLabelValues(labels...)), tt.wantValue)
 				}
+			}
+		})
+	}
+}
+
+func TestGenerateDeviceMetricsAppliesFanCapabilitiesAndSentinels(t *testing.T) {
+	t.Run("Ascend emits no fan query or gauge", func(t *testing.T) {
+		const deviceID = "Ascend-fan-unsupported"
+		generator := newDeviceMetricsTestGenerator(
+			&biz.DeviceInfo{
+				Id: deviceID, Devmem: 65536, Devcore: 100, Count: 1,
+				Type: "Ascend910B", NodeName: "node-ascend-fan", Provider: biz.AscendGPUDevice,
+			},
+			map[string]*pb.InstantResponse{},
+		)
+		t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+		if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+			t.Fatalf("GenerateDeviceMetrics() error = %v", err)
+		}
+		queries := generator.monitorService.(*fakeInstantQuerier).queries
+		for _, query := range queries {
+			if strings.Contains(query, "npu_chip_link_speed") {
+				t.Fatalf("Ascend fan capability emitted link-speed query: %s", query)
+			}
+		}
+		labels := []string{"node-ascend-fan", biz.AscendGPUDevice, "Ascend910B", deviceID, "", ""}
+		assertGaugeTracked(t, generator, HamiDeviceFanSpeedP, labels, false)
+		assertGaugeTracked(t, generator, HamiDeviceFanSpeedR, labels, false)
+	})
+
+	mluTests := []struct {
+		name        string
+		deviceID    string
+		value       float32
+		wantTracked bool
+	}{
+		{name: "no-fan sentinel is omitted", deviceID: "MLU-fan-missing", value: -1},
+		{name: "explicit zero is exported", deviceID: "MLU-fan-zero", value: 0, wantTracked: true},
+	}
+	for _, tt := range mluTests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := `avg(mlu_fan_speed{uuid="` + tt.deviceID + `"})`
+			generator := newDeviceMetricsTestGenerator(
+				&biz.DeviceInfo{
+					Id: tt.deviceID, Devmem: 32768, Devcore: 100, Count: 1,
+					Type: "MLU370", NodeName: "node-mlu-fan", Provider: biz.CambriconGPUDevice,
+				},
+				map[string]*pb.InstantResponse{query: instantValue(tt.value)},
+			)
+			t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+			if err := generator.GenerateDeviceMetrics(context.Background()); err != nil {
+				t.Fatalf("GenerateDeviceMetrics() error = %v", err)
+			}
+			labels := []string{"node-mlu-fan", biz.CambriconGPUDevice, "MLU370", tt.deviceID, "", ""}
+			assertGaugeTracked(t, generator, HamiDeviceFanSpeedR, labels, tt.wantTracked)
+			if tt.wantTracked {
+				assertTrackedGaugeValue(t, generator, HamiDeviceFanSpeedR, labels, 0)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Two provider-specific fan contracts were being interpreted incorrectly:

- Ascend was queried through `npu_chip_link_speed`, which is network link
  speed in MB/s, not fan telemetry. Ascend has no supported fan metric in the
  current producer contract, so the exporter now skips the query.
- Cambricon `mlu_fan_speed=-1` explicitly means that the MLU has no fan. The
  exporter now omits that unavailable sample while preserving a real zero RPM.

This prevents a meaningless Ascend query and avoids publishing `-1 RPM` as
device telemetry.

Producer references:

- [Ascend link-speed metric](https://github.com/Ascend/mind-cluster/blob/78655a79e2f9ff09e88df45c29706c6b1d6c2689/docs/zh/scheduling/06_api/00_npu_exporter/01_prometheus_metrics_api.md#L548-L555)
- [Cambricon fan sentinel](https://github.com/Cambricon/mlu-exporter/blob/02ba4ac78d7d8929b9bed8247536b285a17e34de/examples/metrics.yaml#L752-L764)

**Verification**:

- `go test -count=1 -mod=readonly ./...`
- `go vet -mod=readonly ./...`
- `make verify-mod`

Tests cover query selection and final metric emission for unsupported Ascend fan
telemetry, Cambricon's no-fan sentinel, and an explicit zero RPM.