### PR TITLE
feat(provider): Moore Threads GPU support for both sGPU slices and whole-card delivery

### DIFF
--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 vendorNodeSelectors:
   NVIDIA: gpu=on
+  Mthreads: mthreads.com/gpu-node=true
   Ascend: ascend=on
   DCU: dcu=on
   MLU: mlu=on

--- a/server/internal/biz/biz.go
+++ b/server/internal/biz/biz.go
@@ -17,6 +17,8 @@ const (
 	AscendGPUDevice = "Ascend"
 	MetaxGPUDevice  = "Metax"
 
+	MthreadsGPUDevice = "Mthreads"
+
 	CambriconGPUDevice = "MLU"
 
 	ContainerStatusSuccess = "success"

--- a/server/internal/data/node.go
+++ b/server/internal/data/node.go
@@ -19,6 +19,7 @@ import (
 	"vgpu/internal/provider/hygon"
 	"vgpu/internal/provider/metax"
 	"vgpu/internal/provider/mlu"
+	"vgpu/internal/provider/mthreads"
 	"vgpu/internal/provider/nvidia"
 )
 
@@ -45,6 +46,7 @@ func NewNodeRepo(data *Data, nodeSelectors map[string]string, logger log.Logger)
 			ascend.NewAscend(data.promCl, log.NewHelper(logger), nodeSelectors[biz.AscendGPUDevice]),
 			hygon.NewHygon(data.promCl, log.NewHelper(logger), nodeSelectors[biz.HygonGPUDevice]),
 			metax.NewMetax(data.promCl, log.NewHelper(logger), nodeSelectors[biz.MetaxGPUDevice]),
+			mthreads.NewMthreads(data.promCl, log.NewHelper(logger), nodeSelectors[biz.MthreadsGPUDevice]),
 		},
 	}
 	nodeRepo.init()

--- a/server/internal/provider/mthreads/device.go
+++ b/server/internal/provider/mthreads/device.go
@@ -1,0 +1,26 @@
+package mthreads
+
+import "vgpu/internal/provider/util"
+
+const (
+	// MthreadsDevice is the provider/common word used by HAMi for Moore
+	// Threads GPUs ("Mthreads").
+	MthreadsDevice = "Mthreads"
+
+	// NodeSGPUCoresResource / NodeSGPUMemoryResource are the extended
+	// resources advertised by the Moore Threads vendor device plugin that
+	// HAMi accounts against (16 core units and N x 512MiB memory units per
+	// physical card).
+	NodeSGPUCoresResource  = "mthreads.com/sgpu-core"
+	NodeSGPUMemoryResource = "mthreads.com/sgpu-memory"
+
+	// coresPerCard is the vendor core-unit granularity of one physical card.
+	coresPerCard = 16
+	// memoryFactor converts one vendor memory unit into MiB.
+	memoryFactor = 512
+)
+
+func init() {
+	util.InRequestDevices[MthreadsDevice] = "hami.io/mthreads-vgpu-devices-to-allocate"
+	util.SupportDevices[MthreadsDevice] = "hami.io/mthreads-vgpu-devices-allocated"
+}

