### PR TITLE
fix(task): require complete monitoring coverage

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
     "test:echarts-runtime": "node --test test/echarts-runtime.test.mjs",
     "test:i18n": "node --test test/locale-resolution.test.mjs",
     "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/detail-resource-state.test.mjs projects/vgpu/hooks/use-detail-resource.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/monitor/overview/workload-distribution.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs projects/vgpu/views/card/admin/optional-telemetry-display.test.mjs projects/vgpu/views/node/admin/metric-config.test.mjs",
-    "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs",
+    "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs projects/vgpu/views/task/admin/use-task-monitoring.test.mjs",
     "test:ui-contracts": "node --test projects/vgpu/views/node/detail-location.test.mjs projects/vgpu/views/node/node-status.test.mjs"
   },
   "dependencies": {

--- a/packages/web/projects/vgpu/metrics/query-contract.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.mjs
@@ -8,6 +8,8 @@ const METRICS = Object.freeze({
   memorySchedulableCapacity: 'hami_vmemory_size',
   memoryPhysicalCapacity: 'hami_memory_size',
   memoryUsed: 'hami_memory_used',
+  taskComputeUtilization: 'hami_container_core_util',
+  taskMemoryUsed: 'hami_container_memory_used',
 });
 
 const PROMETHEUS_LABEL_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -145,6 +147,61 @@ export const buildTaskResourceOverviewQueries = ({ selector = '' } = {}) => {
     gpuCards,
     computeLimit: buildTaskComputeAllocationQuery({ selector }),
     singleCardMemory: `${memory} / clamp_min(${gpuCards}, 1) / 1024`,
+  };
+};
+
+export const buildTaskMonitoringQueries = ({
+  expectedDeviceCount,
+  expectedVgpuCount,
+} = {}) => {
+  if (
+    !Number.isSafeInteger(expectedDeviceCount) ||
+    expectedDeviceCount <= 0 ||
+    !Number.isSafeInteger(expectedVgpuCount) ||
+    expectedVgpuCount < expectedDeviceCount
+  ) {
+    throw new TypeError('Valid task device and vGPU counts are required');
+  }
+
+  const group = 'node, provider, device_uuid';
+  const match = `on (${group})`;
+  const usageSelector =
+    'container_name=$container,pod_name=$pod,namespace_name=$namespace';
+  const allocationSelector =
+    `${usageSelector},container_pod_uuid=$container_pod_uuid`;
+  // Usage gauges do not yet carry the Pod UID. Intersect them with the current
+  // lifecycle's allocation identities before aggregation.
+  const devices = `max by (${group}) (${metricSeries(
+    METRICS.vgpuAllocated,
+    allocationSelector,
+  )}) > 0`;
+  const compute = `avg by (${group}) (${metricSeries(
+    METRICS.taskComputeUtilization,
+    usageSelector,
+  )}) and ${match} (${devices})`;
+  const memoryAllocation = `max by (${group}) (${metricSeries(
+    METRICS.memoryAllocated,
+    allocationSelector,
+  )}) and ${match} (${devices})`;
+  const memoryUsed = `avg by (${group}) (${metricSeries(
+    METRICS.taskMemoryUsed,
+    usageSelector,
+  )}) and ${match} (${memoryAllocation})`;
+  const completeDeviceCount = (series) =>
+    `and on () (count(${series}) == ${expectedDeviceCount})`;
+  // count protects unique device coverage; sum also protects vGPU/slot
+  // coverage when several allocations share one device identity.
+  const completeVgpuCount =
+    `and on () (sum(${devices}) == ${expectedVgpuCount})`;
+
+  return {
+    computeUsage:
+      `(avg(${compute})) ${completeDeviceCount(devices)} ${completeVgpuCount} ` +
+      `${completeDeviceCount(compute)}`,
+    memoryUsage:
+      `(100 * sum(${memoryUsed}) / clamp_min(sum(${memoryAllocation}), 1)) ` +
+      `${completeDeviceCount(devices)} ${completeVgpuCount} ` +
+      `${completeDeviceCount(memoryAllocation)} ${completeDeviceCount(memoryUsed)}`,
   };
 };
 

