### PR TITLE
chore(release): prepare v2.0.0 metadata

### DIFF
--- a/charts/hami-webui/Chart.yaml
+++ b/charts/hami-webui/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-rc.1
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "main"
+appVersion: "2.0.0"
 
 # Match the minimum supported by the bundled monitoring dependencies and
 # require the stable Kubernetes Ingress pathType contract.

--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -1,6 +1,6 @@
 # HAMi-WebUI
 
-![Version: 2.0.0-rc.1](https://img.shields.io/badge/Version-2.0.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 ## Get Repo Info
 
@@ -107,10 +107,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.digest | string | `""` | Immutable manifest digest; takes precedence over `image.tag` when set. |
+| image.digest | string | `"sha256:80a8f63dab912d714dc1c12b90ee46b3557352c9cb11070968d25eba9644ca83"` | Immutable manifest digest; takes precedence over `image.tag` when set. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the application image. |
 | image.repository | string | `"projecthami/hami-webui"` | Unified HAMi-WebUI image repository. |
-| image.tag | string | `"main"` | Used only when `image.digest` is empty. Release packaging replaces development defaults with the released version. |
+| image.tag | string | `"v2.0.0"` | Used only when `image.digest` is empty; stable releases pin both fields to the same image. |
 | imagePullSecrets | list | `[]` | Image pull secrets used by the WebUI Pod. |
 | ingress.annotations | object | `{}`                                                                               |  |
 | ingress.className | string | `""`                                                                               |  |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -17,9 +17,9 @@ image:
   # Overrides the image tag. When empty, a semantic chart appVersion uses its
   # matching v-prefixed release tag (with '+' mapped to '_', as OCI tags do not
   # allow '+'); other appVersions are used unchanged.
-  tag: "main"
+  tag: "v2.0.0"
   # When set, digest takes precedence over tag and renders repository@digest.
-  digest: ""
+  digest: "sha256:80a8f63dab912d714dc1c12b90ee46b3557352c9cb11070968d25eba9644ca83"
 
 # Image pull secrets used by the WebUI Pod.
 imagePullSecrets: []


### PR DESCRIPTION
## What this PR does

Prepares the verified HAMi-WebUI 2.0.0 release metadata:

- sets Chart `version` and `appVersion` to `2.0.0`;
- pins `projecthami/hami-webui:v2.0.0` to the Docker Hub candidate digest;
- synchronizes the Chart README defaults.

The image was built once from exact source `0cff6b015bc4fa88cfa97cc1a1b2d1e9ad85713d` by [candidate run 33447873308](https://github.com/Project-HAMi/HAMi-WebUI/actions/runs/33447873308). Docker Hub and GHCR both resolve the candidate to `sha256:80a8f63dab912d714dc1c12b90ee46b3557352c9cb11070968d25eba9644ca83` with amd64 and arm64 manifests.

No application, template, dependency, workflow, or test code changed after the candidate build.

## Verification

- release metadata contract against the sealed candidate manifest;
- full Chart verifier with stable tag/digest defaults;
- Helm dependency lock unchanged;
- version-matched install documentation check.

Merging this PR does not publish 2.0.0. The canonical Chart bundle will remain behind the protected release environment until exact-bundle validation and explicit browser acceptance are complete.
