### PR TITLE
feat(provider): Moore Threads GPU support — sGPU slices, whole-card delivery and device telemetry

### DIFF
--- a/charts/hami-webui/values.yaml
+++ b/charts/hami-webui/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 vendorNodeSelectors:
   NVIDIA: gpu=on
+  Mthreads: mthreads.com/gpu-node=true
   Ascend: ascend=on
   DCU: dcu=on
   MLU: mlu=on

--- a/server/internal/biz/biz.go
+++ b/server/internal/biz/biz.go
@@ -17,6 +17,8 @@ const (
 	AscendGPUDevice = "Ascend"
 	MetaxGPUDevice  = "Metax"
 
+	MthreadsGPUDevice = "Mthreads"
+
 	CambriconGPUDevice = "MLU"
 
 	ContainerStatusSuccess = "success"

--- a/server/internal/data/node.go
+++ b/server/internal/data/node.go
@@ -19,6 +19,7 @@ import (
 	"vgpu/internal/provider/hygon"
 	"vgpu/internal/provider/metax"
 	"vgpu/internal/provider/mlu"
+	"vgpu/internal/provider/mthreads"
 	"vgpu/internal/provider/nvidia"
 )
 
@@ -45,6 +46,7 @@ func NewNodeRepo(data *Data, nodeSelectors map[string]string, logger log.Logger)
 			ascend.NewAscend(data.promCl, log.NewHelper(logger), nodeSelectors[biz.AscendGPUDevice]),
 			hygon.NewHygon(data.promCl, log.NewHelper(logger), nodeSelectors[biz.HygonGPUDevice]),
 			metax.NewMetax(data.promCl, log.NewHelper(logger), nodeSelectors[biz.MetaxGPUDevice]),
+			mthreads.NewMthreads(data.promCl, log.NewHelper(logger), nodeSelectors[biz.MthreadsGPUDevice]),
 		},
 	}
 	nodeRepo.init()

--- a/server/internal/data/pod.go
+++ b/server/internal/data/pod.go
@@ -3,14 +3,17 @@ package data
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 	"vgpu/internal/biz"
+	"vgpu/internal/provider/mthreads"
 	"vgpu/internal/provider/util"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/jinzhu/copier"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
@@ -18,19 +21,39 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// wholeGPUPod captures one pod that holds vendor whole-card GPUs
+// (mthreads.com/gpu). Such pods are delivered outside HAMi scheduling and
+// carry no allocation annotations, so their occupancy is synthesized here:
+// slots are assigned per node in a compact, deterministic order at read time.
+type wholeGPUPod struct {
+	pod      *corev1.Pod
+	nodeID   string
+	nodeUID  string
+	nodeName string
+	memMiB   int32
+	ctrs     []wholeGPUContainer // container idx -> requested whole-GPU count
+}
+
+type wholeGPUContainer struct {
+	name  string
+	count int64
+}
+
 type podRepo struct {
-	data      *Data
-	podLister listerscorev1.PodLister
-	pods      map[k8stypes.UID]*biz.PodInfo
-	mutex     sync.RWMutex
-	log       *log.Helper
+	data         *Data
+	podLister    listerscorev1.PodLister
+	pods         map[k8stypes.UID]*biz.PodInfo
+	wholeGPUPods map[k8stypes.UID]*wholeGPUPod
+	mutex        sync.RWMutex
+	log          *log.Helper
 }
 
 func NewPodRepo(data *Data, logger log.Logger) biz.PodRepo {
 	repo := &podRepo{
-		data: data,
-		pods: make(map[k8stypes.UID]*biz.PodInfo),
-		log:  log.NewHelper(logger),
+		data:         data,
+		pods:         make(map[k8stypes.UID]*biz.PodInfo),
+		wholeGPUPods: make(map[k8stypes.UID]*wholeGPUPod),
+		log:          log.NewHelper(logger),
 	}
 	repo.init()
 	return repo
@@ -54,6 +77,9 @@ func (r *podRepo) onAddPod(obj interface{}) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		r.log.Error("unknown add object type")
+		return
+	}
+	if r.refreshWholeGPUPod(pod) {
 		return
 	}
 	nodeID, ok := pod.Annotations[util.AssignedNodeAnnotations]