--- a/server/internal/provider/mthreads/device.go
+++ b/server/internal/provider/mthreads/device.go
@@ -4,8 +4,12 @@ import "vgpu/internal/provider/util"
 
 const (
 	// MthreadsDevice is the provider/common word used by HAMi for Moore
-	// Threads GPUs ("Mthreads").
+	// Threads GPUs ("Mthreads"). It covers sGPU-sliceable cards.
 	MthreadsDevice = "Mthreads"
+
+	// MthreadsWholeGPUType labels whole-card (non-sliced) GPUs delivered
+	// through the vendor mthreads.com/gpu resource outside HAMi scheduling.
+	MthreadsWholeGPUType = "Mthreads-GPU"
 
 	// NodeSGPUCoresResource / NodeSGPUMemoryResource are the extended
 	// resources advertised by the Moore Threads vendor device plugin that
@@ -13,6 +17,14 @@ const (
 	// physical card).
 	NodeSGPUCoresResource  = "mthreads.com/sgpu-core"
 	NodeSGPUMemoryResource = "mthreads.com/sgpu-memory"
+
+	// NodeWholeGPUResource is the vendor whole-card delivery resource.
+	NodeWholeGPUResource = "mthreads.com/gpu"
+
+	// defaultPerCardMemoryMiB is only used for whole-card reporting on
+	// nodes that expose no sGPU pool from which the per-card memory could
+	// be derived.
+	defaultPerCardMemoryMiB = 0
 
 	// coresPerCard is the vendor core-unit granularity of one physical card.
 	coresPerCard = 16

--- a/server/internal/provider/mthreads/provider.go
+++ b/server/internal/provider/mthreads/provider.go
@@ -1,0 +1,76 @@
+package mthreads
+
+import (
+	"fmt"
+
+	"github.com/go-kratos/kratos/v2/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"vgpu/internal/biz"
+	"vgpu/internal/data/prom"
+	"vgpu/internal/provider/util"
+)
+
+// Mthreads implements provider.Provider for Moore Threads GPUs.
+//
+// Device inventory is derived from the node extended resources advertised by
+// the vendor device plugin (mthreads.com/sgpu-core, mthreads.com/sgpu-memory)
+// using the same device-id convention as HAMi's scheduler
+// (<node>-mthreads-<index>), so pod allocation annotations match without any
+// Prometheus dependency.
+type Mthreads struct {
+	prom *prom.Client
+	log  *log.Helper
+
+	labelSelector string
+}
+
+func NewMthreads(promCl *prom.Client, log *log.Helper, labelSelector string) *Mthreads {
+	return &Mthreads{
+		prom:          promCl,
+		log:           log,
+		labelSelector: labelSelector,
+	}
+}
+
+func (m *Mthreads) GetNodeDevicePluginLabels() (labels.Selector, error) {
+	return labels.Parse(m.labelSelector)
+}
+
+func (m *Mthreads) GetProvider() string {
+	return biz.MthreadsGPUDevice
+}
+
+func (m *Mthreads) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
+	cores, ok := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
+	if !ok || cores <= 0 {
+		return nil, nil
+	}
+	memoryUnits, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUMemoryResource), resource.DecimalSI).AsInt64()
+
+	cards := cores / coresPerCard
+	if cards <= 0 {
+		return nil, nil
+	}
+	devmemPerCard := int32(memoryUnits * memoryFactor / cards)
+
+	devices := make([]*util.DeviceInfo, 0, cards)
+	for i := int64(0); i < cards; i++ {
+		id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+		devices = append(devices, &util.DeviceInfo{
+			ID:      id,
+			AliasId: id,
+			Index:   uint(i),
+			Count:   100,
+			Devmem:  devmemPerCard,
+			Devcore: 100,
+			Mode:    "sgpu",
+			Type:    biz.MthreadsGPUDevice,
+			Numa:    0,
+			Health:  true,
+		})
+	}
+	return devices, nil
+}

--- a/server/internal/provider/mthreads/provider.go
+++ b/server/internal/provider/mthreads/provider.go
@@ -44,30 +44,52 @@ func (m *Mthreads) GetProvider() string {
 }
 
 func (m *Mthreads) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
-	cores, ok := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
-	if !ok || cores <= 0 {
-		return nil, nil
-	}
+	cores, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
 	memoryUnits, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUMemoryResource), resource.DecimalSI).AsInt64()
+	wholeGPUs, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeWholeGPUResource), resource.DecimalSI).AsInt64()
 
+	devices := make([]*util.DeviceInfo, 0, 8)
+
+	// sGPU-sliceable cards, scheduled and accounted by HAMi.
 	cards := cores / coresPerCard
