### PR TITLE
fix(metrics): make exporter refresh transactional

### DIFF
--- a/server/internal/exporter/cells.go
+++ b/server/internal/exporter/cells.go
@@ -14,13 +14,10 @@ import (
 // landed between reset() and the end of populate saw partial / empty data. The
 // resulting series flickered in and out of the UI at scrape boundaries.
 //
-// The fix: instead of wiping the GaugeVec at the start of each cycle, every Set
-// goes through MetricsGenerator.set, which both writes the value AND records the
-// (gauge, label tuple) it touched. After a cycle completes successfully, we walk
-// the previous cycle's recorded set and DeleteLabelValues for any tuple that
-// disappeared this round. Existing series are atomically overwritten in place,
-// brand-new series appear when their Set runs, vanished series disappear at the
-// end-of-cycle prune. There is no window where a known device is missing.
+// The fix: instead of wiping or mutating GaugeVecs while upstream queries are in
+// flight, every Set stages the value and label tuple in memory. A completed cycle
+// applies the staged values and removes tuples that disappeared. A fatal cycle can
+// therefore discard its staging map without leaking partial values or new labels.
 
 // cellKey identifies a single observation (gauge vector + concrete label tuple).
 // The joined string is just a map-key encoding of the labels; the original
@@ -33,18 +30,26 @@ type cellKey struct {
 type cell struct {
 	gauge  *prometheus.GaugeVec
 	labels []string
+	value  float64
 }
 
 // labelSep is a 0-byte separator that cannot appear in normal Prometheus label
 // values, so strings.Join produces an unambiguous key.
 const labelSep = "\x00"
 
-// set writes value into the gauge and records the (gauge, labels) tuple in the
-// current-cycle map. Safe for concurrent use; the collector itself only calls
-// it from one goroutine, but we lock anyway in case callers add a parallel pass.
-func (s *MetricsGenerator) set(g *prometheus.GaugeVec, value float64, labels ...string) {
-	g.WithLabelValues(labels...).Set(value)
+func (s *MetricsGenerator) beginCycle() {
+	s.cellMu.Lock()
+	s.current = make(map[cellKey]cell)
+	s.degradedCount = 0
+	s.firstDegraded = nil
+	s.fatalErr = nil
+	s.cellMu.Unlock()
+}
 
+// set stages a value and its label tuple in the current-cycle map. GaugeVecs are
+// only changed by commitCycle, so dropCurrentCycle can leave the last committed
+// registry snapshot untouched.
+func (s *MetricsGenerator) set(g *prometheus.GaugeVec, value float64, labels ...string) {
 	k := cellKey{gauge: g, joined: strings.Join(labels, labelSep)}
 	s.cellMu.Lock()
 	defer s.cellMu.Unlock()
@@ -52,20 +57,27 @@ func (s *MetricsGenerator) set(g *prometheus.GaugeVec, value float64, labels ...
 		s.current = make(map[cellKey]cell)
 	}
 	// Copy the labels slice — callers reuse the underlying array between iterations.
-	s.current[k] = cell{gauge: g, labels: append([]string(nil), labels...)}
+	s.current[k] = cell{gauge: g, labels: append([]string(nil), labels...), value: value}
 }
 
 // commitCycle promotes the current cycle to "previous" and removes any label
-// tuple that existed in the previous cycle but not this one. Call ONLY when the
-// cycle completed without being cut short by ctx cancellation: pruning on a
-// partial map would erroneously delete cells that just weren't re-Set this time.
+// tuple that existed in the previous cycle but not this one. It may commit a
+// best-effort degraded cycle, but must only be called after the full inventory
+// walk completes: pruning a fatally partial map would erase unvisited cells.
 func (s *MetricsGenerator) commitCycle() {
 	s.cellMu.Lock()
 	defer s.cellMu.Unlock()
 	if s.current == nil {
 		// Nothing was written this cycle; leave prev intact.
+		s.degradedCount = 0
+		s.firstDegraded = nil
+		s.fatalErr = nil
 		return
 	}
+	for _, c := range s.current {
+		c.gauge.WithLabelValues(c.labels...).Set(c.value)
+	}
+
 	deleted := 0
 	for k, c := range s.prev {
 		if _, ok := s.current[k]; ok {
@@ -80,17 +92,19 @@ func (s *MetricsGenerator) commitCycle() {
 	}
 	s.prev = s.current
 	s.current = nil
+	s.degradedCount = 0
+	s.firstDegraded = nil
+	s.fatalErr = nil
 }
 
 // dropCurrentCycle discards the in-progress map without promoting it. Use this
 // when a cycle ran into ctx cancellation or any other partial-completion path,
-// so the next cycle's prune still references the last KNOWN-GOOD snapshot.
-//
-// Any partial Set() calls that did land remain in the GaugeVec as freshly
-// overwritten cells — that is intentional and harmless, since they only update
-// values on label tuples that already existed.
+// so the next cycle's prune still references the last committed snapshot.
 func (s *MetricsGenerator) dropCurrentCycle() {
 	s.cellMu.Lock()
 	s.current = nil
+	s.degradedCount = 0
+	s.firstDegraded = nil
+	s.fatalErr = nil
 	s.cellMu.Unlock()
 }

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -37,10 +37,34 @@ var (
 	errInvalidCoreCapacity          = errors.New("allocated core capacity must be greater than zero")
 	errWorkloadTelemetryUnsupported = errors.New("workload telemetry is not supported by provider")
 	errFanSpeedTelemetryUnsupported = errors.New("fan speed telemetry is not supported by provider")
+	errTelemetryUnsupported         = errors.New("telemetry is not supported by provider")
 )
 
 type instantQuerier interface {
 	QueryInstant(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error)
+}
+
+type refreshFailure struct {
+	fatal bool
+	count int
+	first error
+}
+
+func (e *refreshFailure) Error() string {
+	kind := "degraded"
+	if e.fatal {
+		kind = "fatal"
+	}
+	return fmt.Sprintf("%s metrics refresh: %d error(s); first: %v", kind, e.count, e.first)
+}
+
+func (e *refreshFailure) Unwrap() error {
+	return e.first
+}
+
+func isFatalRefreshFailure(err error) bool {
+	var failure *refreshFailure
+	return errors.As(err, &failure) && failure.fatal
 }
 
 // MetricsGenerator owns the lifecycle of the background /metrics collector.
@@ -73,13 +97,24 @@ type MetricsGenerator struct {
 
 	// Diff-based cell tracking. See cells.go for the full rationale.
 	// current holds tuples written during the in-progress cycle; prev holds the
-	// last successfully-committed cycle so we know which tuples to delete when a
-	// device or container disappears.
+	// last committed cycle so we know which tuples to delete when a device or
+	// container disappears.
 	cellMu  sync.Mutex
 	current map[cellKey]cell
 	prev    map[cellKey]cell
 
-	cacheTime time.Time
+	degradedCount int
+	firstDegraded error
+	fatalErr      error
+
+	now func() time.Time
+}
+
+func (s *MetricsGenerator) clockNow() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 // roundToTwoDecimal rounds value to two decimal places.
@@ -124,6 +159,48 @@ func resolveCollectorIntervals(bc *conf.Bootstrap) (interval, timeout time.Durat
 		timeout = d
 	}
 	return
+}
+
+// recordTelemetryError records a failed query that was actually sent upstream.
+// Only cancellation of the cycle context itself is fatal; an upstream request
+// timeout while that context remains valid is a degraded query failure.
+func (s *MetricsGenerator) recordTelemetryError(ctx context.Context, err error) {
+	s.cellMu.Lock()
+	defer s.cellMu.Unlock()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if s.fatalErr == nil {
+			s.fatalErr = ctxErr
+		}
+		return
+	}
+	if s.firstDegraded == nil {
+		s.firstDegraded = err
+	}
+	s.degradedCount++
+}
+
+func (s *MetricsGenerator) recordFatalError(err error) error {
+	if err == nil {
+		return nil
+	}
+	s.cellMu.Lock()
+	if s.fatalErr == nil {
+		s.fatalErr = err
+	}
+	s.cellMu.Unlock()
+	return s.currentRefreshError()
+}
+
+func (s *MetricsGenerator) currentRefreshError() error {
+	s.cellMu.Lock()
+	defer s.cellMu.Unlock()
+	if s.fatalErr != nil {
+		return &refreshFailure{fatal: true, count: 1, first: s.fatalErr}
+	}
+	if s.degradedCount > 0 {
+		return &refreshFailure{count: s.degradedCount, first: s.firstDegraded}
+	}
+	return nil
 }
 
 // Start launches the background collector loop. It is invoked once by the kratos
@@ -194,17 +271,27 @@ func (s *MetricsGenerator) runOnce(parent context.Context) {
 
 	ctx, cancel := context.WithTimeout(parent, s.timeout)
 	defer cancel()
-	start := time.Now()
-	if err := s.GenerateMetrics(ctx); err != nil {
-		// Partial cycle (ctx canceled, upstream error, etc.): keep last known good
-		// snapshot intact so the registry doesn't briefly lose cells that simply
-		// could not be re-queried this round.
+	start := s.clockNow()
+	err := s.GenerateMetrics(ctx)
+	if isFatalRefreshFailure(err) {
 		s.dropCurrentCycle()
-		s.log.Errorw("msg", "metrics refresh failed (partial cycle, last-known cells retained)", "err", err, "elapsed", time.Since(start))
+		finished := s.clockNow()
+		HamiWebUIMetricsRefreshDurationSeconds.Set(finished.Sub(start).Seconds())
+		HamiWebUIMetricsRefreshSuccess.Set(0)
+		s.log.Errorw("msg", "metrics refresh failed (partial cycle, last-known cells retained)", "err", err, "elapsed", finished.Sub(start))
 		return
 	}
 	s.commitCycle()
-	s.log.Debugw("msg", "metrics refresh complete", "elapsed", time.Since(start))
+	finished := s.clockNow()
+	HamiWebUIMetricsRefreshDurationSeconds.Set(finished.Sub(start).Seconds())
+	if err != nil {
+		HamiWebUIMetricsRefreshSuccess.Set(0)
+		s.log.Warnw("msg", "metrics refresh degraded (best-effort snapshot committed)", "err", err, "elapsed", finished.Sub(start))
+		return
+	}
+	HamiWebUIMetricsRefreshLastSuccessTimestampSeconds.Set(float64(finished.Unix()))
+	HamiWebUIMetricsRefreshSuccess.Set(1)
+	s.log.Debugw("msg", "metrics refresh complete", "elapsed", finished.Sub(start))
 }
 
 // GenerateMetrics runs one full fanout cycle (device + container dimensions) into
@@ -212,35 +299,38 @@ func (s *MetricsGenerator) runOnce(parent context.Context) {
 // triggered manually if needed, but on the request path it must never be called
 // synchronously: the registry is the only thing /metrics serves.
 //
-// The function intentionally does NOT clear existing gauges. Each Set goes
-// through s.set, which both writes the value and records the (gauge, labels)
-// tuple. runOnce decides whether to commit the new snapshot (delete tuples that
-// disappeared) or drop it (keep the previous snapshot intact). See cells.go.
+// Each Set goes through s.set, which stages the value and label tuple without
+// touching the live GaugeVec. runOnce decides whether to commit the staged
+// snapshot or drop it and keep the previous registry values intact. See cells.go.
 func (s *MetricsGenerator) GenerateMetrics(ctx context.Context) error {
-	s.cellMu.Lock()
-	s.current = make(map[cellKey]cell)
-	s.cellMu.Unlock()
+	s.beginCycle()
 
-	s.GenerateDeviceMetrics(ctx)
-	s.GenerateContainerMetrics(ctx)
+	if err := s.GenerateDeviceMetrics(ctx); isFatalRefreshFailure(err) {
+		return err
+	}
+	if err := s.GenerateContainerMetrics(ctx); isFatalRefreshFailure(err) {
+		return err
+	}
 
 	// Surface ctx cancellation so runOnce treats this as a partial cycle and
 	// preserves the prior snapshot. Without this guard, a mid-cycle timeout
 	// would silently commit an incomplete map and erase real series.
 	if err := ctx.Err(); err != nil {
-		return err
+		return s.recordFatalError(err)
 	}
-	s.cacheTime = time.Now()
-	return nil
+	return s.currentRefreshError()
 }
 
 // GenerateDeviceMetrics refreshes device-level metrics from inventory and provider telemetry.
 func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 	deviceInfos, err := s.nodeUsecase.ListAllDevices(ctx)
 	if err != nil {
-		return err
+		return s.recordFatalError(fmt.Errorf("list devices: %w", err))
 	}
 	for _, device := range deviceInfos {
+		if err := ctx.Err(); err != nil {
+			return s.recordFatalError(err)
+		}
 		provider := device.Provider
 		deviceAdditional, err := s.queryDeviceAdditional(ctx, provider, device.Id)
 		var driver, deviceNo = "", ""
@@ -302,11 +392,17 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 			s.set(HamiDeviceLastXIDErrorCode, float64(lastXIDErrorCode), device.NodeName, provider, device.Type, device.Id, driver, deviceNo)
 		}
 	}
-	return nil
+	if err := ctx.Err(); err != nil {
+		return s.recordFatalError(err)
+	}
+	return s.currentRefreshError()
 }
 
-func (s *MetricsGenerator) generateMetricsForMetaxGPU(containers []*biz.Container) {
+func (s *MetricsGenerator) generateMetricsForMetaxGPU(ctx context.Context, containers []*biz.Container) error {
 	for _, c := range containers {
+		if err := ctx.Err(); err != nil {
+			return s.recordFatalError(err)
+		}
 		if len(c.ContainerDevices) == 0 {
 			continue
 		}
@@ -325,14 +421,18 @@ func (s *MetricsGenerator) generateMetricsForMetaxGPU(containers []*biz.Containe
 		query := fmt.Sprintf("mx_memory_used{exported_namespace=\"%s\", exported_pod=\"%s\", exported_container=\"%s\", type=\"vram\"}",
 			c.Namespace, c.PodName, c.Name)
 
-		res, err := s.monitorService.QueryInstant(context.TODO(), &pb.QueryInstantRequest{
-			Query: query,
-		})
+		res, err := s.queryInstant(ctx, query)
 		if err != nil {
+			if ctx.Err() != nil {
+				return s.currentRefreshError()
+			}
 			continue
 		}
 		reportLen := min(len(res.Data), len(c.ContainerDevices))
 		for i := range reportLen {
+			if err := ctx.Err(); err != nil {
+				return s.recordFatalError(err)
+			}
 			deviceUUID := res.Data[i].Metric["uuid"]
 			deviceType := res.Data[i].Metric["modelName"]
 			nodeName := res.Data[i].Metric["Hostname"]
@@ -343,39 +443,64 @@ func (s *MetricsGenerator) generateMetricsForMetaxGPU(containers []*biz.Containe
 			s.set(HamiContainerVcoreAllocated, float64(core[i]), nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace, podUIDLabel)
 
 			taskMemoryUsed := float32(res.Data[i].Value) // KB
-			s.set(HamiContainerMemoryUsed, float64(taskMemoryUsed/1024), nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
-			s.set(HamiContainerMemoryUtil, roundToOneDecimal(100*float64(taskMemoryUsed/1024)/float64(memory[i])), nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
+			if !math.IsNaN(float64(taskMemoryUsed)) && !math.IsInf(float64(taskMemoryUsed), 0) {
+				s.set(HamiContainerMemoryUsed, float64(taskMemoryUsed/1024), nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
+				if memory[i] > 0 {
+					s.set(HamiContainerMemoryUtil, roundToOneDecimal(100*float64(taskMemoryUsed/1024)/float64(memory[i])), nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
+				}
+			}
 
-			taskCoreUsed, err := s.taskCoreUsed(context.TODO(), metax.MetaxGPUDevice, c.Namespace, c.PodName, c.Name, c.PodUID, deviceUUID, nodeName, -1)
+			taskCoreUsed, err := s.taskCoreUsed(ctx, metax.MetaxGPUDevice, c.Namespace, c.PodName, c.Name, c.PodUID, deviceUUID, nodeName, -1)
 			if err == nil {
 				used := float64(taskCoreUsed)
-				util := roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core[0]))
-				cardCoreUtil, err := s.deviceCoreUtil(context.TODO(), metax.MetaxGPUDevice, deviceUUID)
+				util := math.NaN()
+				if core[i] > 0 {
+					util = roundToOneDecimal(100 * float64(taskCoreUsed) / float64(core[i]))
+				}
+				cardCoreUtil, err := s.deviceCoreUtil(ctx, metax.MetaxGPUDevice, deviceUUID)
 				if err == nil && used != 0 && cardCoreUtil > 95 {
 					used = float64(cardCoreUtil) / 100 * float64(core[i])
 					util = float64(cardCoreUtil)
+				} else if ctx.Err() != nil {
+					return s.currentRefreshError()
 				}
 				s.set(HamiContainerCoreUsed, used, nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
-				s.set(HamiContainerCoreUtil, util, nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
+				if !math.IsNaN(util) && !math.IsInf(util, 0) {
+					s.set(HamiContainerCoreUtil, util, nodeName, metax.MetaxGPUDevice, deviceType, deviceUUID, c.PodName, c.Name, c.Namespace)
+				}
+			} else if ctx.Err() != nil {
+				return s.currentRefreshError()
 			}
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return s.recordFatalError(err)
+	}
+	return s.currentRefreshError()
 }
 
 // GenerateContainerMetrics refreshes workload-level allocation and usage metrics.
 func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 	deviceInfos, err := s.nodeUsecase.ListAllDevices(ctx)
 	if err != nil {
-		return err
+		return s.recordFatalError(fmt.Errorf("list devices for container metrics: %w", err))
 	}
 	containers, err := s.podUsecase.ListAll(ctx)
 	if err != nil {
-		return err
+		return s.recordFatalError(fmt.Errorf("list containers: %w", err))
 	}
 
-	s.generateMetricsForMetaxGPU(containers)
+	if err := s.generateMetricsForMetaxGPU(ctx, containers); isFatalRefreshFailure(err) {
+		return err
+	}
 	for _, device := range deviceInfos {
+		if err := ctx.Err(); err != nil {
+			return s.recordFatalError(err)
+		}
 		for _, c := range containers {
+			if err := ctx.Err(); err != nil {
+				return s.recordFatalError(err)
+			}
 			var vGPU int32 = 0
 			var core int32 = 0
 			var memory int32 = 0
@@ -422,11 +547,16 @@ func (s *MetricsGenerator) GenerateContainerMetrics(ctx context.Context) error {
 				default:
 				}
 				s.set(HamiContainerMemoryUsed, float64(taskMemoryUsed/1024/1024), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
-				s.set(HamiContainerMemoryUtil, roundToOneDecimal(100*float64(taskMemoryUsed/1024/1024)/float64(memory)), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
+				if memory > 0 {
+					s.set(HamiContainerMemoryUtil, roundToOneDecimal(100*float64(taskMemoryUsed/1024/1024)/float64(memory)), device.NodeName, provider, device.Type, device.Id, c.PodName, c.Name, c.Namespace)
+				}
 			}
 		}
 	}
-	return nil
+	if err := ctx.Err(); err != nil {
+		return s.recordFatalError(err)
+	}
+	return s.currentRefreshError()
 }
 
 func (s *MetricsGenerator) queryInstantVal(ctx context.Context, query string) (float32, error) {
@@ -434,10 +564,16 @@ func (s *MetricsGenerator) queryInstantVal(ctx context.Context, query string) (f
 	return val, err
 }
 
+func (s *MetricsGenerator) queryInstant(ctx context.Context, query string) (*pb.InstantResponse, error) {
+	res, err := s.monitorService.QueryInstant(ctx, &pb.QueryInstantRequest{Query: query})
+	if err != nil {
+		s.recordTelemetryError(ctx, fmt.Errorf("prometheus query %q: %w", query, err))
+	}
+	return res, err
+}
+
 func (s *MetricsGenerator) queryInstantValWithPresence(ctx context.Context, query string) (float32, bool, error) {
-	res, err := s.monitorService.QueryInstant(ctx, &pb.QueryInstantRequest{
-		Query: query,
-	})
+	res, err := s.queryInstant(ctx, query)
 	if err != nil {
 		return 0, false, err
 	}
@@ -472,7 +608,7 @@ func (s *MetricsGenerator) deviceMemUsed(ctx context.Context, provider, deviceUU
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("avg(mx_memory_used{uuid=\"%s\", type=\"vram\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	val, err := s.queryRequiredInstantVal(ctx, query)
 	if err != nil {
@@ -495,7 +631,7 @@ func (s *MetricsGenerator) deviceMemTotal(ctx context.Context, provider, deviceU
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("avg(mx_memory_total{uuid=\"%s\", type=\"vram\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	val, err := s.queryRequiredInstantVal(ctx, query)
 	if err != nil {
@@ -529,7 +665,7 @@ func (s *MetricsGenerator) deviceCoreUtil(ctx context.Context, provider, deviceU
 	case biz.MetaxGPUDevice, metax.MetaxGPUDevice, metax.MetaxSGPUDevice:
 		query = fmt.Sprintf("avg(mx_gpu_usage{uuid=\"%s\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -551,7 +687,7 @@ func (s *MetricsGenerator) taskCoreUsed(ctx context.Context, provider, namespace
 		query = fmt.Sprintf("avg(mx_sgpu_usage{Hostname=\"%s\", deviceId=\"%d\", exported_namespace=\"%s\", exported_pod=\"%s\", exported_container=\"%s\"})",
 			hostname, deviceIndex, namespace, pod, container)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -602,6 +738,8 @@ func (s *MetricsGenerator) containerCoreMetrics(ctx context.Context, provider, n
 	if err == nil && used != 0 && cardCoreUtil > 95 {
 		used = float64(cardCoreUtil) / 100 * float64(allocatedCore)
 		util = float64(cardCoreUtil)
+	} else if ctx.Err() != nil {
+		return 0, 0, ctx.Err()
 	}
 	return used, util, nil
 }
@@ -623,7 +761,7 @@ func (s *MetricsGenerator) taskMemoryUsed(ctx context.Context, provider, namespa
 		query = fmt.Sprintf("avg(mx_sgpu_used_memory{Hostname=\"%s\", deviceId=\"%d\", exported_namespace=\"%s\", exported_pod=\"%s\", exported_container=\"%s\"})",
 			hostname, deviceIndex, namespace, pod, container)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -642,7 +780,7 @@ func (s *MetricsGenerator) gpuTemperature(ctx context.Context, provider, deviceU
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("avg(mx_chip_hotspot_temp{uuid=\"%s\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -659,7 +797,7 @@ func (s *MetricsGenerator) memoryTemperature(ctx context.Context, provider, devi
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("avg(mx_chip_hbm_temp{uuid=\"%s\"})", deviceUUID)
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -678,7 +816,7 @@ func (s *MetricsGenerator) gpuPower(ctx context.Context, provider, deviceUUID st
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("avg(mx_board_power{uuid=\"%s\"})", deviceUUID) // mW
 	default:
-		return 0, errors.New("provider not exists")
+		return 0, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
 
 	power, err := s.queryRequiredInstantVal(ctx, query)
@@ -694,7 +832,7 @@ func (s *MetricsGenerator) lastXIDErrorCode(ctx context.Context, provider, devic
 	case biz.NvidiaGPUDevice:
 		query = fmt.Sprintf("avg(DCGM_FI_DEV_XID_ERRORS{UUID=\"%s\"})", deviceUUID)
 	default:
-		return 0, fmt.Errorf("last XID error code is not supported by provider %q", provider)
+		return 0, fmt.Errorf("%w: last XID error code for %q", errTelemetryUnsupported, provider)
 	}
 	return s.queryRequiredInstantVal(ctx, query)
 }
@@ -738,11 +876,9 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 	case biz.MetaxGPUDevice:
 		query = fmt.Sprintf("mx_board_power{uuid=\"%s\"}", deviceUUID)
 	default:
-		return nil, errors.New("provider not exists")
+		return nil, fmt.Errorf("%w: %q", errTelemetryUnsupported, provider)
 	}
-	res, err := s.monitorService.QueryInstant(context.TODO(), &pb.QueryInstantRequest{
-		Query: query,
-	})
+	res, err := s.queryInstant(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -767,7 +903,7 @@ func (s *MetricsGenerator) queryDeviceAdditional(ctx context.Context, provider, 
 		}
 		return info, nil
 	}
-	return nil, fmt.Errorf("unknown error")
+	return nil, errNoMetricData
 }
 
 func (s *MetricsGenerator) systemComponentHealth(ctx context.Context, componentType, componentName string) (float32, error) {

--- a/server/internal/exporter/exporter_test.go
+++ b/server/internal/exporter/exporter_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 type fakeInstantQuerier struct {
@@ -23,10 +22,14 @@ type fakeInstantQuerier struct {
 	errorsByQuery    map[string]error
 	queryErr         error
 	queries          []string
+	query            func(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error)
 }
 
-func (f *fakeInstantQuerier) QueryInstant(_ context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+func (f *fakeInstantQuerier) QueryInstant(ctx context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
 	f.queries = append(f.queries, req.GetQuery())
+	if f.query != nil {
+		return f.query(ctx, req)
+	}
 	if f.queryErr != nil {
 		return nil, f.queryErr
 	}
@@ -45,7 +48,9 @@ func (f *fakeInstantQuerier) QueryInstant(_ context.Context, req *pb.QueryInstan
 }
 
 type fakeNodeRepo struct {
-	devices []*biz.DeviceInfo
+	devices            []*biz.DeviceInfo
+	err                error
+	listAllDevicesFunc func(context.Context) ([]*biz.DeviceInfo, error)
 }
 
 func (f *fakeNodeRepo) ListAll(context.Context) ([]*biz.Node, error) {
@@ -56,8 +61,11 @@ func (f *fakeNodeRepo) GetNode(context.Context, string) (*biz.Node, error) {
 	return nil, nil
 }
 
-func (f *fakeNodeRepo) ListAllDevices(context.Context) ([]*biz.DeviceInfo, error) {
-	return f.devices, nil
+func (f *fakeNodeRepo) ListAllDevices(ctx context.Context) ([]*biz.DeviceInfo, error) {
+	if f.listAllDevicesFunc != nil {
+		return f.listAllDevicesFunc(ctx)
+	}
+	return f.devices, f.err
 }
 
 func (f *fakeNodeRepo) FindDeviceByAliasId(string) (*biz.DeviceInfo, error) {
@@ -66,10 +74,11 @@ func (f *fakeNodeRepo) FindDeviceByAliasId(string) (*biz.DeviceInfo, error) {
 
 type fakePodRepo struct {
 	containers []*biz.Container
+	err        error
 }
 
 func (f *fakePodRepo) ListAll(context.Context) ([]*biz.Container, error) {
-	return f.containers, nil
+	return f.containers, f.err
 }
 
 func (f *fakePodRepo) FindOne(context.Context, string, string) (*biz.Container, error) {
@@ -695,8 +704,8 @@ func TestGenerateDeviceMetricsExportsOnlyPresentFiniteOptionalTelemetry(t *testi
 				HamiDeviceFanSpeedP,
 			} {
 				assertGaugeTracked(t, generator, gauge, labels, tt.wantTracked)
-				if tt.wantTracked && testutil.ToFloat64(gauge.WithLabelValues(labels...)) != tt.wantValue {
-					t.Fatalf("optional gauge value = %v, want %v", testutil.ToFloat64(gauge.WithLabelValues(labels...)), tt.wantValue)
+				if tt.wantTracked {
+					assertTrackedGaugeValue(t, generator, gauge, labels, tt.wantValue)
 				}
 			}
 		})
@@ -799,8 +808,8 @@ func TestGenerateDeviceMetricsExportsOnlyPresentXIDErrorCodes(t *testing.T) {
 			}
 			labels := []string{"node-xid", biz.NvidiaGPUDevice, "A100", tt.deviceID, "", ""}
 			assertGaugeTracked(t, generator, HamiDeviceLastXIDErrorCode, labels, tt.wantTracked)
-			if tt.wantTracked && testutil.ToFloat64(HamiDeviceLastXIDErrorCode.WithLabelValues(labels...)) != tt.wantValue {
-				t.Fatalf("last XID error code gauge value = %v, want %v", testutil.ToFloat64(HamiDeviceLastXIDErrorCode.WithLabelValues(labels...)), tt.wantValue)
+			if tt.wantTracked {
+				assertTrackedGaugeValue(t, generator, HamiDeviceLastXIDErrorCode, labels, tt.wantValue)
 			}
 		})
 	}
@@ -916,9 +925,13 @@ func assertTrackedGaugeValue(
 	want float64,
 ) {
 	t.Helper()
-	assertGaugeTracked(t, generator, gauge, labels, true)
-	if got := testutil.ToFloat64(gauge.WithLabelValues(labels...)); got != want {
-		t.Fatalf("gauge value = %v, want %v", got, want)
+	key := cellKey{gauge: gauge, joined: strings.Join(labels, labelSep)}
+	tracked, ok := generator.current[key]
+	if !ok {
+		t.Fatalf("gauge is not tracked")
+	}
+	if tracked.value != want {
+		t.Fatalf("staged gauge value = %v, want %v", tracked.value, want)
 	}
 }
 
@@ -977,6 +990,57 @@ func deleteTrackedTestCells(generator *MetricsGenerator) {
 		for _, tracked := range cells {
 			tracked.gauge.DeleteLabelValues(tracked.labels...)
 		}
+	}
+}
+
+func TestMetaxMultiDeviceUtilizationUsesEachDeviceAllocation(t *testing.T) {
+	const (
+		podName    = "metax-pod"
+		container  = "worker"
+		namespace  = "research"
+		podUID     = "pod-uid"
+		nodeName   = "metax-node"
+		deviceType = "C500"
+	)
+	devices := []struct {
+		uuid      string
+		allocated int32
+		wantUtil  float64
+	}{
+		{uuid: "MX-0", allocated: 20, wantUtil: 50},
+		{uuid: "MX-1", allocated: 40, wantUtil: 25},
+	}
+
+	containerDevices := make(biz.ContainerDevices, 0, len(devices))
+	memoryResponse := &pb.InstantResponse{}
+	responses := []*pb.InstantResponse{memoryResponse}
+	for _, device := range devices {
+		containerDevices = append(containerDevices, biz.ContainerDevice{
+			UUID: device.uuid, Type: metax.MetaxGPUDevice, Usedmem: 1024, Usedcores: device.allocated,
+		})
+		memoryResponse.Data = append(memoryResponse.Data, &pb.Sample{
+			Metric: map[string]string{"uuid": device.uuid, "modelName": deviceType, "Hostname": nodeName},
+			Value:  128,
+		})
+		responses = append(responses, instantValue(10), instantValue(50))
+	}
+
+	containers := []*biz.Container{{
+		Name: container, PodName: podName, PodUID: podUID, Namespace: namespace,
+		ContainerDevices: containerDevices,
+	}}
+	generator := &MetricsGenerator{
+		monitorService: &fakeInstantQuerier{responses: responses},
+		log:            log.NewHelper(log.NewStdLogger(io.Discard)),
+	}
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	if err := generator.generateMetricsForMetaxGPU(context.Background(), containers); err != nil {
+		t.Fatalf("generateMetricsForMetaxGPU() error = %v", err)
+	}
+	for _, device := range devices {
+		labels := []string{nodeName, metax.MetaxGPUDevice, deviceType, device.uuid, podName, container, namespace}
+		assertTrackedGaugeValue(t, generator, HamiContainerCoreUtil, labels, device.wantUtil)
 	}
 }
 
@@ -1133,8 +1197,8 @@ func TestGenerateContainerMetricsPreservesMissingAndIdleUsage(t *testing.T) {
 			labels := []string{nodeName, biz.NvidiaGPUDevice, deviceType, deviceID, podName, container, namespace}
 			for _, gauge := range []*prometheus.GaugeVec{HamiContainerCoreUsed, HamiContainerCoreUtil, HamiContainerMemoryUsed, HamiContainerMemoryUtil} {
 				assertGaugeTracked(t, generator, gauge, labels, tt.wantUsageSet)
-				if tt.wantUsageSet && testutil.ToFloat64(gauge.WithLabelValues(labels...)) != 0 {
-					t.Fatalf("idle gauge value must be zero")
+				if tt.wantUsageSet {
+					assertTrackedGaugeValue(t, generator, gauge, labels, 0)
 				}
 			}
 		})

--- a/server/internal/exporter/metrics.go
+++ b/server/internal/exporter/metrics.go
@@ -42,6 +42,11 @@ func init() {
 	prometheus.MustRegister(HamiPoolVmemorySize)
 
 	prometheus.MustRegister(HamiSystemComponentHealth)
+
+	// Background cache refresh health.
+	prometheus.MustRegister(HamiWebUIMetricsRefreshSuccess)
+	prometheus.MustRegister(HamiWebUIMetricsRefreshDurationSeconds)
+	prometheus.MustRegister(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds)
 }
 
 var (
@@ -199,6 +204,21 @@ var (
 		Name: "hami_system_component_health",
 		Help: "system component health",
 	}, []string{"component"})
+
+	HamiWebUIMetricsRefreshSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "hami_webui_metrics_refresh_success",
+		Help: "Whether the most recent completed background refresh of the cached HAMi metrics snapshot was fully successful (1) or degraded/failed (0).",
+	})
+
+	HamiWebUIMetricsRefreshDurationSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "hami_webui_metrics_refresh_duration_seconds",
+		Help: "Duration in seconds of the most recent completed background refresh of the cached HAMi metrics snapshot.",
+	})
+
+	HamiWebUIMetricsRefreshLastSuccessTimestampSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "hami_webui_metrics_refresh_last_success_timestamp_seconds",
+		Help: "Unix timestamp in seconds of the most recent fully successful commit of the cached HAMi metrics snapshot.",
+	})
 
 	Reset = true
 )

--- a/server/internal/exporter/refresh_test.go
+++ b/server/internal/exporter/refresh_test.go
@@ -1,0 +1,393 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	pb "vgpu/api/v1"
+	"vgpu/internal/biz"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestDropCurrentCycleDoesNotLeakStagedValues(t *testing.T) {
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_refresh_transaction_value",
+		Help: "Test-only gauge for refresh transaction semantics.",
+	}, []string{"id"})
+	generator := &MetricsGenerator{log: log.NewHelper(log.NewStdLogger(io.Discard))}
+	t.Cleanup(func() {
+		gauge.DeleteLabelValues("existing")
+		gauge.DeleteLabelValues("new")
+	})
+
+	generator.beginCycle()
+	generator.set(gauge, 42, "existing")
+	generator.commitCycle()
+	if got := testutil.ToFloat64(gauge.WithLabelValues("existing")); got != 42 {
+		t.Fatalf("committed value = %v, want 42", got)
+	}
+
+	generator.beginCycle()
+	generator.set(gauge, 84, "existing")
+	generator.set(gauge, 7, "new")
+	generator.dropCurrentCycle()
+
+	if got := testutil.ToFloat64(gauge.WithLabelValues("existing")); got != 42 {
+		t.Fatalf("value after fatal drop = %v, want previous value 42", got)
+	}
+	assertGaugeLabelsPresent(t, gauge, map[string]string{"id": "new"}, false)
+}
+
+func TestMetricsRefreshTwoCycleTelemetrySemantics(t *testing.T) {
+	tests := []struct {
+		name               string
+		secondResponse     *pb.InstantResponse
+		secondErr          error
+		wantTemperature    bool
+		wantTemperatureVal float64
+		wantSuccess        float64
+		wantLastSuccess    float64
+	}{
+		{
+			name:            "empty omits telemetry without degrading",
+			secondResponse:  &pb.InstantResponse{},
+			wantSuccess:     1,
+			wantLastSuccess: 200,
+		},
+		{
+			name:               "real zero remains present",
+			secondResponse:     instantValue(0),
+			wantTemperature:    true,
+			wantTemperatureVal: 0,
+			wantSuccess:        1,
+			wantLastSuccess:    200,
+		},
+		{
+			name:            "upstream request timeout degrades while cycle context is valid",
+			secondErr:       context.DeadlineExceeded,
+			wantSuccess:     0,
+			wantLastSuccess: 100,
+		},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetRefreshSelfMetrics(t)
+			deviceID := "GPU-refresh-" + string(rune('a'+index))
+			nodeName := "node-refresh-" + string(rune('a'+index))
+			device := &biz.DeviceInfo{
+				Id: deviceID, Devmem: 40960, Devcore: 100, Count: 1,
+				Type: "A100", NodeName: nodeName, Provider: biz.NvidiaGPUDevice,
+			}
+			response := instantValue(42)
+			var queryErr error
+			querier := &fakeInstantQuerier{query: func(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+				if queryErr != nil {
+					return nil, queryErr
+				}
+				return response, nil
+			}}
+			now := time.Unix(100, 0)
+			generator := newRefreshCycleTestGenerator(&fakeNodeRepo{devices: []*biz.DeviceInfo{device}}, &fakePodRepo{}, querier, func() time.Time { return now })
+			t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+			generator.runOnce(context.Background())
+			labels := map[string]string{
+				"node": nodeName, "provider": biz.NvidiaGPUDevice, "device_type": "A100",
+				"device_uuid": deviceID, "driver_version": "", "device_no": "",
+			}
+			assertGaugeLabelsPresent(t, HamiDeviceTemperature, labels, true)
+			if got := testutil.ToFloat64(HamiDeviceTemperature.WithLabelValues(nodeName, biz.NvidiaGPUDevice, "A100", deviceID, "", "")); got != 42 {
+				t.Fatalf("first temperature = %v, want 42", got)
+			}
+
+			response = tt.secondResponse
+			queryErr = tt.secondErr
+			now = time.Unix(200, 0)
+			generator.runOnce(context.Background())
+
+			assertGaugeLabelsPresent(t, HamiDeviceTemperature, labels, tt.wantTemperature)
+			if tt.wantTemperature {
+				if got := testutil.ToFloat64(HamiDeviceTemperature.WithLabelValues(nodeName, biz.NvidiaGPUDevice, "A100", deviceID, "", "")); got != tt.wantTemperatureVal {
+					t.Fatalf("second temperature = %v, want %v", got, tt.wantTemperatureVal)
+				}
+			}
+			assertGaugeLabelsPresent(t, HamiVgpuCount, labels, true)
+			if got := testutil.ToFloat64(HamiWebUIMetricsRefreshSuccess); got != tt.wantSuccess {
+				t.Fatalf("refresh success = %v, want %v", got, tt.wantSuccess)
+			}
+			if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != tt.wantLastSuccess {
+				t.Fatalf("last success timestamp = %v, want %v", got, tt.wantLastSuccess)
+			}
+		})
+	}
+}
+
+func TestMetricsRefreshCommitsSuccessfulTelemetryWhenAnotherQueryFails(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	const (
+		deviceID = "GPU-refresh-mixed"
+		nodeName = "node-refresh-mixed"
+	)
+	device := &biz.DeviceInfo{
+		Id: deviceID, Devmem: 40960, Devcore: 100, Count: 1,
+		Type: "A100", NodeName: nodeName, Provider: biz.NvidiaGPUDevice,
+	}
+	value := float32(42)
+	failTemperature := false
+	temperatureQuery := `avg(DCGM_FI_DEV_GPU_TEMP{UUID="GPU-refresh-mixed"})`
+	querier := &fakeInstantQuerier{query: func(_ context.Context, req *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+		if failTemperature && req.GetQuery() == temperatureQuery {
+			return nil, errors.New("temperature query failed")
+		}
+		return instantValue(value), nil
+	}}
+	now := time.Unix(250, 0)
+	generator := newRefreshCycleTestGenerator(&fakeNodeRepo{devices: []*biz.DeviceInfo{device}}, &fakePodRepo{}, querier, func() time.Time { return now })
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	generator.runOnce(context.Background())
+	labels := map[string]string{
+		"node": nodeName, "provider": biz.NvidiaGPUDevice, "device_type": "A100",
+		"device_uuid": deviceID, "driver_version": "", "device_no": "",
+	}
+	assertGaugeLabelsPresent(t, HamiDeviceTemperature, labels, true)
+	assertGaugeLabelsPresent(t, HamiDevicePower, labels, true)
+
+	failTemperature = true
+	value = 84
+	now = time.Unix(260, 0)
+	generator.runOnce(context.Background())
+
+	assertGaugeLabelsPresent(t, HamiDeviceTemperature, labels, false)
+	assertGaugeLabelsPresent(t, HamiDevicePower, labels, true)
+	if got := testutil.ToFloat64(HamiDevicePower.WithLabelValues(nodeName, biz.NvidiaGPUDevice, "A100", deviceID, "", "")); got != 84 {
+		t.Fatalf("successful telemetry in degraded cycle = %v, want 84", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshSuccess); got != 0 {
+		t.Fatalf("refresh success after mixed cycle = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != 250 {
+		t.Fatalf("last success timestamp after mixed cycle = %v, want 250", got)
+	}
+}
+
+func TestMetricsRefreshDoesNotDegradeForUnsupportedHygonTelemetry(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	device := &biz.DeviceInfo{
+		Id: "DCU-refresh-unsupported", Devmem: 16384, Devcore: 100, Count: 1,
+		Type: "DCU", NodeName: "node-refresh-hygon", Provider: biz.HygonGPUDevice,
+	}
+	querier := &fakeInstantQuerier{query: func(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+		return instantValue(42), nil
+	}}
+	now := time.Unix(275, 0)
+	generator := newRefreshCycleTestGenerator(&fakeNodeRepo{devices: []*biz.DeviceInfo{device}}, &fakePodRepo{}, querier, func() time.Time { return now })
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	generator.runOnce(context.Background())
+
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshSuccess); got != 1 {
+		t.Fatalf("refresh success with unsupported Hygon telemetry = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != 275 {
+		t.Fatalf("last success timestamp = %v, want 275", got)
+	}
+	labels := map[string]string{
+		"node": "node-refresh-hygon", "provider": biz.HygonGPUDevice, "device_type": "DCU",
+		"device_uuid": device.Id, "driver_version": "", "device_no": "dcu-",
+	}
+	assertGaugeLabelsPresent(t, HamiDeviceMemoryTemperature, labels, false)
+	assertGaugeLabelsPresent(t, HamiDeviceFanSpeedP, labels, false)
+	assertGaugeLabelsPresent(t, HamiDeviceLastXIDErrorCode, labels, false)
+}
+
+func TestMetricsRefreshFatalAuthorityFailureDropsEntireStage(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	oldDevice := &biz.DeviceInfo{
+		Id: "GPU-refresh-fatal-old", Devmem: 40960, Devcore: 100, Count: 1,
+		Type: "A100", NodeName: "node-refresh-fatal", Provider: biz.NvidiaGPUDevice,
+	}
+	newDevice := &biz.DeviceInfo{
+		Id: "GPU-refresh-fatal-new", Devmem: 40960, Devcore: 100, Count: 1,
+		Type: "A100", NodeName: "node-refresh-fatal", Provider: biz.NvidiaGPUDevice,
+	}
+	devices := []*biz.DeviceInfo{oldDevice}
+	listCalls := 0
+	authorityErr := errors.New("device inventory unavailable")
+	nodeRepo := &fakeNodeRepo{listAllDevicesFunc: func(context.Context) ([]*biz.DeviceInfo, error) {
+		listCalls++
+		if listCalls == 4 {
+			return nil, authorityErr
+		}
+		return devices, nil
+	}}
+	value := float32(42)
+	querier := &fakeInstantQuerier{query: func(context.Context, *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+		return instantValue(value), nil
+	}}
+	now := time.Unix(300, 0)
+	generator := newRefreshCycleTestGenerator(nodeRepo, &fakePodRepo{}, querier, func() time.Time { return now })
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	generator.runOnce(context.Background())
+	oldLabels := map[string]string{
+		"node": "node-refresh-fatal", "provider": biz.NvidiaGPUDevice, "device_type": "A100",
+		"device_uuid": oldDevice.Id, "driver_version": "", "device_no": "",
+	}
+	assertGaugeLabelsPresent(t, HamiDeviceTemperature, oldLabels, true)
+
+	devices = []*biz.DeviceInfo{oldDevice, newDevice}
+	value = 84
+	now = time.Unix(400, 0)
+	generator.runOnce(context.Background())
+
+	if got := testutil.ToFloat64(HamiDeviceTemperature.WithLabelValues("node-refresh-fatal", biz.NvidiaGPUDevice, "A100", oldDevice.Id, "", "")); got != 42 {
+		t.Fatalf("old value after fatal cycle = %v, want 42", got)
+	}
+	newLabels := map[string]string{
+		"node": "node-refresh-fatal", "provider": biz.NvidiaGPUDevice, "device_type": "A100",
+		"device_uuid": newDevice.Id, "driver_version": "", "device_no": "",
+	}
+	assertGaugeLabelsPresent(t, HamiDeviceTemperature, newLabels, false)
+	assertGaugeLabelsPresent(t, HamiVgpuCount, newLabels, false)
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshSuccess); got != 0 {
+		t.Fatalf("refresh success after fatal cycle = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != 300 {
+		t.Fatalf("last success timestamp after fatal cycle = %v, want 300", got)
+	}
+}
+
+func TestMetricsRefreshUsesCycleContextForNestedQueries(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	device := &biz.DeviceInfo{
+		Id: "GPU-refresh-context", Devmem: 40960, Devcore: 100, Count: 1,
+		Type: "A100", NodeName: "node-refresh-context", Provider: biz.NvidiaGPUDevice,
+	}
+	queryObservedCancellation := false
+	ctx, cancel := context.WithCancel(context.Background())
+	querier := &fakeInstantQuerier{query: func(ctx context.Context, _ *pb.QueryInstantRequest) (*pb.InstantResponse, error) {
+		cancel()
+		<-ctx.Done()
+		queryObservedCancellation = true
+		return nil, ctx.Err()
+	}}
+	now := time.Unix(500, 0)
+	generator := newRefreshCycleTestGenerator(&fakeNodeRepo{devices: []*biz.DeviceInfo{device}}, &fakePodRepo{}, querier, func() time.Time { return now })
+	t.Cleanup(func() { deleteTrackedTestCells(generator) })
+
+	generator.runOnce(ctx)
+
+	if !queryObservedCancellation {
+		t.Fatal("nested query did not observe cycle cancellation")
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshSuccess); got != 0 {
+		t.Fatalf("refresh success after canceled cycle = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != 0 {
+		t.Fatalf("last success timestamp after canceled first cycle = %v, want 0", got)
+	}
+}
+
+func TestQueryDeviceAdditionalTreatsEmptyVectorAsExpectedOmission(t *testing.T) {
+	generator := &MetricsGenerator{monitorService: &fakeInstantQuerier{responses: []*pb.InstantResponse{{}}}}
+	_, err := generator.queryDeviceAdditional(context.Background(), biz.NvidiaGPUDevice, "GPU-empty-additional")
+	if !errors.Is(err, errNoMetricData) {
+		t.Fatalf("queryDeviceAdditional() error = %v, want errNoMetricData", err)
+	}
+}
+
+func TestMetricsRefreshDurationAndTimestampAreRecordedAfterCommit(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	times := []time.Time{time.Unix(600, 0), time.Unix(602, 0)}
+	clockCalls := 0
+	commitObserved := false
+	var generator *MetricsGenerator
+	clock := func() time.Time {
+		if clockCalls == 1 {
+			generator.cellMu.Lock()
+			commitObserved = generator.current == nil && generator.prev != nil
+			generator.cellMu.Unlock()
+		}
+		value := times[clockCalls]
+		clockCalls++
+		return value
+	}
+	generator = newRefreshCycleTestGenerator(&fakeNodeRepo{}, &fakePodRepo{}, &fakeInstantQuerier{}, clock)
+
+	generator.runOnce(context.Background())
+
+	if clockCalls != 2 {
+		t.Fatalf("clock calls = %d, want 2", clockCalls)
+	}
+	if !commitObserved {
+		t.Fatal("completion time was read before the staged snapshot was committed")
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshDurationSeconds); got != 2 {
+		t.Fatalf("refresh duration = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(HamiWebUIMetricsRefreshLastSuccessTimestampSeconds); got != 602 {
+		t.Fatalf("last success timestamp = %v, want 602", got)
+	}
+}
+
+func TestRefreshSelfMetricDescriptors(t *testing.T) {
+	resetRefreshSelfMetrics(t)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(
+		HamiWebUIMetricsRefreshSuccess,
+		HamiWebUIMetricsRefreshDurationSeconds,
+		HamiWebUIMetricsRefreshLastSuccessTimestampSeconds,
+	)
+	want := `
+# HELP hami_webui_metrics_refresh_duration_seconds Duration in seconds of the most recent completed background refresh of the cached HAMi metrics snapshot.
+# TYPE hami_webui_metrics_refresh_duration_seconds gauge
+hami_webui_metrics_refresh_duration_seconds 0
+# HELP hami_webui_metrics_refresh_last_success_timestamp_seconds Unix timestamp in seconds of the most recent fully successful commit of the cached HAMi metrics snapshot.
+# TYPE hami_webui_metrics_refresh_last_success_timestamp_seconds gauge
+hami_webui_metrics_refresh_last_success_timestamp_seconds 0
+# HELP hami_webui_metrics_refresh_success Whether the most recent completed background refresh of the cached HAMi metrics snapshot was fully successful (1) or degraded/failed (0).
+# TYPE hami_webui_metrics_refresh_success gauge
+hami_webui_metrics_refresh_success 0
+`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want)); err != nil {
+		t.Fatalf("refresh self metrics differ: %v", err)
+	}
+}
+
+func newRefreshCycleTestGenerator(
+	nodeRepo *fakeNodeRepo,
+	podRepo *fakePodRepo,
+	querier *fakeInstantQuerier,
+	now func() time.Time,
+) *MetricsGenerator {
+	logger := log.NewStdLogger(io.Discard)
+	return &MetricsGenerator{
+		nodeUsecase:    biz.NewNodeUsecase(nodeRepo, logger),
+		podUsecase:     biz.NewPodUseCase(podRepo, logger),
+		monitorService: querier,
+		timeout:        time.Minute,
+		log:            log.NewHelper(logger),
+		now:            now,
+	}
+}
+
+func resetRefreshSelfMetrics(t *testing.T) {
+	t.Helper()
+	HamiWebUIMetricsRefreshSuccess.Set(0)
+	HamiWebUIMetricsRefreshDurationSeconds.Set(0)
+	HamiWebUIMetricsRefreshLastSuccessTimestampSeconds.Set(0)
+	t.Cleanup(func() {
+		HamiWebUIMetricsRefreshSuccess.Set(0)
+		HamiWebUIMetricsRefreshDurationSeconds.Set(0)
+		HamiWebUIMetricsRefreshLastSuccessTimestampSeconds.Set(0)
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The background exporter claimed failed cycles retained the last known snapshot, but `set()` updated live `GaugeVec` cells before a refresh finished. A timeout or authority failure could therefore expose partial new values and labels even after the staged tracking map was dropped.

This change:

- stages business metric cells and writes them only when a cycle commits;
- keeps successful empty, unsupported, NaN, and Inf telemetry absent while preserving a real zero;
- commits a best-effort snapshot when an individual supported Prometheus query fails and marks the refresh degraded;
- drops the entire stage when device/workload authority or the cycle context fails;
- passes the cycle context through every exporter query;
- exports no-label success, duration, and last-success timestamp gauges.

It does not change readiness or liveness. The final `GaugeVec` commit is still applied cell by cell; this removes mixed data during the upstream query window and prevents fatal-cycle leakage, but does not claim scrape-level atomicity.

**Verification**:

- `go test -race -count=1 -mod=readonly ./internal/exporter`
- `go test -count=1 -mod=readonly ./...`
- `go vet -mod=readonly ./...`
- `go build -mod=readonly ./...`
- `go mod tidy -diff`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metrics showing refresh success, refresh duration, and the timestamp of the last successful refresh.
- **Bug Fixes**
  - Improved metrics refresh reliability by preserving the last complete snapshot when critical data collection fails.
  - Partial telemetry failures can now be reported without discarding valid metrics from the same refresh.
  - Prevented invalid values such as `NaN`, infinity, and divide-by-zero results from being exported.
  - Improved cancellation and timeout handling during metric collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->