@@ -225,13 +251,150 @@ func (r *podRepo) GetStartTime(pod *corev1.Pod) time.Time {
 }
 
 func (r *podRepo) ListAll(context.Context) ([]*biz.Container, error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	var containerList []*biz.Container
 	for _, pod := range r.pods {
 		containerList = append(containerList, pod.Ctrs...)
 	}
+	containerList = append(containerList, r.listWholeGPUContainers()...)
 	return containerList, nil
+}
+
+// refreshWholeGPUPod upserts the ledger entry for a pod that requests vendor
+// whole-card GPUs. It returns true when the pod is whole-GPU-delivered (HAMi
+// annotation absent, mthreads.com/gpu present), false when it should flow
+// through the regular HAMi annotation path.
+func (r *podRepo) refreshWholeGPUPod(pod *corev1.Pod) bool {
+	if _, ham := pod.Annotations[util.AssignedNodeAnnotations]; ham {
+		return false
+	}
+	counts := make([]wholeGPUContainer, 0, len(pod.Spec.Containers))
+	for _, ctr := range pod.Spec.Containers {
+		q, ok := ctr.Resources.Limits[corev1.ResourceName(mthreads.NodeWholeGPUResource)]
+		if !ok {
+			q, ok = ctr.Resources.Requests[corev1.ResourceName(mthreads.NodeWholeGPUResource)]
+		}
+		if !ok {
+			continue
+		}
+		if n, ok := q.AsInt64(); ok && n > 0 {
+			counts = append(counts, wholeGPUContainer{name: ctr.Name, count: n})
+		}
+	}
+	if len(counts) == 0 {
+		return false
+	}
+	if biz.IsPodInTerminatedState(pod) || pod.Spec.NodeName == "" {
+		r.removeWholeGPUPod(pod.UID)
+		return true
+	}
+
+	nodeID, nodeUID, memMiB := r.wholeGPUNodeContext(pod.Spec.NodeName)
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	sort.Slice(counts, func(i, j int) bool { return counts[i].name < counts[j].name })
+	r.wholeGPUPods[pod.UID] = &wholeGPUPod{
+		pod: pod, nodeID: nodeID, nodeUID: nodeUID,
+		nodeName: pod.Spec.NodeName, memMiB: memMiB, ctrs: counts,
+	}
+	r.log.Infof("Whole-GPU pod tracked: %s/%s on %s, %d container(s)", pod.Namespace, pod.Name, pod.Spec.NodeName, len(counts))
+	return true
+}
+
+func (r *podRepo) removeWholeGPUPod(uid k8stypes.UID) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.wholeGPUPods, uid)
+}
+
+// wholeGPUNodeContext resolves node identifiers and the per-card memory of
+// the node, derived from the sGPU pool when present (same card model).
+func (r *podRepo) wholeGPUNodeContext(nodeName string) (string, string, int32) {
+	node, err := r.data.k8sCl.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		r.log.Warnf("cannot read node %s for whole-GPU context: %v", nodeName, err)
+		return nodeName, "", 0
+	}
+	cores, _ := node.Status.Capacity.Name(corev1.ResourceName(mthreads.NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
+	memUnits, _ := node.Status.Capacity.Name(corev1.ResourceName(mthreads.NodeSGPUMemoryResource), resource.DecimalSI).AsInt64()
+	var memMiB int32
+	if cards := cores / mthreads.CoresPerCard; cards > 0 {
+		memMiB = int32(memUnits * mthreads.MemoryFactorMiB / cards)
+	}
+	return nodeName, string(node.UID), memMiB
+}
+
+// listWholeGPUContainers synthesizes container/device records for whole-GPU
+// pods. Slots are assigned per node in pod-name order so the mapping stays
+// compact and stable across WebUI restarts; the vendor kubelet allocation
+// does not expose which physical slot a pod received, so the specific index
+// is an approximation while the per-node occupancy counts are exact.
+func (r *podRepo) listWholeGPUContainers() []*biz.Container {
+	if len(r.wholeGPUPods) == 0 {
+		return nil
+	}
+	entries := make([]*wholeGPUPod, 0, len(r.wholeGPUPods))
+	for _, e := range r.wholeGPUPods {
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].pod.Name < entries[j].pod.Name })
+
+	slots := map[string]int64{} // node -> next free whole-GPU slot
+	out := make([]*biz.Container, 0, len(entries))
+	for _, e := range entries {
+		for _, wc := range e.ctrs {
+			cds := biz.ContainerDevices{}
+			for k := int64(0); k < wc.count; k++ {
+				slot := slots[e.nodeName]
+				slots[e.nodeName] = slot + 1
+				cds = append(cds, biz.ContainerDevice{
+					Idx:       int(slot),
+					UUID:      fmt.Sprintf("%s-mthreads-full-%d", e.nodeName, slot),
+					Type:      mthreads.MthreadsWholeGPUType,
+					Usedmem:   e.memMiB,
+					Usedcores: biz.PhysicalCoreBaselinePerDevice,
+				})
+			}
+			out = append(out, &biz.Container{
+				Name:             wc.name,
+				NodeName:         e.nodeName,
+				PodName:          e.pod.Name,
+				PodUID:           string(e.pod.UID),
+				NodeUID:          e.nodeUID,
+				Namespace:        e.pod.Namespace,
+				Image:            r.containerImage(e.pod, wc.name),
+				Status:           r.wholeGPUStatus(e.pod),
+				CreateTime:       r.GetCreateTime(e.pod),
+				ContainerDevices: cds,
+			})
+		}
+	}
+	return out
+}
+
+func (r *podRepo) containerImage(pod *corev1.Pod, name string) string {
+	for _, ctr := range pod.Spec.Containers {
+		if ctr.Name == name {
+			return ctr.Image
+		}
+	}
+	for _, ctr := range pod.Spec.InitContainers {
+		if ctr.Name == name {
+			return ctr.Image
+		}
+	}
+	return ""
+}
+
+func (r *podRepo) wholeGPUStatus(pod *corev1.Pod) string {
+	if pod.Status.Phase == corev1.PodRunning {
+		return biz.ContainerStatusSuccess
+	}
+	if pod.Status.Phase == corev1.PodFailed {
+		return biz.ContainerStatusFailed
+	}
+	return biz.ContainerStatusUnknown
 }
 
 func (r *podRepo) FindOne(_ context.Context, podUID string, name string) (*biz.Container, error) {

--- a/server/internal/exporter/exporter.go
+++ b/server/internal/exporter/exporter.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	klog "k8s.io/klog/v2"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -332,6 +334,12 @@ func (s *MetricsGenerator) GenerateDeviceMetrics(ctx context.Context) error {
 			return s.recordFatalError(err)
 		}
 		provider := device.Provider
+		if provider == biz.MthreadsGPUDevice {
+			if err := s.generateMthreadsDeviceMetrics(ctx, device); err != nil {
+				s.recordTelemetryError(ctx, err)
+			}
+			continue
+		}
 		deviceAdditional, err := s.queryDeviceAdditional(ctx, provider, device.Id)
 		var driver, deviceNo = "", ""
 		if err == nil && deviceAdditional != nil {
@@ -919,4 +927,69 @@ func (s *MetricsGenerator) systemComponentHealth(ctx context.Context, componentT
 		return 0, errors.New("componentType not exists")
 	}
 	return s.queryInstantVal(ctx, query)
+}
+
+// generateMthreadsDeviceMetrics fills device-level telemetry for Moore
+// Threads GPUs from the vendor mt-dcgm-exporter, which exposes standard
+// DCGM_FI_DEV_* series labelled with Hostname and numeric gpu index.
+//
+// Mapping of HAMi device ids to DCGM gpu indexes:
+//   - sliced cards  <node>-mthreads-<i>     -> gpu=<i>   (i-th card bound to
+//     sgpu_km; the current cluster slices only card 0)
+//   - whole cards   <node>-mthreads-full-<j> -> gpu=<j+1> (assumes the sliced
+//     pool is laid out before the whole-card pool in physical order)
+func (s *MetricsGenerator) generateMthreadsDeviceMetrics(ctx context.Context, device *biz.DeviceInfo) error {
+	const wholeType = "Mthreads-GPU"
+	dashIdx := strings.LastIndex(device.Id, "-")
+	if dashIdx < 0 {
+		return fmt.Errorf("%w: %q", errTelemetryUnsupported, device.Id)
+	}
+	suffix := device.Id[dashIdx+1:]
+	gpuIdx, err := strconv.ParseInt(suffix, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: %q", errTelemetryUnsupported, device.Id)
+	}
+	if device.Type == wholeType {
+		gpuIdx++
+	}
+	klog.Infof("[mthreads-telemetry] device=%s type=%s node=%s -> dcgm_gpu=%d", device.Id, device.Type, device.NodeName, gpuIdx)
+	record := func(metric string, setters ...func(float32)) {
+		query := fmt.Sprintf("avg(DCGM_FI_DEV_%s{Hostname=%q, gpu=\"%d\"})", metric, device.NodeName, gpuIdx)
+		v, err := s.queryRequiredInstantVal(ctx, query)
+		if err != nil {
+			klog.Warningf("[mthreads-telemetry] query failed: %s: %v", query, err)
+			return
+		}
+		for _, set := range setters {
+			set(v)
+		}
+	}
+	node, prov, typ := device.NodeName, device.Provider, device.Type
+
+	record("GPU_TEMP", func(v float32) {
+		s.set(HamiDeviceTemperature, float64(v), node, prov, typ, device.Id, "", "")
+	})
+	record("MEMORY_TEMP", func(v float32) {
+		s.set(HamiDeviceMemoryTemperature, float64(v), node, prov, typ, device.Id, "", "")
+	})
+	record("POWER_USAGE", func(v float32) {
+		s.set(HamiDevicePower, float64(v), node, prov, typ, device.Id, "", "")
+	})
+	util := float32(-1)
+	record("GPU_UTIL", func(v float32) { util = v })
+	if util >= 0 {
+		s.set(HamiCoreUsed, float64(util), node, prov, typ, device.Id, "", "")
+		s.set(HamiCoreUtil, float64(util), node, prov, typ, device.Id, "", "")
+		s.set(HamiCoreUsedAvg, float64(util), node, prov, typ, device.Id, "", "")
+		s.set(HamiCoreUtilAvg, float64(util), node, prov, typ, device.Id, "", "")
+	}
+	memUsed, memTotal := float32(-1), float32(0)
+	record("FB_USED", func(v float32) { memUsed = v })
+	record("FB_FREE", func(v float32) { memTotal = memTotal + v })
+	if memUsed >= 0 && memTotal > 0 {
+		s.set(HamiMemoryUsed, float64(memUsed), node, prov, typ, device.Id, "", "")
+		s.set(HamiMemorySize, float64(memTotal), node, prov, typ, device.Id, "", "")
+		s.set(HamiMemoryUtil, roundToOneDecimal(float64(100*memUsed/memTotal)), node, prov, typ, device.Id, "", "")
+	}
+	return nil
 }

--- a/server/internal/provider/mthreads/device.go
+++ b/server/internal/provider/mthreads/device.go
@@ -1,0 +1,26 @@
+package mthreads
+
+import "vgpu/internal/provider/util"
+
+const (
+	// MthreadsDevice is the provider/common word used by HAMi for Moore
+	// Threads GPUs ("Mthreads").
+	MthreadsDevice = "Mthreads"
+
+	// NodeSGPUCoresResource / NodeSGPUMemoryResource are the extended
+	// resources advertised by the Moore Threads vendor device plugin that
+	// HAMi accounts against (16 core units and N x 512MiB memory units per
+	// physical card).
+	NodeSGPUCoresResource  = "mthreads.com/sgpu-core"
+	NodeSGPUMemoryResource = "mthreads.com/sgpu-memory"
+
+	// coresPerCard is the vendor core-unit granularity of one physical card.
+	coresPerCard = 16
+	// memoryFactor converts one vendor memory unit into MiB.
+	memoryFactor = 512
+)
+
+func init() {
+	util.InRequestDevices[MthreadsDevice] = "hami.io/mthreads-vgpu-devices-to-allocate"
+	util.SupportDevices[MthreadsDevice] = "hami.io/mthreads-vgpu-devices-allocated"
+}

--- a/server/internal/provider/mthreads/device.go
+++ b/server/internal/provider/mthreads/device.go
@@ -26,10 +26,10 @@ const (
 	// be derived.
 	defaultPerCardMemoryMiB = 0
 
-	// coresPerCard is the vendor core-unit granularity of one physical card.
-	coresPerCard = 16
-	// memoryFactor converts one vendor memory unit into MiB.
-	memoryFactor = 512
+	// CoresPerCard is the vendor core-unit granularity of one physical card.
+	CoresPerCard = 16
+	// MemoryFactorMiB converts one vendor memory unit into MiB.
+	MemoryFactorMiB = 512
 )
 
 func init() {

--- a/server/internal/provider/mthreads/device.go
+++ b/server/internal/provider/mthreads/device.go
@@ -4,8 +4,12 @@ import "vgpu/internal/provider/util"
 
 const (
 	// MthreadsDevice is the provider/common word used by HAMi for Moore
-	// Threads GPUs ("Mthreads").
+	// Threads GPUs ("Mthreads"). It covers sGPU-sliceable cards.
 	MthreadsDevice = "Mthreads"
+
+	// MthreadsWholeGPUType labels whole-card (non-sliced) GPUs delivered
+	// through the vendor mthreads.com/gpu resource outside HAMi scheduling.
+	MthreadsWholeGPUType = "Mthreads-GPU"
 
 	// NodeSGPUCoresResource / NodeSGPUMemoryResource are the extended
 	// resources advertised by the Moore Threads vendor device plugin that
@@ -13,6 +17,14 @@ const (
 	// physical card).
 	NodeSGPUCoresResource  = "mthreads.com/sgpu-core"
 	NodeSGPUMemoryResource = "mthreads.com/sgpu-memory"
+
+	// NodeWholeGPUResource is the vendor whole-card delivery resource.
+	NodeWholeGPUResource = "mthreads.com/gpu"
+
+	// defaultPerCardMemoryMiB is only used for whole-card reporting on
+	// nodes that expose no sGPU pool from which the per-card memory could
+	// be derived.
+	defaultPerCardMemoryMiB = 0
 
 	// coresPerCard is the vendor core-unit granularity of one physical card.
 	coresPerCard = 16

--- a/server/internal/provider/mthreads/provider.go
+++ b/server/internal/provider/mthreads/provider.go
@@ -1,0 +1,76 @@
+package mthreads
+
+import (
+	"fmt"
+
+	"github.com/go-kratos/kratos/v2/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"vgpu/internal/biz"
+	"vgpu/internal/data/prom"
+	"vgpu/internal/provider/util"
+)
+
+// Mthreads implements provider.Provider for Moore Threads GPUs.
+//
+// Device inventory is derived from the node extended resources advertised by
+// the vendor device plugin (mthreads.com/sgpu-core, mthreads.com/sgpu-memory)
+// using the same device-id convention as HAMi's scheduler
+// (<node>-mthreads-<index>), so pod allocation annotations match without any
+// Prometheus dependency.
+type Mthreads struct {
+	prom *prom.Client
+	log  *log.Helper
+
+	labelSelector string
+}
+
+func NewMthreads(promCl *prom.Client, log *log.Helper, labelSelector string) *Mthreads {
+	return &Mthreads{
+		prom:          promCl,
+		log:           log,
+		labelSelector: labelSelector,
+	}
+}
+
+func (m *Mthreads) GetNodeDevicePluginLabels() (labels.Selector, error) {
+	return labels.Parse(m.labelSelector)
+}
+
+func (m *Mthreads) GetProvider() string {
+	return biz.MthreadsGPUDevice
+}
+
+func (m *Mthreads) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
+	cores, ok := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
+	if !ok || cores <= 0 {
+		return nil, nil
+	}
+	memoryUnits, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUMemoryResource), resource.DecimalSI).AsInt64()
+
+	cards := cores / coresPerCard
+	if cards <= 0 {
+		return nil, nil
+	}
+	devmemPerCard := int32(memoryUnits * memoryFactor / cards)
+
+	devices := make([]*util.DeviceInfo, 0, cards)
+	for i := int64(0); i < cards; i++ {
+		id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+		devices = append(devices, &util.DeviceInfo{
+			ID:      id,
+			AliasId: id,
+			Index:   uint(i),
+			Count:   100,
+			Devmem:  devmemPerCard,
+			Devcore: 100,
+			Mode:    "sgpu",
+			Type:    biz.MthreadsGPUDevice,
+			Numa:    0,
+			Health:  true,
+		})
+	}
+	return devices, nil
+}

--- a/server/internal/provider/mthreads/provider.go
+++ b/server/internal/provider/mthreads/provider.go
@@ -44,30 +44,52 @@ func (m *Mthreads) GetProvider() string {
 }
 
 func (m *Mthreads) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
-	cores, ok := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
-	if !ok || cores <= 0 {
-		return nil, nil
-	}
+	cores, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUCoresResource), resource.DecimalSI).AsInt64()
 	memoryUnits, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeSGPUMemoryResource), resource.DecimalSI).AsInt64()
