### PR TITLE
fix(ui): clarify GPU memory capacity domains

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,7 @@
     "test:i18n": "node --test test/locale-resolution.test.mjs",
     "test:metrics": "node --test src/hooks/request-state.test.mjs projects/vgpu/components/tab-top-state.test.mjs projects/vgpu/hooks/detail-resource-state.test.mjs projects/vgpu/hooks/use-detail-resource.test.mjs projects/vgpu/hooks/instant-vector-state.test.mjs projects/vgpu/hooks/range-vector-query-state.test.mjs projects/vgpu/metrics/query-contract.test.mjs projects/vgpu/metrics/range-vector-state.test.mjs projects/vgpu/metrics/tooltip-html.test.mjs projects/vgpu/views/monitor/overview/metric-config.test.mjs projects/vgpu/views/monitor/overview/overview-state.test.mjs projects/vgpu/views/monitor/overview/workload-distribution.test.mjs projects/vgpu/views/card/admin/allocation-percent.test.mjs projects/vgpu/views/card/admin/optional-telemetry-display.test.mjs projects/vgpu/views/node/admin/metric-config.test.mjs",
     "test:workload": "node --test projects/vgpu/views/task/admin/workload-identity.test.mjs projects/vgpu/views/task/admin/use-task-monitoring.test.mjs",
-    "test:ui-contracts": "node --test projects/vgpu/views/node/detail-location.test.mjs projects/vgpu/views/node/node-status.test.mjs"
+    "test:ui-contracts": "node --test projects/vgpu/views/memory-domain-labels.test.mjs projects/vgpu/views/node/detail-location.test.mjs projects/vgpu/views/node/node-status.test.mjs"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.1.0",

