### PR TITLE
fix(metrics): total workload allocation rankings

### DIFF
--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -106,14 +106,31 @@ export const buildTaskComputeAllocationQuery = ({
 } = {}) => {
   validateGroupLabel(groupLabel);
   const allocated = metricSeries(METRICS.computeAllocated, selector);
-  const aggregate = groupLabel
-    ? `avg by (${groupLabel}) (${allocated})`
-    : aggregateAcrossExporterReplicas(allocated);
+  const aggregate = aggregateAcrossExporterReplicas(allocated, groupLabel);
 
   return excludeUnknownComputeAllocations(aggregate, {
     selector,
     groupLabel,
   });
+};
+
+export const buildTaskAllocationTopQueries = () => {
+  const groupLabel = 'container_pod_uuid';
+  const compute = buildTaskComputeAllocationQuery({ groupLabel });
+  const memory = aggregateAcrossExporterReplicas(
+    METRICS.memoryAllocated,
+    groupLabel,
+  );
+  const vgpu = aggregateAcrossExporterReplicas(
+    METRICS.vgpuAllocated,
+    groupLabel,
+  );
+
+  return {
+    compute: `topk(5, (${compute}) / 100)`,
+    memory: `topk(5, ${memory} / 1024)`,
+    vgpu: `topk(5, ${vgpu})`,
+  };
 };
 
 export const buildTaskResourceOverviewQueries = ({ selector = '' } = {}) => {

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -7,6 +7,7 @@ import {
   buildGroupedResourceTopQueries,
   buildMemoryAllocationQueries,
   buildMemoryUsageQueries,
+  buildTaskAllocationTopQueries,
   buildTaskComputeAllocationQuery,
   buildTaskCountQueries,
   buildTaskResourceOverviewQueries,
@@ -60,12 +61,38 @@ test('task compute queries reject partial unknown allocations', () => {
   );
   assert.match(
     ranked,
-    /^\(avg by \(container_pod_uuid\) \(hami_container_vcore_allocated\)/,
+    /^\(avg by \(container_pod_uuid\) \(sum by \(container_pod_uuid, instance\) \(hami_container_vcore_allocated\)\)\)/,
   );
   assert.match(
     ranked,
     /unless on \(container_pod_uuid\) max by \(container_pod_uuid\)/,
   );
+});
+
+test('workload allocation rankings total cards within each exporter replica', () => {
+  const queries = buildTaskAllocationTopQueries();
+  const replicaSafe = (metric) =>
+    `avg by (container_pod_uuid) (sum by (container_pod_uuid, instance) (${metric}))`;
+
+  assert.equal(
+    queries.compute,
+    `topk(5, ((${replicaSafe('hami_container_vcore_allocated')}) unless on (container_pod_uuid) max by (container_pod_uuid) (hami_container_vcore_allocation_known == 0)) / 100)`,
+  );
+  assert.equal(
+    queries.memory,
+    `topk(5, ${replicaSafe('hami_container_vmemory_allocated')} / 1024)`,
+  );
+  assert.equal(
+    queries.vgpu,
+    `topk(5, ${replicaSafe('hami_container_vgpu_allocated')})`,
+  );
+
+  for (const query of Object.values(queries)) {
+    assert.doesNotMatch(
+      query,
+      /avg by \(container_pod_uuid\) \(hami_container_/,
+    );
+  }
 });
 
 test('task resource totals stay stable for one or two exporter replicas and multiple cards', () => {

--- a/packages/web/projects/vgpu/views/task/admin/top.vue
+++ b/packages/web/projects/vgpu/views/task/admin/top.vue
@@ -12,16 +12,14 @@ import { ElMessage } from 'element-plus';
 import { useI18n } from 'vue-i18n';
 import { computed } from 'vue';
 import {
-  buildTaskComputeAllocationQuery,
+  buildTaskAllocationTopQueries,
   buildTaskCountQueries,
 } from '~/vgpu/metrics/query-contract.mjs';
 
 const router = useRouter();
 const { t } = useI18n();
 const taskCountQueries = buildTaskCountQueries();
-const taskComputeAllocationQuery = buildTaskComputeAllocationQuery({
-  groupLabel: 'container_pod_uuid',
-});
+const taskAllocationTopQueries = buildTaskAllocationTopQueries();
 
 const handleChartClick = async (params) => {
   const name = params.data.name;
@@ -83,8 +81,8 @@ const topConfig = computed(() => [
         key: 'core',
         data: [],
         nameKey: 'container_pod_uuid',
-        unit: ' ',
-        query: `topk(5, ${taskComputeAllocationQuery})`,
+        unit: t('dashboard.acceleratorEquivalentUnit'),
+        query: taskAllocationTopQueries.compute,
       },
       {
         tab: t('dashboard.memory'),
@@ -92,8 +90,7 @@ const topConfig = computed(() => [
         data: [],
         unit: 'GiB',
         nameKey: 'container_pod_uuid',
-        query:
-          'topk(5, avg by (container_pod_uuid) (hami_container_vmemory_allocated))/1024',
+        query: taskAllocationTopQueries.memory,
       },
       {
         tab: 'vGPU',
@@ -101,7 +98,7 @@ const topConfig = computed(() => [
         data: [],
         nameKey: 'container_pod_uuid',
         unit: t('dashboard.vgpuSlotUnit'),
-        query: 'topk(5, avg by (container_pod_uuid) (hami_container_vgpu_allocated))',
+        query: taskAllocationTopQueries.vgpu,
       },
     ],
   },

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -310,7 +310,7 @@ export default {
     memoryUsageTrend: 'Memory Usage (%)',
     noMonitorSupport: 'Vendor does not support task-level monitoring',
     topCount: 'Workload Count Top5',
-    topApply: 'Workload Requests Top5',
+    topApply: 'Workload Allocation Top5',
     detail: {
       title: 'Workload',
       detailInfo: 'Basic Info',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -306,7 +306,7 @@ export default {
     memoryUsageTrend: '内存使用率（%）',
     noMonitorSupport: '该设备厂商暂不支持任务维度监控',
     topCount: '任务数量分布 Top5',
-    topApply: '任务资源申请 Top5',
+    topApply: '工作负载分配 Top5',
     detail: {
       title: '任务管理',
       detailInfo: '基础信息',

--- a/test/web-entry/web-entry.browser.test.mjs
+++ b/test/web-entry/web-entry.browser.test.mjs
@@ -790,7 +790,7 @@ test('browser language selects English without leaking active Chinese UI text', 
 
     const requestsCard = page.locator('.task-top-box .home-block').nth(1)
     await requestsCard.locator('.title')
-      .filter({ hasText: 'Workload Requests Top5' })
+      .filter({ hasText: 'Workload Allocation Top5' })
       .waitFor()
     await requestsCard.locator('.t-radio-button')
       .filter({ hasText: 'vGPU' })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The workload allocation Top5 used `avg by (container_pod_uuid)` directly on
per-device metrics. That kept duplicate WebUI replicas from doubling the value,
but it also averaged the cards assigned to a multi-card workload. For example,
30 + 70 vCore appeared as 50, 4 + 8 GiB as 6 GiB, and two allocated slots as 1.

Aggregate each workload in two stages:

1. sum its device series inside each exporter instance;
2. average equivalent instance totals across WebUI replicas.

The compute ranking is shown as accelerator equivalents (allocated vCore / 100),
while memory remains GiB and vGPU remains slots. The title now says
`Workload Allocation Top5` because these series represent current allocations,
not pending requests.

The existing unknown-Ascend allocation exclusion is preserved.

**Verification**:

- all 94 frontend contract tests
- frontend ESLint
- production Vite build
- source-language verification

The query contract test asserts the exact two-stage aggregation for compute,
memory, and vGPU.