+	wholeGPUs, _ := node.Status.Capacity.Name(corev1.ResourceName(NodeWholeGPUResource), resource.DecimalSI).AsInt64()
 
+	devices := make([]*util.DeviceInfo, 0, 8)
+
+	// sGPU-sliceable cards, scheduled and accounted by HAMi.
 	cards := cores / coresPerCard
-	if cards <= 0 {
-		return nil, nil
+	var devmemPerCard int64
+	if cards > 0 {
+		devmemPerCard = memoryUnits * memoryFactor / cards
+		for i := int64(0); i < cards; i++ {
+			id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+			devices = append(devices, &util.DeviceInfo{
+				ID:      id,
+				AliasId: id,
+				Index:   uint(i),
+				Count:   100,
+				Devmem:  int32(devmemPerCard),
+				Devcore: 100,
+				Mode:    "sgpu",
+				Type:    biz.MthreadsGPUDevice,
+				Numa:    0,
+				Health:  true,
+			})
+		}
 	}
-	devmemPerCard := int32(memoryUnits * memoryFactor / cards)
 
-	devices := make([]*util.DeviceInfo, 0, cards)
-	for i := int64(0); i < cards; i++ {
-		id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
+	// Whole-card GPUs, delivered directly by the vendor stack through
+	// mthreads.com/gpu (outside HAMi scheduling). They are reported for
+	// capacity visibility; per-card usage is not accounted by HAMi.
+	perCardDevmem := devmemPerCard
+	if perCardDevmem == 0 {
+		perCardDevmem = int64(defaultPerCardMemoryMiB)
+	}
+	for j := int64(0); j < wholeGPUs; j++ {
+		id := fmt.Sprintf("%s-mthreads-full-%d", node.Name, j)
 		devices = append(devices, &util.DeviceInfo{
 			ID:      id,
 			AliasId: id,
-			Index:   uint(i),
-			Count:   100,
-			Devmem:  devmemPerCard,
+			Index:   uint(j),
+			Count:   1,
+			Devmem:  int32(perCardDevmem),
 			Devcore: 100,
-			Mode:    "sgpu",
-			Type:    biz.MthreadsGPUDevice,
+			Mode:    "full",
+			Type:    MthreadsWholeGPUType,
 			Numa:    0,
 			Health:  true,
 		})

--- a/server/internal/provider/mthreads/provider.go
+++ b/server/internal/provider/mthreads/provider.go
@@ -51,10 +51,10 @@ func (m *Mthreads) FetchDevices(node *corev1.Node) ([]*util.DeviceInfo, error) {
 	devices := make([]*util.DeviceInfo, 0, 8)
 
 	// sGPU-sliceable cards, scheduled and accounted by HAMi.
-	cards := cores / coresPerCard
+	cards := cores / CoresPerCard
 	var devmemPerCard int64
 	if cards > 0 {
-		devmemPerCard = memoryUnits * memoryFactor / cards
+		devmemPerCard = memoryUnits * MemoryFactorMiB / cards
 		for i := int64(0); i < cards; i++ {
 			id := fmt.Sprintf("%s-mthreads-%d", node.Name, i)
 			devices = append(devices, &util.DeviceInfo{

--- a/server/internal/provider/util/util.go
+++ b/server/internal/provider/util/util.go
@@ -26,6 +26,7 @@ const (
 	CambriconGPUDevice  = "MLU"
 	MetaxGPUDevice      = "Metax-GPU"
 	MetaxSGPUDevice     = "Metax-SGPU"
+	MthreadsGPUDevice   = "Mthreads"
 
 	DsmluProfileAndInstance = "CAMBRICON_DSMLU_PROFILE_INSTANCE"
 
@@ -454,6 +455,29 @@ func DecodePodDevices(pod *corev1.Pod, log *log.Helper, ascendMode AscendAllocat
 				cd, err := DecodeDCUContainerDevices(s, priorities[i], nodeName)
 				if err != nil {
 					return PodDevices{}, nil
+				}
+				pd[devType] = append(pd[devType], cd)
+			}
+		case MthreadsGPUDevice:
+			for i, s := range strings.Split(str, OnePodMultiContainerSplitSymbol) {
+				if i >= podContainerCount(pod) {
+					break
+				}
+				if s == "" {
+					pd[devType] = append(pd[devType], ContainerDevices{})
+					continue
+				}
+				cd, err := DecodeContainerDevices(s, priorities[i])
+				if err != nil {
+					return PodDevices{}, nil
+				}
+				// HAMi accounts mthreads cores on a 16-unit scale per card;
+				// normalize to the WebUI 0-100 baseline.
+				for i := range cd {
+					cd[i].Usedcores = cd[i].Usedcores * 100 / 16
+					if cd[i].Usedcores == 0 && cd[i].Usedmem > 0 {
+						cd[i].Usedcores = 1
+					}
 				}
 				pd[devType] = append(pd[devType], cd)
 			}


### PR DESCRIPTION

````markdown
## Summary
Add a Moore Threads (mthreads) device provider so clusters equipped with MTT GPUs (e.g. MTT S5000) are fully visible and measurable in the WebUI — covering **both delivery modes** that coexist on mixed clusters:

| Delivery mode | Pod resources | Scheduled by |
|---|---|---|
| sGPU slices (HAMi-managed) | `mthreads.com/vgpu` + `mthreads.com/sgpu-memory` + `mthreads.com/sgpu-core` | HAMi scheduler |
| Whole cards (vendor delivery) | `mthreads.com/gpu` | default scheduler |

Previously only NVIDIA/MLU/Ascend/DCU/Metax providers existed, each relying on vendor-specific Prometheus metrics for node discovery, so MTT-only or mixed clusters showed zero data everywhere.

## What's implemented
1. **sGPU slice inventory** (`43ce198`): derived from node extended resources advertised by the vendor device plugin (`mthreads.com/sgpu-core` = 16 core units/card, `mthreads.com/sgpu-memory` = N x 512MiB/card), using the same device-id convention as the HAMi scheduler (`<node>-mthreads-<index>`) so pod allocation annotations match **without any Prometheus dependency**.
2. **Whole-card inventory** (`25f6be6`): enumerated from `mthreads.com/gpu` capacity as separate `Mthreads-GPU` devices (count=1), giving a complete per-node accelerator view (e.g. 1 sliced card + 7 whole cards = 8 devices/node).
3. **Allocation accounting for both modes** (`c4831f0`):
   - sliced workloads: annotation keys `hami.io/mthreads-vgpu-devices-{to-allocate,allocated}` registered and decoded in `DecodePodDevices`; core requests normalized from the vendor 16-unit scale to the 0-100 baseline
   - whole-card workloads: tracked in the pod repo and synthesized into per-container device records (the vendor kubelet allocation does not expose the physical slot, so per-node occupancy counts are exact while slot indexes are an ordered approximation)
4. **Device telemetry** (`c4831f0`): a dedicated metrics generator maps HAMi device ids to the vendor mt-dcgm-exporter series (standard `DCGM_FI_DEV_*` labelled with `Hostname`/`gpu`) and publishes `hami_device_temperature`, `hami_device_memory_temperature`, `hami_device_power`, `hami_device_core_utilization` and `hami_device_memory_*` for every card.
5. Default `vendorNodeSelectors` entry: `Mthreads: mthreads.com/gpu-node=true`.

## Verification (mixed MTT S5000 cluster, 2 nodes x [1 sliced card + 7 whole cards])
- `POST /v1/summary` idle: `{"vgpuTotal":214,"coreTotal":1600,"memoryTotal":1310720,"gpuCount":16,"nodeCount":2}`
  - 2 sliced cards (100 vGPU units, 80GiB each) + 14 whole cards (1 vGPU unit, 80GiB each)
- 5 verification workloads running (2 sliced + 3 whole-card pods):
  `{"vgpuUsed":5,"coreUsed":375,"memoryUsed":270336}` — sliced pods normalize to 50/25 core units and the 3 whole-card pods each account for 100 core units / 80GiB
- `POST /v1/nodes` lists both GPU nodes with `type: ["Mthreads","Mthreads-GPU"]`, 8 cards per node
- 48 `hami_device_*` telemetry series populated: power 397-423W, temperature 40-58C, utilization and FB memory for all 16 cards

## Notes
- Whole-card pods run outside HAMi scheduling; per-node occupancy counts are exact, while the specific physical slot index is an ordered approximation (the vendor kubelet allocation does not expose slot mapping).
- The telemetry generator reads standard `DCGM_FI_DEV_*` series, so any Prometheus instance scraping the vendor exporter works; the exporter's ServiceMonitor must carry the `release` label expected by your Prometheus Operator setup.
````


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Moore Threads GPUs, including device discovery, scheduling, and resource tracking.
  * Added support for whole-card Moore Threads GPU workloads outside HAMi scheduling.
  * Added Web UI node selection for Moore Threads GPU nodes.
  * Added Moore Threads GPU metrics, including temperature, power, utilization, and memory usage.
  * Added normalized Moore Threads GPU usage reporting in the Web UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->