### PR TITLE
fix(metrics): match detail identities exactly

### DIFF
--- a/packages/web/projects/vgpu/metrics/promql-template.mjs
+++ b/packages/web/projects/vgpu/metrics/promql-template.mjs
@@ -1,0 +1,11 @@
+export const promQLStringLiteral = (value) => JSON.stringify(String(value));
+
+const PROMQL_TEMPLATE_VARIABLE = /\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+export const renderPromQLTemplate = (query, variables) =>
+  query.replace(PROMQL_TEMPLATE_VARIABLE, (placeholder, name) => {
+    if (!Object.hasOwn(variables, name)) {
+      throw new TypeError(`Missing PromQL template variable: ${name}`);
+    }
+    return promQLStringLiteral(variables[name]);
+  });

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -12,6 +13,55 @@ import {
   buildTaskCountQueries,
   buildTaskResourceOverviewQueries,
 } from './query-contract.mjs';
+import {
+  promQLStringLiteral,
+  renderPromQLTemplate,
+} from './promql-template.mjs';
+
+test('PromQL templates render complete escaped string literals', () => {
+  assert.equal(promQLStringLiteral('gpu.node-1'), '"gpu.node-1"');
+  assert.equal(promQLStringLiteral('GPU-"lab"'), '"GPU-\\"lab\\""');
+  assert.equal(promQLStringLiteral('rack\\slot'), '"rack\\\\slot"');
+  assert.equal(promQLStringLiteral('train\nv1'), '"train\\nv1"');
+
+  assert.equal(
+    renderPromQLTemplate(
+      'metric{node=$node,device_uuid=$device_uuid,pod=$pod}',
+      {
+        node: 'gpu.node-1',
+        device_uuid: 'GPU-"lab"\\slot',
+        pod: 'train\nv1',
+      },
+    ),
+    'metric{node="gpu.node-1",device_uuid="GPU-\\"lab\\"\\\\slot",pod="train\\nv1"}',
+  );
+  assert.equal(
+    renderPromQLTemplate('metric{device_uuid=$device_uuid,pod=$pod}', {
+      device_uuid: 'GPU-$pod',
+      pod: 'train-v1',
+    }),
+    'metric{device_uuid="GPU-$pod",pod="train-v1"}',
+  );
+  assert.throws(
+    () => renderPromQLTemplate('metric{node=$node}', {}),
+    /Missing PromQL template variable: node/,
+  );
+});
+
+test('detail queries do not regex-match exact resource identities', () => {
+  const exactIdentityRegex =
+    /\b(?:node|pod|pod_name|container|container_name|namespace|namespace_name|device_uuid)=~/;
+  const detailFiles = [
+    '../views/node/admin/Detail.vue',
+    '../views/card/admin/Detail.vue',
+    '../views/task/admin/Detail.vue',
+  ];
+
+  for (const file of detailFiles) {
+    const source = readFileSync(new URL(file, import.meta.url), 'utf8');
+    assert.doesNotMatch(source, exactIdentityRegex, file);
+  }
+});
 
 test('compute allocation stays idle at real zero and hides unknown allocations', () => {
   const queries = buildComputeAllocationQueries();
@@ -33,19 +83,19 @@ test('compute allocation stays idle at real zero and hides unknown allocations',
 
 test('scoped compute allocation excludes the whole affected group', () => {
   const queries = buildComputeAllocationQueries({
-    selector: 'node=~"$node"',
+    selector: 'node=$node',
     groupLabel: 'node',
   });
 
   assert.match(
     queries.percentQuery,
-    /unless on \(node\) max by \(node\) \(hami_container_vcore_allocation_known\{node=~"\$node"\} == 0\)/,
+    /unless on \(node\) max by \(node\) \(hami_container_vcore_allocation_known\{node=\$node\} == 0\)/,
   );
 });
 
 test('task compute queries reject partial unknown allocations', () => {
   const selector =
-    'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+    'container_name=$container,pod_name=$pod,namespace_name=$namespace';
   const detail = buildTaskComputeAllocationQuery({ selector });
   const ranked = buildTaskComputeAllocationQuery({
     groupLabel: 'container_pod_uuid',
@@ -97,7 +147,7 @@ test('workload allocation rankings total cards within each exporter replica', ()
 
 test('task resource totals stay stable for one or two exporter replicas and multiple cards', () => {
   const selector =
-    'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+    'container_name=$container,pod_name=$pod,namespace_name=$namespace';
   const queries = buildTaskResourceOverviewQueries({ selector });
   const vgpuSeries = `hami_container_vgpu_allocated{${selector}}`;
   const coreSeries = `hami_container_vcore_allocated{${selector}}`;
@@ -145,16 +195,16 @@ test('memory allocation uses schedulable capacity and fills idle allocation', ()
 
 test('scoped memory allocation keeps the same contract for node and card details', () => {
   const node = buildMemoryAllocationQueries({
-    selector: 'node=~"$node"',
+    selector: 'node=$node',
   });
   const card = buildMemoryAllocationQueries({
-    selector: 'device_uuid=~"$device_uuid"',
+    selector: 'device_uuid=$device_uuid',
   });
 
-  assert.match(node.totalQuery, /hami_vmemory_size\{node=~"\$node"\}/);
+  assert.match(node.totalQuery, /hami_vmemory_size\{node=\$node\}/);
   assert.match(
     card.totalQuery,
-    /hami_vmemory_size\{device_uuid=~"\$device_uuid"\}/,
+    /hami_vmemory_size\{device_uuid=\$device_uuid\}/,
   );
   assert.match(node.percentQuery, / or /);
   assert.match(card.percentQuery, / or /);

--- a/packages/web/projects/vgpu/views/card/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/card/admin/Detail.vue
@@ -308,6 +308,7 @@ import {
   buildMemoryAllocationQueries,
   buildMemoryUsageQueries,
 } from '~/vgpu/metrics/query-contract.mjs';
+import { renderPromQLTemplate } from '~/vgpu/metrics/promql-template.mjs';
 import { buildNodeDetailLocation } from '~/vgpu/views/node/detail-location.mjs';
 import { formatOptionalTelemetry } from './optional-telemetry-display.mjs';
 
@@ -385,7 +386,7 @@ const start = new Date();
 start.setTime(start.getTime() - 3600 * 1000);
 
 const times = ref([start, end]);
-const cardMetricSelector = 'device_uuid=~"$device_uuid"';
+const cardMetricSelector = 'device_uuid=$device_uuid';
 const computeAllocationQueries = buildComputeAllocationQueries({
   selector: cardMetricSelector,
 });
@@ -431,8 +432,8 @@ const _gaugeConfigBase = [
   {
     titleKey: 'dashboard.computeUsageRate',
     percent: 0,
-    query: `avg(sum(hami_core_util{device_uuid=~"$device_uuid"}) by (instance))`,
-    percentQuery: `avg(sum(hami_core_util_avg{device_uuid=~"$device_uuid"}) by (instance))`,
+    query: `avg(sum(hami_core_util{device_uuid=$device_uuid}) by (instance))`,
+    percentQuery: `avg(sum(hami_core_util_avg{device_uuid=$device_uuid}) by (instance))`,
     total: 100,
     used: 0,
     unit: ' ',
@@ -451,7 +452,9 @@ const _gaugeConfigBase = [
 
 const gaugeData = useInstantVector(
   _gaugeConfigBase.map(item => ({ ...item, title: t(item.titleKey) })),
-  (query) => query.replaceAll(`$device_uuid`, detailCardUuid.value),
+  (query) => renderPromQLTemplate(query, {
+    device_uuid: detailCardUuid.value,
+  }),
   times,
 );
 
@@ -555,7 +558,7 @@ const lineTools = ref([
   {
     titleKey: 'card.detail.gpuTemperatureTrend',
     seriesNameKey: 'card.detail.gpuTemperature',
-    query: `avg by (device_no,driver_version) (hami_device_temperature{device_uuid=~"$device_uuid"})`,
+    query: `avg by (device_no,driver_version) (hami_device_temperature{device_uuid=$device_uuid})`,
     data: [],
     unit: '℃',
     gaugeUnit: '℃',
@@ -567,7 +570,7 @@ const lineTools = ref([
   {
     titleKey: 'card.detail.gpuPowerTrend',
     seriesNameKey: 'card.detail.gpuPower',
-    query: `avg by (device_no,driver_version) (hami_device_power{device_uuid=~"$device_uuid"})`,
+    query: `avg by (device_no,driver_version) (hami_device_power{device_uuid=$device_uuid})`,
     data: [],
     unit: 'W',
     gaugeUnit: 'W',
@@ -602,7 +605,7 @@ const fetchLineData = async () => {
   }
 
   const requests = lineTools.value.flatMap((item, index) => {
-    const query = item.query.replaceAll(`$device_uuid`, uuid);
+    const query = renderPromQLTemplate(item.query, { device_uuid: uuid });
     const rangeRequest = cardApi
       .getRangeVector({
         range: {

--- a/packages/web/projects/vgpu/views/node/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/node/admin/Detail.vue
@@ -209,6 +209,7 @@ import {
   buildMemoryAllocationQueries,
   buildMemoryUsageQueries,
 } from '~/vgpu/metrics/query-contract.mjs';
+import { renderPromQLTemplate } from '~/vgpu/metrics/promql-template.mjs';
 import { createNodeComputeUsageGaugeConfig } from './metric-config.mjs';
 
 const route = useRoute();
@@ -243,7 +244,7 @@ const start = new Date();
 start.setTime(start.getTime() - 3600 * 1000);
 
 const times = ref([start, end]);
-const nodeMetricSelector = 'node=~"$node"';
+const nodeMetricSelector = 'node=$node';
 const computeAllocationQueries = buildComputeAllocationQueries({
   selector: nodeMetricSelector,
 });
@@ -291,12 +292,11 @@ const _gaugeConfigBase = [
 const gaugeData = useInstantVector(
   _gaugeConfigBase.map(item => ({ ...item, title: t(item.titleKey) })),
   (query) =>
-    query.replaceAll(
-      `$node`,
-      detailStatus.value === REQUEST_STATUS.READY
+    renderPromQLTemplate(query, {
+      node: detailStatus.value === REQUEST_STATUS.READY
         ? detail.value.name
         : 'undefined',
-    ),
+    }),
   times,
 );
 

--- a/packages/web/projects/vgpu/views/node/admin/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/node/admin/metric-config.test.mjs
@@ -12,13 +12,13 @@ import {
 import { createNodeComputeUsageGaugeConfig } from './metric-config.mjs';
 
 const config = createNodeComputeUsageGaugeConfig({
-  selector: 'node=~"$node"',
+  selector: 'node=$node',
 });
 
 test('node compute utilization stays normalized for one-card and eight-card nodes', () => {
   assert.equal(
     config.query,
-    'avg(avg(hami_core_util{node=~"$node"}) by (node, device_uuid))',
+    'avg(avg(hami_core_util{node=$node}) by (node, device_uuid))',
   );
   assert.equal(config.total, 100);
   assert.equal(config.totalQuery, undefined);

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -227,6 +227,7 @@ import { classifyDetailPayload } from '~/vgpu/hooks/detail-resource-state.mjs';
 import useDetailResource from '~/vgpu/hooks/useDetailResource';
 import { buildNodeDetailLocation } from '~/vgpu/views/node/detail-location.mjs';
 import { buildTaskResourceOverviewQueries } from '~/vgpu/metrics/query-contract.mjs';
+import { renderPromQLTemplate } from '~/vgpu/metrics/promql-template.mjs';
 
 const route = useRoute();
 const router = useRouter();
@@ -367,7 +368,7 @@ const basicCreateTime = computed(() => (
   detail.value?.createTime ? timeParse(detail.value.createTime) : '--'
 ));
 const taskAllocationSelector =
-  'container_name="$container",pod_name=~"$pod",namespace_name="$namespace"';
+  'container_name=$container,pod_name=$pod,namespace_name=$namespace';
 const taskResourceOverviewQueries = buildTaskResourceOverviewQueries({
   selector: taskAllocationSelector,
 });
@@ -388,25 +389,26 @@ const resourceOverviewData = useInstantVector(
     {
       key: 'cpuLimit',
       query:
-        `sum(kube_pod_container_resource_limits{resource="cpu", namespace="$namespace", pod=~"$pod", container="$container"})`,
+        `sum(kube_pod_container_resource_limits{resource="cpu", namespace=$namespace, pod=$pod, container=$container})`,
     },
     {
       key: 'memoryLimit',
       query:
-        `sum(kube_pod_container_resource_limits{resource="memory", namespace="$namespace", pod=~"$pod", container="$container"}) / 1024 / 1024 / 1024`,
+        `sum(kube_pod_container_resource_limits{resource="memory", namespace=$namespace, pod=$pod, container=$container}) / 1024 / 1024 / 1024`,
     },
     {
       key: 'containerInfo',
       query:
-        `count(kube_pod_container_info{namespace="$namespace", pod=~"$pod", container="$container"})`,
+        `count(kube_pod_container_info{namespace=$namespace, pod=$pod, container=$container})`,
     },
   ],
   (query) => {
     if (detailStatus.value !== REQUEST_STATUS.READY) return 'undefined';
-    return query
-      .replaceAll(`$container`, detail.value.name || '')
-      .replaceAll(`$namespace`, detail.value.namespace || '')
-      .replaceAll(`$pod`, detail.value.appName || '');
+    return renderPromQLTemplate(query, {
+      container: detail.value.name || '',
+      namespace: detail.value.namespace || '',
+      pod: detail.value.appName || '',
+    });
   },
 );
 const toNumOrUndefined = (v) => {
@@ -450,12 +452,12 @@ const handleGpuJump = (uuid) => {
 const lineConfig = ref([
   {
     titleKey: 'task.computeUsageTrend',
-    query: `avg(avg(hami_container_core_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid))`,
+    query: `avg(avg(hami_container_core_util{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid))`,
     data: [],
   },
   {
     titleKey: 'task.memUsageTrend',
-    query: `100 * sum(avg(hami_container_memory_used{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid)) / clamp_min(sum(avg(hami_container_vmemory_allocated{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (node, device_uuid)), 1)`,
+    query: `100 * sum(avg(hami_container_memory_used{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid)) / clamp_min(sum(avg(hami_container_vmemory_allocated{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid)), 1)`,
     data: [],
   },
 ]);
@@ -504,10 +506,11 @@ const fetchLineData = async () => {
           end: timeParse(rangeEnd),
           step: calculatePrometheusStep(rangeStart, rangeEnd),
         },
-        query: item.query
-          .replaceAll(`$container`, name)
-          .replaceAll(`$namespace`, namespace)
-          .replaceAll(`$pod`, appName),
+        query: renderPromQLTemplate(item.query, {
+          container: name,
+          namespace,
+          pod: appName,
+        }),
       });
       return { ok: true, data: res.data[0]?.values || [] };
     } catch {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Node, Pod, container, and device identities on detail pages are single exact
resource keys, but several PromQL selectors used regex matchers and inserted raw
values. A legal name such as `gpu.node-1` could therefore also match
`gpuXnode-1`, while quotes or backslashes in a provider device ID could produce
invalid PromQL.

Use equality matchers for these exact identities and render every template value
as a complete escaped PromQL string literal. The change covers Node, Card, and
Task instant and range queries; intentional regex use outside these singleton
detail identities is unchanged.

**Verification**:

- Full frontend unit and metric-contract tests pass.
- ESLint and source-language checks pass.
- Production Vite build passes.
- All 19 Chromium Web-entry contracts pass.
- Tests cover dots, quotes, backslashes, newlines, placeholder-like device IDs,
  missing template variables, and the absence of exact-identity regex matchers.