### PR TITLE
fix(metrics): include idle nodes in workload distribution

### DIFF
--- a/packages/web/projects/vgpu/views/monitor/overview/index.vue
+++ b/packages/web/projects/vgpu/views/monitor/overview/index.vue
@@ -382,6 +382,7 @@ import Gauge from '~/vgpu/components/gauge.vue';
 import { getRangeConfigInit } from './config';
 import {
   createNodeTopQueries,
+  createNodeWorkloadDistributionQuery,
   createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 import {
@@ -521,7 +522,7 @@ const fetchNodeWorkloadTop5 = () =>
 const fetchNodeWorkloadDistribution = () =>
   fetchVectorRows(
     nodeWorkloadDistributionState,
-    'count(count by (node, container_pod_uuid) (hami_container_vgpu_allocated{})) by (node)',
+    createNodeWorkloadDistributionQuery(),
     (item) => ({
       name: item?.metric?.node || '-',
       value: Number(item?.value),

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.mjs
@@ -96,3 +96,6 @@ export const createOverviewGaugeConfigs = () => {
 
 export const createNodeTopQueries = () =>
   buildGroupedResourceTopQueries('node');
+
+export const createNodeWorkloadDistributionQuery = () =>
+  'count(count by (node, container_pod_uuid) (hami_container_vgpu_allocated)) by (node) or on (node) (count by (node) (hami_vgpu_count) * 0)';

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   createComputeUsageGaugeConfig,
   createNodeTopQueries,
+  createNodeWorkloadDistributionQuery,
   createOverviewGaugeConfigs,
 } from './metric-config.mjs';
 
@@ -104,4 +105,14 @@ test('node allocation rankings keep idle nodes and exclude unknown compute scope
     /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
   );
   assert.doesNotMatch(queries.memoryUsage, / or /);
+});
+
+test('node workload distribution includes idle accelerator inventory nodes', () => {
+  const query = createNodeWorkloadDistributionQuery();
+
+  assert.equal(
+    query,
+    'count(count by (node, container_pod_uuid) (hami_container_vgpu_allocated)) by (node) or on (node) (count by (node) (hami_vgpu_count) * 0)',
+  );
+  assert.doesNotMatch(query, /vector\(0\)/);
 });

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -133,7 +133,7 @@ export default {
     nodeWorkloadTop5: 'Node Workload Count Top5',
     nodeWorkloadDistribution: 'Node Workload Distribution',
     nodeWorkloadDistributionDesc1:
-      'Show the distribution of all cluster nodes by workload-count ranges.',
+      'Show HAMi-managed accelerator nodes by workload-count ranges, including idle nodes.',
     nodeWorkloadDistributionDesc2:
       'X-axis is workload-count range per node, and Y-axis is number of nodes in that range.',
     workload24hTrendTop5: '24h Workload Usage Trend Top5 (%)',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -131,7 +131,7 @@ export default {
     nodeMemoryTop5: '节点显存 Top5',
     nodeWorkloadTop5: '节点工作负载数量 Top5',
     nodeWorkloadDistribution: '节点工作负载分布（台）',
-    nodeWorkloadDistributionDesc1: '展示集群中所有节点的工作负载在不同数量区间的分布情况。',
+    nodeWorkloadDistributionDesc1: '展示 HAMi 管理的加速卡节点在不同工作负载数量区间的分布，包含空闲节点。',
     nodeWorkloadDistributionDesc2: '横轴是节点的工作负载数量范围，纵轴表示落入该范围的节点数量。',
     workload24hTrendTop5: '24 小时工作负载使用趋势 Top5 (%)',
     workloadRange: '工作负载区间',


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The overview's node workload distribution only used container allocation
metrics. HAMi-managed accelerator nodes with no current workload therefore
disappeared, and an entirely idle cluster looked like missing telemetry.

Use `hami_vgpu_count` as the accelerator-node inventory and add zero only for
idle nodes with `or on (node)`. Busy-node counts remain unchanged, CPU-only
nodes remain out of scope, and a missing HAMi inventory still stays missing
rather than becoming a synthetic zero.

The tooltip now states the actual scope: HAMi-managed accelerator nodes,
including idle nodes.

**Verification**:

- Frontend unit and metric-contract tests pass.
- ESLint and source-language checks pass.
- Production Vite build passes.
- The query contract rejects a global `vector(0)` fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload distribution metrics to include idle accelerator nodes and accurately count workloads per node.

* **Documentation**
  * Clarified English and Chinese descriptions to explain that the chart covers HAMi-managed accelerator nodes, including idle nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->