### PR TITLE
fix(metrics): pair physical memory series

### DIFF
--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -170,8 +170,12 @@ export const buildMemoryUsageQueries = ({
 } = {}) => {
   const usedSeries = metricSeries(METRICS.memoryUsed, selector);
   const capacitySeries = metricSeries(METRICS.memoryPhysicalCapacity, selector);
+  const reportingUsedSeries = `${usedSeries} and ${REPORTING_DEVICE_MATCH} ${capacitySeries}`;
   const reportingCapacitySeries = `${capacitySeries} and ${REPORTING_DEVICE_MATCH} ${usedSeries}`;
-  const used = aggregateAcrossExporterReplicas(usedSeries, groupLabel);
+  const used = aggregateAcrossExporterReplicas(
+    reportingUsedSeries,
+    groupLabel,
+  );
   const capacity = aggregateAcrossExporterReplicas(
     reportingCapacitySeries,
     groupLabel,

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -210,9 +210,13 @@ test('scoped memory allocation keeps the same contract for node and card details
   assert.match(card.percentQuery, / or /);
 });
 
-test('memory usage capacity only includes devices that report usage', () => {
+test('memory usage only includes devices that report both used and capacity', () => {
   const queries = buildMemoryUsageQueries();
 
+  assert.match(
+    queries.query,
+    /hami_memory_used and on \(instance, node, provider, device_uuid\) hami_memory_size/,
+  );
   assert.match(
     queries.totalQuery,
     /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
@@ -233,6 +237,10 @@ test('grouped rankings preserve idle allocation but not missing usage', () => {
     assert.match(queries.memoryAllocation, /hami_vmemory_size/);
     assert.match(
       queries.memoryUsage,
+      /hami_memory_used and on \(instance, node, provider, device_uuid\) hami_memory_size/,
+    );
+    assert.match(
+      queries.memoryUsage,
       /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,
     );
     assert.doesNotMatch(queries.memoryUsage, / or /);
@@ -246,6 +254,10 @@ test('cluster trends share the allocation and reporting-device contracts', () =>
   assert.match(queries.computeAllocation, / or /);
   assert.match(queries.memoryAllocation, /hami_vmemory_size/);
   assert.match(queries.memoryAllocation, / or /);
+  assert.match(
+    queries.memoryUsage,
+    /hami_memory_used and on \(instance, node, provider, device_uuid\) hami_memory_size/,
+  );
   assert.match(
     queries.memoryUsage,
     /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,

--- a/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
+++ b/packages/web/projects/vgpu/views/monitor/overview/metric-config.test.mjs
@@ -80,9 +80,13 @@ test('an idle cluster reports zero allocation when capacity is present', () => {
   );
 });
 
-test('memory utilization capacity only includes reporting devices', () => {
+test('memory utilization values only include devices reporting both sides', () => {
   const memoryUtilization = createOverviewGaugeConfigs().at(-1);
 
+  assert.match(
+    memoryUtilization.query,
+    /hami_memory_used and on \(instance, node, provider, device_uuid\) hami_memory_size/,
+  );
   assert.match(
     memoryUtilization.totalQuery,
     /hami_memory_size and on \(instance, node, provider, device_uuid\) hami_memory_used/,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Physical memory utilization is intended to include only devices that report both used and total physical memory. The existing query filters only the denominator, so a device with used telemetry but no capacity telemetry inflates the percentage.

For example, if two devices each report 8 GiB used but only one reports 16 GiB total, the old query reports 100%. Intersecting both sides on the exporter instance and device identity reports 50% and keeps incomplete coverage absent.

This shared query contract fixes the cluster gauge, trends, node rankings, and node/card detail consumers without changing allocation semantics or UI copy.

**Verification**:

- full frontend lint and test suite
- production build
- Vite environment boundary check

Part of #209.