--- a/packages/web/projects/vgpu/metrics/query-contract.test.mjs
+++ b/packages/web/projects/vgpu/metrics/query-contract.test.mjs
@@ -13,6 +13,7 @@ import {
   buildTaskComputeAllocationQuery,
   buildTaskCountQueries,
   buildTaskContainerResourceQueries,
+  buildTaskMonitoringQueries,
   buildTaskResourceOverviewQueries,
 } from './query-contract.mjs';
 import {
@@ -169,6 +170,70 @@ test('task resource totals stay stable for one or two exporter replicas and mult
     queries.singleCardMemory,
     `${replicaSafeMemory} / clamp_min(${replicaSafeVgpu}, 1) / 1024`,
   );
+});
+
+test('task trends require current-lifecycle telemetry from every allocated device', () => {
+  const queries = buildTaskMonitoringQueries({
+    expectedDeviceCount: 2,
+    expectedVgpuCount: 3,
+  });
+
+  for (const query of Object.values(queries)) {
+    assert.match(
+      query,
+      /hami_container_vgpu_allocated\{container_name=\$container,pod_name=\$pod,namespace_name=\$namespace,container_pod_uuid=\$container_pod_uuid\}/,
+    );
+    assert.match(query, /max by \(node, provider, device_uuid\)/);
+    assert.match(query, /hami_container_vgpu_allocated\{[^}]+\}\) > 0/);
+    assert.match(query, /count\([^]*hami_container_vgpu_allocated[^]*\) == 2/);
+    assert.match(query, /sum\([^]*hami_container_vgpu_allocated[^]*\) == 3/);
+    assert.doesNotMatch(query, /\bbool\b/);
+  }
+
+  assert.match(
+    queries.computeUsage,
+    /hami_container_core_util\{container_name=\$container,pod_name=\$pod,namespace_name=\$namespace\}/,
+  );
+  assert.match(
+    queries.computeUsage,
+    /and on \(node, provider, device_uuid\) \(max by/,
+  );
+  assert.match(
+    queries.computeUsage,
+    /count\([^]*hami_container_core_util[^]*\) == 2/,
+  );
+
+  assert.match(
+    queries.memoryUsage,
+    /hami_container_memory_used\{container_name=\$container,pod_name=\$pod,namespace_name=\$namespace\}/,
+  );
+  assert.match(
+    queries.memoryUsage,
+    /hami_container_vmemory_allocated\{container_name=\$container,pod_name=\$pod,namespace_name=\$namespace,container_pod_uuid=\$container_pod_uuid\}/,
+  );
+  assert.match(
+    queries.memoryUsage,
+    /count\([^]*hami_container_vmemory_allocated[^]*\) == 2/,
+  );
+  assert.match(
+    queries.memoryUsage,
+    /count\([^]*hami_container_memory_used[^]*\) == 2/,
+  );
+});
+
+test('task trend queries reject inconsistent device-identity and vGPU counts', () => {
+  for (const counts of [
+    {},
+    { expectedDeviceCount: 0, expectedVgpuCount: 1 },
+    { expectedDeviceCount: 1.5, expectedVgpuCount: 2 },
+    { expectedDeviceCount: 2, expectedVgpuCount: 1 },
+    { expectedDeviceCount: 2, expectedVgpuCount: 2.5 },
+  ]) {
+    assert.throws(
+      () => buildTaskMonitoringQueries(counts),
+      /Valid task device and vGPU counts/,
+    );
+  }
 });
 
 test('Kubernetes resource queries deduplicate replicas and bind the current Pod UID', () => {

--- a/packages/web/projects/vgpu/views/task/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/task/admin/Detail.vue
@@ -173,24 +173,46 @@
     </div>
   </block-box>
 
-  <TrendTimeFilter
-    v-if="supportsTaskMonitoring"
-    v-model="times"
-  />
+  <TrendTimeFilter v-model="times" />
 
   <div class="task-trend-row">
-    <block-box v-for="{ title, data } in lineConfigView" :key="title" :title="title">
-      <div class="trend-chart">
-        <template v-if="primaryDeviceType && !supportsTaskMonitoring">
-          <el-empty :description="$t('task.noMonitorSupport')" :image-size="60" />
-        </template>
-        <template v-else>
-          <VChart
-            :option="getLineOptions({ data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
-            :autoresize="true"
-            class="trend-vchart"
+    <block-box v-for="item in lineConfigView" :key="item.key" :title="item.title">
+      <div
+        class="trend-chart"
+        :aria-busy="item.status === REQUEST_STATUS.LOADING ? 'true' : 'false'"
+      >
+        <template v-if="item.status === REQUEST_STATUS.LOADING">
+          <t-skeleton
+            animation="gradient"
+            :row-col="[
+              { width: '100%', height: '200px' },
+              { width: '42%', height: '16px', margin: '16px auto 0' },
+            ]"
+            class="trend-chart-skeleton"
+            aria-hidden="true"
           />
+          <span class="trend-state-sr-only" role="status">{{ $t('common.loading') }}</span>
         </template>
+        <VChart
+          v-else-if="item.status === REQUEST_STATUS.READY"
+          :option="getLineOptions({ data: item.data, seriesName: $t('dashboard.usageRateLegend'), animation: false })"
+          :autoresize="true"
+          class="trend-vchart"
+        />
+        <el-empty
+          v-else
+          :description="getTaskMonitoringStateText(item.status)"
+          :image-size="60"
+          class="trend-state"
+        >
+          <el-button
+            v-if="item.status === REQUEST_STATUS.ERROR || item.status === REQUEST_STATUS.INVALID"
+            type="primary"
+            @click="retryTaskMonitoring"
+          >
+            {{ $t('common.retry') }}
+          </el-button>
+        </el-empty>
       </div>
     </block-box>
   </div>
@@ -218,6 +240,9 @@ import { getLineOptions } from '~/vgpu/components/config';
 import VChart from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
 import { formatWorkloadName } from './workload-identity.mjs';
+import useTaskMonitoring, {
+  getTaskMonitoringAllocationShape,
+} from './useTaskMonitoring';
 import {
   METRIC_STATUS,
   readReadyMetricField,
@@ -300,17 +325,11 @@ const getStatusDisplay = (status) => {
 const safeDeviceIds = computed(() => (
   Array.isArray(detail.value?.deviceIds) ? detail.value.deviceIds : []
 ));
-const primaryDeviceType = computed(() => {
-  const primaryDeviceId = safeDeviceIds.value[0];
-  return (
-    (primaryDeviceId && cardTypeById.value?.[primaryDeviceId]) ||
-    detail.value?.type ||
-    ''
-  );
-});
-const supportsTaskMonitoring = computed(() => (
-  primaryDeviceType.value.startsWith('NVIDIA') ||
-  primaryDeviceType.value.startsWith('MXC')
+const monitoringAllocationShape = computed(() => (
+  getTaskMonitoringAllocationShape({
+    allocatedDevices: detail.value?.allocatedDevices,
+    deviceIds: safeDeviceIds.value,
+  })
 ));
 const gpuModelList = computed(() => {
   if (!safeDeviceIds.value.length) return [];
@@ -451,92 +470,53 @@ const handleGpuJump = (uuid) => {
   router.push(`/admin/vgpu/card/admin/${uuid}`);
 };
 
-const lineConfig = ref([
-  {
-    titleKey: 'task.computeUsageTrend',
-    query: `avg(avg(hami_container_core_util{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid))`,
-    data: [],
-  },
-  {
-    titleKey: 'task.memUsageTrend',
-    query: `100 * sum(avg(hami_container_memory_used{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid)) / clamp_min(sum(avg(hami_container_vmemory_allocated{container_name=$container,pod_name=$pod,namespace_name=$namespace}) by (node, device_uuid)), 1)`,
-    data: [],
-  },
-]);
-
 const headerStatusDisplay = computed(() => (
   detailStatus.value === REQUEST_STATUS.READY
     ? getStatusDisplay(detail.value?.status)
     : { text: '', icon: '' }
 ));
 
+const taskMonitoringSource = computed(() => {
+  if (
+    detailStatus.value !== REQUEST_STATUS.READY ||
+    !monitoringAllocationShape.value
+  ) return null;
+  return {
+    container: detail.value.name || '',
+    ...monitoringAllocationShape.value,
+    namespace: detail.value.namespace || '',
+    pod: detail.value.appName || '',
+    podUid: detail.value.podUid || requestedIdentity.value.podUid || '',
+  };
+});
+const taskMonitoringRange = computed(() => {
+  const [rangeStart, rangeEnd] = times.value || [];
+  if (!rangeStart || !rangeEnd) return null;
+  return {
+    start: timeParse(rangeStart),
+    end: timeParse(rangeEnd),
+    step: calculatePrometheusStep(rangeStart, rangeEnd),
+  };
+});
+const {
+  data: taskMonitoringSeries,
+  refresh: retryTaskMonitoring,
+} = useTaskMonitoring({
+  source: taskMonitoringSource,
+  range: taskMonitoringRange,
+  request: (payload) => cardApi.getRangeVector(payload),
+});
 const lineConfigView = computed(() =>
-  lineConfig.value.map((item) => ({
+  taskMonitoringSeries.value.map((item) => ({
     ...item,
     title: t(item.titleKey),
   })),
 );
-
-let lineRequestGeneration = 0;
-const clearLineData = () => {
-  lineConfig.value.forEach((item) => {
-    item.data = [];
-  });
+const getTaskMonitoringStateText = (status) => {
+  if (status === REQUEST_STATUS.ERROR) return t('dashboard.metricQueryFailed');
+  if (status === REQUEST_STATUS.INVALID) return t('dashboard.metricInvalid');
+  return t('task.noCompleteMonitorData');
 };
-const fetchLineData = async () => {
-  const generation = ++lineRequestGeneration;
-  if (
-    detailStatus.value !== REQUEST_STATUS.READY ||
-    !supportsTaskMonitoring.value
-  ) {
-    clearLineData();
-    return;
-  }
-
-  const { name, namespace, appName } = detail.value;
-  const [rangeStart, rangeEnd] = times.value || [];
-  if (!name || !namespace || !appName || !rangeStart || !rangeEnd) {
-    clearLineData();
-    return;
-  }
-
-  const results = await Promise.all(lineConfig.value.map(async (item) => {
-    try {
-      const res = await cardApi.getRangeVector({
-        range: {
-          start: timeParse(rangeStart),
-          end: timeParse(rangeEnd),
-          step: calculatePrometheusStep(rangeStart, rangeEnd),
-        },
-        query: renderPromQLTemplate(item.query, {
-          container: name,
-          namespace,
-          pod: appName,
-        }),
-      });
-      return { ok: true, data: res.data[0]?.values || [] };
-    } catch {
-      return { ok: false };
-    }
-  }));
-
-  if (
-    generation !== lineRequestGeneration ||
-    detailStatus.value !== REQUEST_STATUS.READY
-  ) return;
-
-  results.forEach((result, index) => {
-    if (result.ok) lineConfig.value[index].data = result.data;
-  });
-};
-
-watch(
-  [detailStatus, detail, times, primaryDeviceType],
-  () => {
-    void fetchLineData();
-  },
-  { deep: true, immediate: true },
-);
 
 let enrichmentGeneration = 0;
 watch(
@@ -865,6 +845,27 @@ watch(
 .trend-chart {
   height: 250px;
   margin-top: 15px;
+}
+
+.trend-chart-skeleton {
+  width: 100%;
+  padding: 8px 12px 0;
+}
+
+.trend-state {
+  height: 100%;
+}
+
+.trend-state-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .trend-vchart {

--- a/packages/web/projects/vgpu/views/task/admin/use-task-monitoring.test.mjs
+++ b/packages/web/projects/vgpu/views/task/admin/use-task-monitoring.test.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { nextTick, ref } from 'vue';
+
+import { REQUEST_STATUS } from '../../../../../src/hooks/request-state.mjs';
+import useTaskMonitoring, {
+  getTaskMonitoringAllocationShape,
+} from './useTaskMonitoring.js';
+
+const sourceFixture = (overrides = {}) => ({
+  container: 'worker',
+  expectedDeviceCount: 2,
+  expectedVgpuCount: 3,
+  namespace: 'research',
+  pod: 'training-pod',
+  podUid: 'pod-uid-current',
+  ...overrides,
+});
+
+const rangeFixture = (overrides = {}) => ({
+  end: '2026-09-01 11:00:00',
+  start: '2026-09-01 10:00:00',
+  step: '30s',
+  ...overrides,
+});
+
+const deferred = () => {
+  let reject;
+  let resolve;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+test('task monitoring is driven by metric coverage rather than the first device model', () => {
+  const detail = readFileSync(new URL('./Detail.vue', import.meta.url), 'utf8');
+
+  assert.match(detail, /useTaskMonitoring/);
+  assert.match(detail, /getTaskMonitoringAllocationShape/);
+  assert.doesNotMatch(detail, /supportsTaskMonitoring|primaryDeviceType/);
+  assert.doesNotMatch(detail, /startsWith\(['"](?:NVIDIA|MXC)/);
+});
+
+test('task monitoring distinguishes unique device identities from vGPU slots', () => {
+  assert.deepEqual(
+    getTaskMonitoringAllocationShape({
+      allocatedDevices: 2,
+      deviceIds: ['GPU-0', 'GPU-1'],
+    }),
+    { expectedDeviceCount: 2, expectedVgpuCount: 2 },
+  );
+  assert.deepEqual(
+    getTaskMonitoringAllocationShape({
+      allocatedDevices: 2,
+      deviceIds: ['GPU-0', 'GPU-0'],
+    }),
+    { expectedDeviceCount: 1, expectedVgpuCount: 2 },
+  );
+  for (const detail of [
+    { allocatedDevices: 2, deviceIds: ['GPU-0'] },
+    { allocatedDevices: 1, deviceIds: [''] },
+    { allocatedDevices: 0, deviceIds: [] },
+  ]) {
+    assert.equal(getTaskMonitoringAllocationShape(detail), null);
+  }
+});
+
+test('task monitoring binds queries to the current Pod lifecycle and preserves real zeroes', async () => {
+  const calls = [];
+  const monitoring = useTaskMonitoring({
+    source: ref(sourceFixture()),
+    range: ref(rangeFixture()),
+    request: ({ query, range }) => {
+      calls.push({ query, range });
+      return Promise.resolve({
+        data: [{ values: [{ timestamp: 1_000, value: 0 }] }],
+      });
+    },
+  });
+
+  await flushPromises();
+
+  assert.equal(calls.length, 2);
+  for (const call of calls) {
+    assert.match(call.query, /container_pod_uuid="worker:pod-uid-current"/);
+    assert.match(call.query, /count\([^]*hami_container_vgpu_allocated[^]*\) == 2/);
+    assert.match(call.query, /sum\([^]*hami_container_vgpu_allocated[^]*\) == 3/);
+    assert.doesNotMatch(call.query, /\bbool\b/);
+    assert.deepEqual(call.range, rangeFixture());
+  }
+  for (const item of monitoring.data.value) {
+    assert.equal(item.status, REQUEST_STATUS.READY);
+    assert.equal(item.data[0].value, 0);
+  }
+});
+
+test('an empty complete-coverage query result is missing instead of a synthetic zero', async () => {
+  const monitoring = useTaskMonitoring({
+    source: ref(sourceFixture()),
+    range: ref(rangeFixture()),
+    request: async () => ({ data: [] }),
+  });
+
+  await flushPromises();
+
+  for (const item of monitoring.data.value) {
+    assert.equal(item.status, REQUEST_STATUS.MISSING);
+    assert.deepEqual(item.data, []);
+  }
+});
+
+test('an inconsistent detail allocation shape does not issue monitoring queries', async () => {
+  let calls = 0;
+  const monitoring = useTaskMonitoring({
+    source: ref(sourceFixture({ expectedVgpuCount: 1 })),
+    range: ref(rangeFixture()),
+    request: async () => {
+      calls += 1;
+      return { data: [] };
+    },
+  });
+
+  await flushPromises();
+
+  assert.equal(calls, 0);
+  assert.ok(monitoring.data.value.every(
+    (item) => item.status === REQUEST_STATUS.MISSING,
+  ));
+});
+
+test('changing the time range clears old charts and exposes query failures', async () => {
+  const range = ref(rangeFixture());
+  const pending = [];
+  const monitoring = useTaskMonitoring({
+    source: ref(sourceFixture()),
+    range,
+    request: () => {
+      const request = deferred();
+      pending.push(request);
+      return request.promise;
+    },
+  });
+
+  assert.equal(pending.length, 2);
+  for (const request of pending.slice(0, 2)) {
+    request.resolve({
+      data: [{ values: [{ timestamp: 1_000, value: 42 }] }],
+    });
+  }
+  await flushPromises();
+  assert.ok(monitoring.data.value.every((item) => item.status === REQUEST_STATUS.READY));
+
+  range.value = rangeFixture({ start: '2026-08-25 11:00:00' });
+  await nextTick();
+  assert.equal(pending.length, 4);
+  for (const item of monitoring.data.value) {
+    assert.equal(item.status, REQUEST_STATUS.LOADING);
+    assert.deepEqual(item.data, []);
+  }
+
+  for (const request of pending.slice(2, 4)) {
+    request.reject(new Error('Prometheus unavailable'));
+  }
+  await flushPromises();
+  for (const item of monitoring.data.value) {
+    assert.equal(item.status, REQUEST_STATUS.ERROR);
+    assert.deepEqual(item.data, []);
+  }
+});
+
+test('a response for an older workload cannot overwrite the current workload', async () => {
+  const source = ref(sourceFixture({ podUid: 'pod-old' }));
+  const pending = [];
+  const monitoring = useTaskMonitoring({
+    source,
+    range: ref(rangeFixture()),
+    request: () => {
+      const request = deferred();
+      pending.push(request);
+      return request.promise;
+    },
+  });
+
+  source.value = sourceFixture({ podUid: 'pod-new' });
+  await nextTick();
+  assert.equal(pending.length, 4);
+
+  for (const request of pending.slice(2, 4)) {
+    request.resolve({
+      data: [{ values: [{ timestamp: 2_000, value: 77 }] }],
+    });
+  }
+  await flushPromises();
+  assert.ok(monitoring.data.value.every((item) => item.data[0].value === 77));
+
+  for (const request of pending.slice(0, 2)) {
+    request.resolve({
+      data: [{ values: [{ timestamp: 1_000, value: 12 }] }],
+    });
+  }
+  await flushPromises();
+  assert.ok(monitoring.data.value.every((item) => item.data[0].value === 77));
+});

--- a/packages/web/projects/vgpu/views/task/admin/useTaskMonitoring.js
+++ b/packages/web/projects/vgpu/views/task/admin/useTaskMonitoring.js
@@ -1,0 +1,148 @@
+import { computed, ref, unref, watch } from 'vue';
+
+import { REQUEST_STATUS } from '../../../../../src/hooks/request-state.mjs';
+import { readRangeVector } from '../../../hooks/range-vector-query-state.mjs';
+import { buildTaskMonitoringQueries } from '../../../metrics/query-contract.mjs';
+import { renderPromQLTemplate } from '../../../metrics/promql-template.mjs';
+
+const SERIES = Object.freeze([
+  { key: 'computeUsage', titleKey: 'task.computeUsageTrend' },
+  { key: 'memoryUsage', titleKey: 'task.memUsageTrend' },
+]);
+
+const createSeries = (status, outcomes = {}) =>
+  SERIES.map((definition) => ({
+    ...definition,
+    data: outcomes[definition.key]?.data || [],
+    error: outcomes[definition.key]?.error || null,
+    status: outcomes[definition.key]?.status || status,
+  }));
+
+const hasText = (value) =>
+  typeof value === 'string' && value.trim() !== '';
+
+const isValidSource = (source) =>
+  source &&
+  hasText(source.container) &&
+  hasText(source.namespace) &&
+  hasText(source.pod) &&
+  hasText(source.podUid) &&
+  Number.isSafeInteger(source.expectedDeviceCount) &&
+  source.expectedDeviceCount > 0 &&
+  Number.isSafeInteger(source.expectedVgpuCount) &&
+  source.expectedVgpuCount >= source.expectedDeviceCount;
+
+const isValidRange = (range) =>
+  range && hasText(range.start) && hasText(range.end) && hasText(range.step);
+
+export const getTaskMonitoringAllocationShape = ({
+  allocatedDevices,
+  deviceIds,
+} = {}) => {
+  const expectedVgpuCount = Number(allocatedDevices);
+  const normalizedDeviceIds = Array.isArray(deviceIds)
+    ? deviceIds.map((id) => (typeof id === 'string' ? id.trim() : ''))
+    : [];
+  if (
+    !Number.isSafeInteger(expectedVgpuCount) ||
+    expectedVgpuCount <= 0 ||
+    normalizedDeviceIds.length !== expectedVgpuCount ||
+    normalizedDeviceIds.some((id) => !id)
+  ) {
+    return null;
+  }
+
+  return {
+    expectedDeviceCount: new Set(normalizedDeviceIds).size,
+    expectedVgpuCount,
+  };
+};
+
+const useTaskMonitoring = ({ source, range, request }) => {
+  const series = ref(createSeries(REQUEST_STATUS.LOADING));
+  let requestId = 0;
+
+  const refresh = async () => {
+    const currentRequestId = ++requestId;
+    series.value = createSeries(REQUEST_STATUS.LOADING);
+
+    const currentSource = unref(source);
+    const currentRange = unref(range);
+    if (!isValidSource(currentSource) || !isValidRange(currentRange)) {
+      if (currentRequestId === requestId) {
+        series.value = createSeries(REQUEST_STATUS.MISSING);
+      }
+      return;
+    }
+
+    let queries;
+    try {
+      queries = buildTaskMonitoringQueries({
+        expectedDeviceCount: currentSource.expectedDeviceCount,
+        expectedVgpuCount: currentSource.expectedVgpuCount,
+      });
+    } catch (error) {
+      if (currentRequestId === requestId) {
+        const invalid = Object.fromEntries(
+          SERIES.map(({ key }) => [key, {
+            data: [],
+            error,
+            status: REQUEST_STATUS.INVALID,
+          }]),
+        );
+        series.value = createSeries(REQUEST_STATUS.INVALID, invalid);
+      }
+      return;
+    }
+
+    const variables = {
+      container: currentSource.container,
+      container_pod_uuid: `${currentSource.container}:${currentSource.podUid}`,
+      namespace: currentSource.namespace,
+      pod: currentSource.pod,
+    };
+    const outcomes = await Promise.all(
+      SERIES.map(async ({ key }) => {
+        try {
+          const response = await request({
+            query: renderPromQLTemplate(queries[key], variables),
+            range: { ...currentRange },
+          });
+          const state = readRangeVector(response);
+          return [key, {
+            ...state,
+            data: state.status === REQUEST_STATUS.READY ? state.data : [],
+            error: null,
+          }];
+        } catch (error) {
+          return [key, {
+            data: [],
+            error,
+            status: REQUEST_STATUS.ERROR,
+          }];
+        }
+      }),
+    );
+
+    if (currentRequestId !== requestId) return;
+    series.value = createSeries(
+      REQUEST_STATUS.MISSING,
+      Object.fromEntries(outcomes),
+    );
+  };
+
+  watch(
+    () => [unref(source), unref(range)],
+    () => {
+      void refresh();
+    },
+    { deep: true, immediate: true },
+  );
+
+  return {
+    data: computed(() => series.value),
+    refresh,
+  };
+};
+
+export default useTaskMonitoring;

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -311,7 +311,7 @@ export default {
     memUsageTrend: 'GPU Memory Utilization (%)',
     cpuUsageTrend: 'CPU Usage (%)',
     memoryUsageTrend: 'Memory Usage (%)',
-    noMonitorSupport: 'Vendor does not support task-level monitoring',
+    noCompleteMonitorData: 'No complete task monitoring data for this time range',
     topCount: 'Workload Count Top5',
     topApply: 'Workload Allocation Top5',
     detail: {

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -307,7 +307,7 @@ export default {
     memUsageTrend: 'GPU 显存使用率（%）',
     cpuUsageTrend: 'CPU 使用率（%）',
     memoryUsageTrend: '内存使用率（%）',
-    noMonitorSupport: '该设备厂商暂不支持任务维度监控',
+    noCompleteMonitorData: '当前时间范围内没有完整的任务监控数据',
     topCount: '任务数量分布 Top5',
     topApply: '工作负载分配 Top5',
     detail: {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Task trends currently depend on the first device model and can aggregate a partial device set. That hides normalized telemetry for some providers and can present missing cards as low utilization.

This change:
- removes the vendor-prefix gate and queries normalized task metrics;
- intersects usage with the current Pod UID allocation set;
- requires both unique-device and vGPU-slot coverage at each step;
- shows loading, missing, invalid, and error states without retaining stale charts.

A successful empty result now means no complete task monitoring data rather than zero or an unsupported vendor.

**Verification**:

- Prometheus 3.5 promtool syntax and synthetic evaluation for complete, partial, same-device multi-slot, real-zero, missing-vmem, and MetaX allocation-shrinkage cases
- full frontend tests and lint
- Vite environment-boundary check
- production frontend build

**Known follow-up**:

Usage gauges still lack container_pod_uuid. Adding it is a separate metric-schema change for exact same-name, same-device Pod recreation inside the Prometheus lookback window.