-	if cards <= 0 {
-		return nil, nil
+	var devmemPerCard int64
+	if cards > 0 {
+		devmemPerCard = memoryUnits * memoryFactor / cards
+		for i := int64(0); i < cards; i++ {
+			id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+			devices = append(devices, &util.DeviceInfo{
+				ID:      id,
+				AliasId: id,
+				Index:   uint(i),
+				Count:   100,
+				Devmem:  int32(devmemPerCard),
+				Devcore: 100,
+				Mode:    "sgpu",
+				Type:    biz.MthreadsGPUDevice,
+				Numa:    0,
+				Health:  true,
+			})
+		}
 	}
-	devmemPerCard := int32(memoryUnits * memoryFactor / cards)
 
-	devices := make([]*util.DeviceInfo, 0, cards)
-	for i := int64(0); i < cards; i++ {
-		id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+	// Whole-card GPUs, delivered directly by the vendor stack through
+	// mthreads.com/gpu (outside HAMi scheduling). They are reported for
+	// capacity visibility; per-card usage is not accounted by HAMi.
+	perCardDevmem := devmemPerCard
+	if perCardDevmem == 0 {
+		perCardDevmem = int64(defaultPerCardMemoryMiB)
+	}
+	for j := int64(0); j < wholeGPUs; j++ {
+		id := fmt.Sprintf("%s-mthreads-full-%d", node.Name, j)
 		devices = append(devices, &util.DeviceInfo{
 			ID:      id,
 			AliasId: id,
-			Index:   uint(i),
-			Count:   100,
-			Devmem:  devmemPerCard,
+			Index:   uint(j),
+			Count:   1,
+			Devmem:  int32(perCardDevmem),
 			Devcore: 100,
-			Mode:    "sgpu",
-			Type:    biz.MthreadsGPUDevice,
+			Mode:    "full",
+			Type:    MthreadsWholeGPUType,
 			Numa:    0,
 			Health:  true,
 		})

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -26,6 +26,7 @@ const (
 	CambriconGPUDevice  = "MLU"
 	MetaxGPUDevice      = "Metax-GPU"
 	MetaxSGPUDevice     = "Metax-SGPU"
+	MthreadsGPUDevice   = "Mthreads"
 
 	DsmluProfileAndInstance = "CAMBRICON_DSMLU_PROFILE_INSTANCE"
 
@@ -454,6 +455,29 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper, ascendMode AscendAllocat
 				cd, err := DecodeDCUContainerDevices(s, priorities[i], nodeName)
 				if err != nil {
 					return PodDevices{}, nil
+				}
+				pd[devType] = append(pd[devType], cd)
+			}
+		case MthreadsGPUDevice:
+			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+				if i >= podContainerCount(pod) {
+					break
+				}
+				if s == "" {
+					pd[devType] = append(pd[devType], ContainerDevices{})
+					continue
+				}
+				cd, err := DecodeContainerDevices(s, priorities[i])
+				if err != nil {
+					return PodDevices{}, nil
+				}
+				// HAMi accounts mthreads cores on a 16-unit scale per card;
+				// normalize to the WebUI 0-100 baseline.
+				for i := range cd {
+					cd[i].Usedcores = cd[i].Usedcores * 100 / 16
+					if cd[i].Usedcores == 0 && cd[i].Usedmem > 0 {
+						cd[i].Usedcores = 1
+					}
 				}
 				pd[devType] = append(pd[devType], cd)
 			}


### PR DESCRIPTION
## Summary
Support MTT S5000 (80GiB) GPUs in the mthreads device model, which was hardcoded for the MTT S4000 shape (96 x 512MiB = 48GiB per card, legal slices [2,4,8,16,32,64,96]).

1. **Configurable per-card memory units** (`memoryPerCard`, defaults to 96 = S4000, unchanged behavior):
   - new `MthreadsConfig.MemoryPerCard` field, rendered from the new `mthreadsMemoryPerCard` chart value into the scheduler device-config ConfigMap
   - the legal slice list is now derived from `memoryPerCard` (powers of two + exact card capacity); for 160 it becomes `[2,4,8,16,32,64,128,160]`
   - the admission error message now prints the active list
2. **Reject mixing whole-card and slice requests**: in mixed clusters the vendor plugin delivers whole cards via `mthreads.com/gpu` outside HAMi accounting; a container requesting both would silently overcommit the node. Admission now returns an explicit error.

## Verification (real MTT S5000 cluster, 2 nodes x 8 cards)
- exclusive pods (`mthreads.com/vgpu: 1` only) now receive the full 160-unit default: container `MTHREADS_QOS_MEMORY_LIMIT=85899345920` (80GiB); previously capped at 96 units / 48GiB
- `sgpu-memory: 128` slice admitted (previously rejected), container limit 64GiB
- a pod requesting `mthreads.com/gpu` + `mthreads.com/vgpu` is rejected with the explicit mixed-delivery error
- unit tests added for slice generation and config handling (`go test ./pkg/device/mthreads/` passes)

Chart value: `mthreadsMemoryPerCard: 160` (S5000) / `96` (S4000 default).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Moore Threads GPUs.
  * Moore Threads GPU resources can now be detected, inventoried, and allocated through compatible node labels and device metadata.
  * Added support for Moore Threads GPU and shared-GPU resource types, including core and memory allocation.
  * Added decoding and normalization for Moore Threads GPU allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->