--- a/packages/web/projects/vgpu/components/MetricHelp.vue
+++ b/packages/web/projects/vgpu/components/MetricHelp.vue
@@ -1,0 +1,83 @@
+<template>
+  <t-tooltip :content="description" :visible="visible">
+    <button
+      type="button"
+      class="metric-help"
+      :aria-label="helpLabel"
+      :aria-describedby="descriptionId"
+      @mouseenter="hovered = true"
+      @mouseleave="hovered = false"
+      @focus="focused = true"
+      @blur="focused = false"
+      @keydown.esc="dismiss"
+    >
+      <help-circle-icon aria-hidden="true" />
+    </button>
+  </t-tooltip>
+  <span :id="descriptionId" class="metric-help__description">
+    {{ description }}
+  </span>
+</template>
+
+<script setup>
+import { computed, ref, useId } from 'vue';
+import { HelpCircleIcon } from 'tdesign-icons-vue-next';
+
+defineProps({
+  description: { type: String, required: true },
+  helpLabel: { type: String, required: true },
+});
+
+const descriptionId = useId();
+const hovered = ref(false);
+const focused = ref(false);
+const visible = computed(() => hovered.value || focused.value);
+
+const dismiss = () => {
+  hovered.value = false;
+  focused.value = false;
+};
+</script>
+
+<style lang="scss" scoped>
+.metric-help {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  color: #939ea9;
+  background: transparent;
+  cursor: help;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  &:focus-visible {
+    border-radius: 4px;
+    outline: 2px solid var(--el-color-primary);
+    outline-offset: 1px;
+  }
+
+  &__description {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+</style>

--- a/packages/web/projects/vgpu/views/card/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/card/admin/Detail.vue
@@ -149,7 +149,11 @@
               <div class="resource-card-rate-wrap">
                 <div class="resource-card-footer-item">
                   <div class="resource-card-footer-title">
-                    {{ $t('dashboard.allocated') }} / {{ $t('dashboard.allocRateLegend') }}
+                    <span>{{ $t('dashboard.allocated') }} / {{ $t('dashboard.memAllocRate') }}</span>
+                    <metric-help
+                      :description="$t('dashboard.memAllocRateDescription')"
+                      :help-label="$t('dashboard.metricHelpLabel', { metric: $t('dashboard.memAllocRate') })"
+                    />
                   </div>
                   <div class="resource-card-footer-value">
                     <span class="resource-card-footer-metric resource-card-footer-metric--allocated">{{ memoryAllocUsedText }}</span>
@@ -170,7 +174,11 @@
               <div class="resource-card-rate-wrap">
                 <div class="resource-card-footer-item">
                   <div class="resource-card-footer-title">
-                    {{ $t('dashboard.used') }} / {{ $t('dashboard.usageRateLegend') }}
+                    <span>{{ $t('dashboard.physicalUsed') }} / {{ $t('dashboard.memUsageRate') }}</span>
+                    <metric-help
+                      :description="$t('dashboard.memUsageRateDescription')"
+                      :help-label="$t('dashboard.metricHelpLabel', { metric: $t('dashboard.memUsageRate') })"
+                    />
                   </div>
                   <div class="resource-card-footer-value">
                     <span class="resource-card-footer-metric">{{ memoryUsageUsedText }}</span>
@@ -240,7 +248,7 @@
               {
                 ...getRangeOptions([
                   {
-                    name: t('dashboard.allocRateLegend'),
+                    name: t('dashboard.memAllocRate'),
                     data: gaugeConfig[1]?.data,
                     itemStyle: {
                       color: '#5B8FF9',
@@ -252,7 +260,7 @@
                     },
                   },
                   {
-                    name: t('dashboard.usageRateLegend'),
+                    name: t('dashboard.memUsageRate'),
                     data: gaugeConfig[3]?.data,
                     itemStyle: {
                       color: '#42C090',
@@ -288,6 +296,7 @@ import TrendTimeFilter from '@/components/TrendTimeFilter.vue';
 import { RouterLink, useRoute } from 'vue-router';
 import BlockBox from '@/components/BlockBox.vue';
 import DetailPageState from '~/vgpu/components/DetailPageState.vue';
+import MetricHelp from '~/vgpu/components/MetricHelp.vue';
 import { ref, watch, computed } from 'vue';
 import { HelpCircleIcon } from 'tdesign-icons-vue-next';
 import useInstantVector from '~/vgpu/hooks/useInstantVector';
@@ -920,6 +929,7 @@ watch([times, detailCardUuid], fetchLineData, { immediate: true });
 
 .resource-card-footer-item {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
@@ -927,8 +937,10 @@ watch([times, detailCardUuid], fetchLineData, { immediate: true });
 
 .resource-card-footer-title {
   display: inline-flex;
+  flex: 1 1 160px;
   align-items: center;
   gap: 4px;
+  min-width: 0;
   font-size: 12px;
   color: #939ea9;
   line-height: 20px;
@@ -936,9 +948,11 @@ watch([times, detailCardUuid], fetchLineData, { immediate: true });
 
 .resource-card-footer-value {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+  margin-left: auto;
 }
 
 .resource-card-footer-metric {

--- a/packages/web/projects/vgpu/views/memory-domain-labels.test.mjs
+++ b/packages/web/projects/vgpu/views/memory-domain-labels.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const readSource = (relativePath) =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+const nodeDetail = readSource('./node/admin/Detail.vue');
+const nodeOptions = readSource('./node/admin/getOptions.js');
+const cardDetail = readSource('./card/admin/Detail.vue');
+const metricHelp = readSource('../components/MetricHelp.vue');
+const enLocale = readSource('../../../src/locales/en.js');
+
+test('memory labels distinguish schedulable allocation from physical usage', () => {
+  assert.match(enLocale, /memAllocRate: 'Schedulable Memory Allocation'/);
+  assert.match(enLocale, /memUsageRate: 'Physical Memory Usage'/);
+
+  for (const source of [nodeDetail, cardDetail]) {
+    assert.match(source, /dashboard\.memAllocRateDescription/);
+    assert.match(source, /dashboard\.memUsageRateDescription/);
+    assert.match(source, /dashboard\.metricHelpLabel/);
+  }
+
+  assert.match(cardDetail, /dashboard\.physicalUsed/);
+});
+
+test('metric help is available to pointer, keyboard and assistive technology', () => {
+  assert.match(metricHelp, /:visible="visible"/);
+  assert.match(metricHelp, /@mouseenter="hovered = true"/);
+  assert.match(metricHelp, /@focus="focused = true"/);
+  assert.match(metricHelp, /@keydown\.esc="dismiss"/);
+  assert.match(metricHelp, /hovered\.value = false/);
+  assert.match(metricHelp, /focused\.value = false/);
+  assert.match(metricHelp, /:aria-describedby="descriptionId"/);
+  assert.match(metricHelp, /class="metric-help__description"/);
+});
+
+test('detail footers preserve labels and values at narrow widths', () => {
+  for (const source of [nodeDetail, cardDetail]) {
+    assert.match(
+      source,
+      /\.resource-card-footer-item\s*\{[^}]*flex-wrap:\s*wrap;/s,
+    );
+    assert.match(
+      source,
+      /\.resource-card-footer-title\s*\{[^}]*flex:\s*1 1 160px;[^}]*min-width:\s*0;/s,
+    );
+    assert.match(
+      source,
+      /\.resource-card-footer-value\s*\{[^}]*flex:\s*0 0 auto;[^}]*margin-left:\s*auto;/s,
+    );
+  }
+});
+
+test('memory trends use explicit labels while compute trends keep generic labels', () => {
+  assert.match(nodeDetail, /allocationName: t\('dashboard\.memAllocRate'\)/);
+  assert.match(nodeDetail, /usageName: t\('dashboard\.memUsageRate'\)/);
+  assert.match(
+    nodeOptions,
+    /name: allocationName \|\| t\('dashboard\.allocRateLegend'\)/,
+  );
+  assert.match(
+    nodeOptions,
+    /name: usageName \|\| t\('dashboard\.usageRateLegend'\)/,
+  );
+
+  const computeTrend = cardDetail.slice(
+    cardDetail.indexOf("dashboard.gpuComputeAllocUsageTrend"),
+    cardDetail.indexOf("dashboard.gpuMemAllocUsageTrend"),
+  );
+  const memoryTrend = cardDetail.slice(
+    cardDetail.indexOf("dashboard.gpuMemAllocUsageTrend"),
+    cardDetail.indexOf('lineToolsView'),
+  );
+
+  assert.match(computeTrend, /dashboard\.allocRateLegend/);
+  assert.match(computeTrend, /dashboard\.usageRateLegend/);
+  assert.doesNotMatch(computeTrend, /dashboard\.mem(?:Alloc|Usage)Rate/);
+  assert.match(memoryTrend, /dashboard\.memAllocRate/);
+  assert.match(memoryTrend, /dashboard\.memUsageRate/);
+});

--- a/packages/web/projects/vgpu/views/node/admin/Detail.vue
+++ b/packages/web/projects/vgpu/views/node/admin/Detail.vue
@@ -112,7 +112,13 @@
               <div class="resource-card-footer">
                 <div class="resource-card-rate-wrap">
                   <div class="resource-card-footer-item">
-                    <div class="resource-card-footer-title">{{ $t('dashboard.allocRateLegend') }}</div>
+                    <div class="resource-card-footer-title">
+                      <span>{{ $t('dashboard.memAllocRate') }}</span>
+                      <metric-help
+                        :description="$t('dashboard.memAllocRateDescription')"
+                        :help-label="$t('dashboard.metricHelpLabel', { metric: $t('dashboard.memAllocRate') })"
+                      />
+                    </div>
                     <div class="resource-card-footer-value">
                       <span class="resource-card-footer-percent">{{ memoryAllocPercentText }}</span>
                       <t-progress
@@ -129,7 +135,13 @@
 
                 <div class="resource-card-rate-wrap">
                   <div class="resource-card-footer-item">
-                    <div class="resource-card-footer-title">{{ $t('dashboard.usageRateLegend') }}</div>
+                    <div class="resource-card-footer-title">
+                      <span>{{ $t('dashboard.memUsageRate') }}</span>
+                      <metric-help
+                        :description="$t('dashboard.memUsageRateDescription')"
+                        :help-label="$t('dashboard.metricHelpLabel', { metric: $t('dashboard.memUsageRate') })"
+                      />
+                    </div>
                     <div class="resource-card-footer-value">
                       <span class="resource-card-footer-percent">{{ memoryUsagePercentText }}</span>
                       <t-progress
@@ -173,6 +185,8 @@
               getRangeOptions({
                 allocation: gaugeConfig[1].data,
                 usage: gaugeConfig[3].data,
+                allocationName: t('dashboard.memAllocRate'),
+                usageName: t('dashboard.memUsageRate'),
               }, t)
             "
             :autoresize="true"
@@ -193,6 +207,7 @@ import { useRoute } from 'vue-router';
 import BlockBox from '@/components/BlockBox.vue';
 import { computed, ref } from 'vue';
 import DetailPageState from '~/vgpu/components/DetailPageState.vue';
+import MetricHelp from '~/vgpu/components/MetricHelp.vue';
 import {
   classifyDetailPayload,
 } from '~/vgpu/hooks/detail-resource-state.mjs';
@@ -658,12 +673,18 @@ const detailColumnGroups = computed(() => {
 
 .resource-card-footer-item {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
 .resource-card-footer-title {
+  display: inline-flex;
+  flex: 1 1 160px;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
   font-size: 12px;
   color: #939ea9;
   line-height: 20px;
@@ -671,9 +692,11 @@ const detailColumnGroups = computed(() => {
 
 .resource-card-footer-value {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
+  margin-left: auto;
 }
 
 .resource-card-footer-percent {

--- a/packages/web/projects/vgpu/views/node/admin/getOptions.js
+++ b/packages/web/projects/vgpu/views/node/admin/getOptions.js
@@ -30,7 +30,12 @@ const buildPercentTooltipFormatter = () => {
 };
 
 export const getRangeOptions = (
-  { allocation = [], usage = [] },
+  {
+    allocation = [],
+    usage = [],
+    allocationName,
+    usageName,
+  },
   t = (v) => v,
 ) => {
   const normalizedAllocation = normalizeRangeValues(allocation);
@@ -83,7 +88,7 @@ export const getRangeOptions = (
     },
     series: [
       buildRangeLineSeries({
-        name: t('dashboard.allocRateLegend'),
+        name: allocationName || t('dashboard.allocRateLegend'),
         data: normalizedAllocation,
         itemStyle: {
           color: '#5B8FF9',
@@ -94,7 +99,7 @@ export const getRangeOptions = (
         },
       }),
       buildRangeLineSeries({
-        name: t('dashboard.usageRateLegend'),
+        name: usageName || t('dashboard.usageRateLegend'),
         data: normalizedUsage,
         itemStyle: {
           color: '#42C090',

--- a/packages/web/src/locales/en.js
+++ b/packages/web/src/locales/en.js
@@ -77,9 +77,9 @@ export default {
     viewAllGpuTypes: 'View all GPU types',
     vgpuAllocRate: 'vGPU Allocation',
     computeAllocRate: 'Compute Allocation',
-    memAllocRate: 'Memory Allocation',
+    memAllocRate: 'Schedulable Memory Allocation',
     computeUsageRate: 'Compute Utilization',
-    memUsageRate: 'Memory Usage',
+    memUsageRate: 'Physical Memory Usage',
     vgpuAllocRateDescription:
       'Allocated vGPU slots divided by the schedulable slots registered by HAMi. Slot capacity comes from device splitting and is not the physical accelerator count.',
     computeAllocRateDescription:
@@ -114,6 +114,7 @@ export default {
     schedulable: 'Schedulable',
     unschedulable: 'Unschedulable',
     allocated: 'Allocated',
+    physicalUsed: 'Physical Used',
     used: 'Used',
     idle: 'Idle',
     allocRate: 'Allocation Rate',

--- a/packages/web/src/locales/zh.js
+++ b/packages/web/src/locales/zh.js
@@ -76,9 +76,9 @@ export default {
     viewAllGpuTypes: '查看全部 GPU 类型',
     vgpuAllocRate: 'vGPU 分配率',
     computeAllocRate: '算力分配率',
-    memAllocRate: '显存分配率',
+    memAllocRate: '可调度显存分配率',
     computeUsageRate: '算力利用率',
-    memUsageRate: '显存使用率',
+    memUsageRate: '物理显存使用率',
     vgpuAllocRateDescription:
       '已分配 vGPU 槽位 ÷ HAMi 注册的可调度槽位。槽位容量来自设备拆分配置，不等于物理加速卡数量。',
     computeAllocRateDescription:
@@ -113,6 +113,7 @@ export default {
     schedulable: '可调度',
     unschedulable: '禁止调度',
     allocated: '已分配',
+    physicalUsed: '物理已用',
     used: '已用',
     idle: '闲置',
     allocRate: '分配率',


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

GPU memory allocation and usage use different capacity domains, but node and card details label both generically. This becomes misleading when HAMi memory overcommit makes schedulable memory larger than physical memory.

This change:
- labels allocation as schedulable-memory allocation;
- labels usage as physical-memory usage;
- uses the same explicit names in memory trend legends;
- reuses the existing metric definitions in accessible hover and keyboard Tooltips.

Compute labels and all PromQL remain unchanged.

**Verification**:

- root source-language and lint checks
- full frontend tests and lint
- production frontend build
- Vite environment-boundary check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible help tooltips explaining GPU memory metrics.
  * Updated memory charts and cards with distinct labels for schedulable memory allocation and physical memory usage.
  * Added clearer English and Chinese translations for memory metrics.

* **Bug Fixes**
  * Improved metric labeling to prevent confusion between allocated and physically used memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->