### PR TITLE
chore(release): refresh v2.0.0 candidate digest

### DIFF
--- a/charts/hami-webui/README.md
+++ b/charts/hami-webui/README.md
@@ -107,7 +107,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | hamiServiceMonitor.interval | string | `"15s"`                                                                            |  |
 | hamiServiceMonitor.relabelings | list | `[]`                                                                               |  |
 | hamiServiceMonitor.svcNamespace | string | `"kube-system"`                                                                    | Namespace where the HAMi monitor Service is installed. |
-| image.digest | string | `"sha256:80a8f63dab912d714dc1c12b90ee46b3557352c9cb11070968d25eba9644ca83"` | Immutable manifest digest; takes precedence over `image.tag` when set. |
+| image.digest | string | `"sha256:963d644a6a5ccfc47dc3c04d76186ccb307b45b86de8dc95427ff1104bcd65d2"` | Immutable manifest digest; takes precedence over `image.tag` when set. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the application image. |
 | image.repository | string | `"projecthami/hami-webui"` | Unified HAMi-WebUI image repository. |
 | image.tag | string | `"v2.0.0"` | Used only when `image.digest` is empty; stable releases pin both fields to the same image. |

--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -19,7 +19,7 @@ image:
   # allow '+'); other appVersions are used unchanged.
   tag: "v2.0.0"
   # When set, digest takes precedence over tag and renders repository@digest.
-  digest: "sha256:80a8f63dab912d714dc1c12b90ee46b3557352c9cb11070968d25eba9644ca83"
+  digest: "sha256:963d644a6a5ccfc47dc3c04d76186ccb307b45b86de8dc95427ff1104bcd65d2"
 
 # Image pull secrets used by the WebUI Pod.
 imagePullSecrets: []


### PR DESCRIPTION
/kind cleanup

Refresh the v2.0.0 Chart default to the replacement candidate built after #280.

- Candidate run: `33453448927`
- Source: `d3c5a3eda072e804538d3502f1c822fa5ee7ed0f`
- Docker Hub/GHCR index: `sha256:963d644a6a5ccfc47dc3c04d76186ccb307b45b86de8dc95427ff1104bcd65d2`

Only `values.yaml` and its generated README value change. The Chart version, app version, and release tag remain `2.0.0`.

Verification: `verify-release-contract.sh` passes against the downloaded sealed candidate manifest.
